### PR TITLE
Admin API filter by name and external_id

### DIFF
--- a/app/resources/api/rest/admin/account_resource.rb
+++ b/app/resources/api/rest/admin/account_resource.rb
@@ -10,6 +10,8 @@ class Api::Rest::Admin::AccountResource < ::BaseResource
   has_one :customer_invoice_template, class_name: 'Billing::InvoiceTemplate'
   has_one :vendor_invoice_template, class_name: 'Billing::InvoiceTemplate'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/billing/invoice_period_resource.rb
+++ b/app/resources/api/rest/admin/billing/invoice_period_resource.rb
@@ -2,4 +2,6 @@ class Api::Rest::Admin::Billing::InvoicePeriodResource < ::BaseResource
   model_name 'Billing::InvoicePeriod'
 
   attributes :name
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/billing/invoice_template_resource.rb
+++ b/app/resources/api/rest/admin/billing/invoice_template_resource.rb
@@ -2,4 +2,6 @@ class Api::Rest::Admin::Billing::InvoiceTemplateResource < ::BaseResource
   model_name 'Billing::InvoiceTemplate'
 
   attributes :name, :filename
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/codec_group_resource.rb
+++ b/app/resources/api/rest/admin/codec_group_resource.rb
@@ -2,4 +2,6 @@ class Api::Rest::Admin::CodecGroupResource < JSONAPI::Resource
 
   attributes :name
   has_many :codecs, class_name: 'CodecGroupCodec'
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/contractor_resource.rb
+++ b/app/resources/api/rest/admin/contractor_resource.rb
@@ -3,6 +3,8 @@ class Api::Rest::Admin::ContractorResource < JSONAPI::Resource
 
   has_one :smtp_connection, class_name: 'System::SmtpConnection'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/customers_auth_resource.rb
+++ b/app/resources/api/rest/admin/customers_auth_resource.rb
@@ -20,6 +20,8 @@ class Api::Rest::Admin::CustomersAuthResource < JSONAPI::Resource
   has_one :radius_accounting_profile, class_name: 'Equipment::Radius::AccountingProfile'
   has_one :transport_protocol, class_name: 'Equipment::TransportProtocol'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/destination_rate_policy_resource.rb
+++ b/app/resources/api/rest/admin/destination_rate_policy_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::DestinationRatePolicyResource < JSONAPI::Resource
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/destination_resource.rb
+++ b/app/resources/api/rest/admin/destination_resource.rb
@@ -7,6 +7,7 @@ class Api::Rest::Admin::DestinationResource < JSONAPI::Resource
   has_one :rate_policy, class_name: 'DestinationRatePolicy'
   has_one :profit_control_mode, class_name: 'Routing::RateProfitControlMode'
 
+  filters :external_id, :prefix, :rateplan_id
 
   def self.updatable_fields(context)
     [

--- a/app/resources/api/rest/admin/dialpeer_next_rate_resource.rb
+++ b/app/resources/api/rest/admin/dialpeer_next_rate_resource.rb
@@ -4,6 +4,8 @@ class Api::Rest::Admin::DialpeerNextRateResource < JSONAPI::Resource
 
   has_one :dialpeer
 
+  filter :external_id
+
   # def self.updatable_fields(context)
   #   super
   # end

--- a/app/resources/api/rest/admin/dialpeer_resource.rb
+++ b/app/resources/api/rest/admin/dialpeer_resource.rb
@@ -12,6 +12,8 @@ class Api::Rest::Admin::DialpeerResource < JSONAPI::Resource
   has_one :account
   has_many :dialpeer_next_rates
 
+  filters :external_id, :prefix, :routing_group_id
+
   def self.updatable_fields(context)
     [
       :enabled,

--- a/app/resources/api/rest/admin/disconnect_policy_resource.rb
+++ b/app/resources/api/rest/admin/disconnect_policy_resource.rb
@@ -1,4 +1,6 @@
 class Api::Rest::Admin::DisconnectPolicyResource < JSONAPI::Resource
 
   attributes :name
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/diversion_policy_resource.rb
+++ b/app/resources/api/rest/admin/diversion_policy_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::DiversionPolicyResource < JSONAPI::Resource
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/dump_level_resource.rb
+++ b/app/resources/api/rest/admin/dump_level_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::DumpLevelResource < JSONAPI::Resource
   immutable
   attributes :name, :log_sip, :log_rtp
+  filter :name
 end

--- a/app/resources/api/rest/admin/equipment/gateway_rel100_mode_resource.rb
+++ b/app/resources/api/rest/admin/equipment/gateway_rel100_mode_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::Equipment::GatewayRel100ModeResource < ::BaseResource
   model_name 'Equipment::GatewayRel100Mode'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/equipment/radius/accounting_profile_resource.rb
+++ b/app/resources/api/rest/admin/equipment/radius/accounting_profile_resource.rb
@@ -3,4 +3,6 @@ class Api::Rest::Admin::Equipment::Radius::AccountingProfileResource < ::BaseRes
 
   attributes :name, :server, :port, :secret, :timeout, :attempts, :enable_start_accounting,
              :enable_interim_accounting, :interim_accounting_interval, :enable_stop_accounting
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/equipment/radius/auth_profile_resource.rb
+++ b/app/resources/api/rest/admin/equipment/radius/auth_profile_resource.rb
@@ -3,4 +3,5 @@ class Api::Rest::Admin::Equipment::Radius::AuthProfileResource < ::BaseResource
 
   attributes :name, :server, :port, :secret, :reject_on_error, :timeout, :attempts
 
+  filter :name
 end

--- a/app/resources/api/rest/admin/equipment/transport_protocol_resource.rb
+++ b/app/resources/api/rest/admin/equipment/transport_protocol_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::Equipment::TransportProtocolResource < ::BaseResource
   model_name 'Equipment::TransportProtocol'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/filter_type_resource.rb
+++ b/app/resources/api/rest/admin/filter_type_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::FilterTypeResource < JSONAPI::Resource
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/gateway_group_resource.rb
+++ b/app/resources/api/rest/admin/gateway_group_resource.rb
@@ -3,6 +3,8 @@ class Api::Rest::Admin::GatewayGroupResource < JSONAPI::Resource
 
   has_one :vendor, class_name: 'Contractor'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/gateway_resource.rb
+++ b/app/resources/api/rest/admin/gateway_resource.rb
@@ -31,6 +31,8 @@ class Api::Rest::Admin::GatewayResource < JSONAPI::Resource
   has_one :orig_proxy_transport_protocol, class_name: 'Equipment::TransportProtocol'
   has_one :rel100_mode, class_name: 'Equipment::GatewayRel100Mode'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/pop_resource.rb
+++ b/app/resources/api/rest/admin/pop_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::PopResource < JSONAPI::Resource
 
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/rateplan_resource.rb
+++ b/app/resources/api/rest/admin/rateplan_resource.rb
@@ -3,6 +3,8 @@ class Api::Rest::Admin::RateplanResource < JSONAPI::Resource
 
   has_one :profit_control_mode, class_name: 'Routing::RateProfitControlMode'
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/routing/numberlist_resource.rb
+++ b/app/resources/api/rest/admin/routing/numberlist_resource.rb
@@ -3,4 +3,6 @@ class Api::Rest::Admin::Routing::NumberlistResource < ::BaseResource
 
   attributes :name, :created_at, :updated_at, :default_src_rewrite_rule, :default_src_rewrite_result,
              :default_dst_rewrite_rule, :default_dst_rewrite_result
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/routing/rate_profit_control_mode_resource.rb
+++ b/app/resources/api/rest/admin/routing/rate_profit_control_mode_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::Routing::RateProfitControlModeResource < ::BaseResource
   model_name 'Routing::RateProfitControlMode'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/routing_group_resource.rb
+++ b/app/resources/api/rest/admin/routing_group_resource.rb
@@ -1,6 +1,8 @@
 class Api::Rest::Admin::RoutingGroupResource < JSONAPI::Resource
   attributes :name
 
+  filter :name
+
   def self.updatable_fields(context)
     [ :name ]
   end

--- a/app/resources/api/rest/admin/routing_plan_resource.rb
+++ b/app/resources/api/rest/admin/routing_plan_resource.rb
@@ -5,6 +5,8 @@ class Api::Rest::Admin::RoutingPlanResource < JSONAPI::Resource
 
   has_one :sorting
 
+  filter :name
+
   def self.updatable_fields(context)
     [
       :name,

--- a/app/resources/api/rest/admin/sdp_c_location_resource.rb
+++ b/app/resources/api/rest/admin/sdp_c_location_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::SdpCLocationResource < JSONAPI::Resource
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/session_refresh_method_resource.rb
+++ b/app/resources/api/rest/admin/session_refresh_method_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::SessionRefreshMethodResource < JSONAPI::Resource
   immutable
   attributes :name, :value
+  filter :name
 end

--- a/app/resources/api/rest/admin/sorting_resource.rb
+++ b/app/resources/api/rest/admin/sorting_resource.rb
@@ -1,4 +1,5 @@
 class Api::Rest::Admin::SortingResource < JSONAPI::Resource
 
   attributes :name, :description, :use_static_routes
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/dtmf_receive_mode_resource.rb
+++ b/app/resources/api/rest/admin/system/dtmf_receive_mode_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::System::DtmfReceiveModeResource < ::BaseResource
   model_name 'System::DtmfReceiveMode'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/dtmf_send_mode_resource.rb
+++ b/app/resources/api/rest/admin/system/dtmf_send_mode_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::System::DtmfSendModeResource < ::BaseResource
   model_name 'System::DtmfSendMode'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/sensor_level_resource.rb
+++ b/app/resources/api/rest/admin/system/sensor_level_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::System::SensorLevelResource < ::BaseResource
   model_name 'System::SensorLevel'
   immutable
   attributes :name
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/sensor_resource.rb
+++ b/app/resources/api/rest/admin/system/sensor_resource.rb
@@ -3,4 +3,5 @@ class Api::Rest::Admin::System::SensorResource < ::BaseResource
 
   attributes :name, :mode_id, :source_interface, :target_mac, :use_routing, :target_ip, :source_ip
 
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/smtp_connection_resource.rb
+++ b/app/resources/api/rest/admin/system/smtp_connection_resource.rb
@@ -2,4 +2,6 @@ class Api::Rest::Admin::System::SmtpConnectionResource < ::BaseResource
   model_name 'System::SmtpConnection'
 
   attributes :name, :host , :port, :from_address, :auth_user, :auth_password, :global
+
+  filter :name
 end

--- a/app/resources/api/rest/admin/system/timezone_resource.rb
+++ b/app/resources/api/rest/admin/system/timezone_resource.rb
@@ -2,4 +2,5 @@ class Api::Rest::Admin::System::TimezoneResource < ::BaseResource
   model_name 'System::Timezone'
   immutable
   attributes :name, :abbrev, :utc_offset, :is_dst
+  filter :name
 end

--- a/spec/controllers/api/rest/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/accounts_controller_spec.rb
@@ -19,6 +19,14 @@ describe Api::Rest::Admin::AccountsController, type: :controller do
     it { expect(response_data.size).to eq(accounts.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :account, 2 }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create(:account) }
+    end
+  end
+
   describe 'GET show' do
     let!(:account) { create :account }
 
@@ -101,4 +109,3 @@ describe Api::Rest::Admin::AccountsController, type: :controller do
     it { expect(Account.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/contractors_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/contractors_controller_spec.rb
@@ -19,6 +19,14 @@ describe Api::Rest::Admin::ContractorsController, type: :controller do
     it { expect(response_data.size).to eq(contractors.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :contractor, 2, vendor: true }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create(:contractor, vendor: true) }
+    end
+  end
+
   describe 'GET show' do
     let!(:contractor) { create :contractor, vendor: true }
 
@@ -92,4 +100,3 @@ describe Api::Rest::Admin::ContractorsController, type: :controller do
     it { expect(Contractor.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/destinations_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/destinations_controller_spec.rb
@@ -21,6 +21,24 @@ describe Api::Rest::Admin::DestinationsController, type: :controller do
     it { expect(response_data.size).to eq(destinations.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :destination, 2 }
+
+    it_behaves_like :jsonapi_filter_by_external_id do
+      let(:subject_record) { create(:destination) }
+    end
+
+    it_behaves_like :jsonapi_filter_by, :prefix do
+      let(:subject_record) { create :destination, prefix: attr_value }
+      let(:attr_value) { '987' }
+    end
+
+    it_behaves_like :jsonapi_filter_by, :rateplan_id do
+      let(:subject_record) { create :destination, rateplan: rateplan }
+      let(:attr_value) { subject_record.rateplan_id }
+    end
+  end
+
   describe 'GET show' do
     let!(:destination) { create :destination }
 
@@ -113,4 +131,3 @@ describe Api::Rest::Admin::DestinationsController, type: :controller do
     it { expect(Destination.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/dialpeers_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/dialpeers_controller_spec.rb
@@ -19,6 +19,24 @@ describe Api::Rest::Admin::DialpeersController, type: :controller do
     it { expect(response_data.size).to eq(dialpeers.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :dialpeer, 2 }
+
+    it_behaves_like :jsonapi_filter_by_external_id do
+      let(:subject_record) { create :dialpeer }
+    end
+
+    it_behaves_like :jsonapi_filter_by, :prefix do
+      let(:subject_record) { create :dialpeer, prefix: attr_value }
+      let(:attr_value) { '987' }
+    end
+
+    it_behaves_like :jsonapi_filter_by, :routing_group_id do
+      let(:subject_record) { create :dialpeer }
+      let(:attr_value) { subject_record.routing_group_id }
+    end
+  end
+
   describe 'GET show' do
     let!(:dialpeer) { create :dialpeer }
 

--- a/spec/controllers/api/rest/admin/gateway_groups_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/gateway_groups_controller_spec.rb
@@ -39,6 +39,14 @@ describe Api::Rest::Admin::GatewayGroupsController, type: :controller do
     end
   end
 
+  describe 'GET index with filters' do
+    before { create_list :gateway_group, 2 }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create :gateway_group }
+    end
+  end
+
   describe 'POST create' do
     before do
       post :create, data: { type: 'gateway-groups',
@@ -98,4 +106,3 @@ describe Api::Rest::Admin::GatewayGroupsController, type: :controller do
     it { expect(GatewayGroup.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/rateplans_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/rateplans_controller_spec.rb
@@ -21,6 +21,14 @@ describe Api::Rest::Admin::RateplansController, type: :controller do
     it { expect(response_data.size).to eq(rateplans.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :rateplan, 2 }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create :rateplan }
+    end
+  end
+
   describe 'GET show' do
     let!(:rateplan) { create :rateplan }
 
@@ -100,4 +108,3 @@ describe Api::Rest::Admin::RateplansController, type: :controller do
     it { expect(Rateplan.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/routing_groups_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/routing_groups_controller_spec.rb
@@ -19,6 +19,14 @@ describe Api::Rest::Admin::RoutingGroupsController, type: :controller do
     it { expect(response_data.size).to eq(routing_groups.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :routing_group, 2 }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create :routing_group }
+    end
+  end
+
   describe 'GET show' do
     let!(:routing_group) { create :routing_group }
 
@@ -85,4 +93,3 @@ describe Api::Rest::Admin::RoutingGroupsController, type: :controller do
     it { expect(RoutingGroup.count).to eq(0) }
   end
 end
-

--- a/spec/controllers/api/rest/admin/routing_plans_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/routing_plans_controller_spec.rb
@@ -19,6 +19,14 @@ describe Api::Rest::Admin::RoutingPlansController, type: :controller do
     it { expect(response_data.size).to eq(routing_plans.size) }
   end
 
+  describe 'GET index with filters' do
+    before { create_list :routing_plan, 2 }
+
+    it_behaves_like :jsonapi_filter_by_name do
+      let(:subject_record) { create :routing_plan }
+    end
+  end
+
   describe 'GET show' do
     let!(:routing_plan) { create :routing_plan }
 
@@ -85,4 +93,3 @@ describe Api::Rest::Admin::RoutingPlansController, type: :controller do
     it { expect(Routing::RoutingPlan.count).to eq(0) }
   end
 end
-

--- a/spec/factories/destination.rb
+++ b/spec/factories/destination.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :destination, aliases: [:rate], class: Destination do
+    sequence(:external_id)
     prefix nil
     connect_fee 0
     enabled true

--- a/spec/factories/dialpeer.rb
+++ b/spec/factories/dialpeer.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :dialpeer, class: Dialpeer do
+    sequence(:external_id)
     enabled true
     prefix nil
     src_rewrite_rule nil

--- a/spec/support/examples/jsonapi_filter_by.rb
+++ b/spec/support/examples/jsonapi_filter_by.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples :jsonapi_filter_by do |attr_name|
+  let(:subject_record) { raise 'Define' }
+  let(:attr_value) { raise 'Define' }
+
+  before do
+    subject_record
+  end
+
+  it 'returns only one expected record' do
+    get :index, filter: { attr_name => attr_value }
+
+    expect(response_data).to match_array(
+      [
+        hash_including('id' => subject_record.id.to_s)
+      ]
+    )
+  end
+end

--- a/spec/support/examples/jsonapi_filter_by_external_id.rb
+++ b/spec/support/examples/jsonapi_filter_by_external_id.rb
@@ -1,0 +1,5 @@
+RSpec.shared_examples :jsonapi_filter_by_external_id do
+  include_examples :jsonapi_filter_by, :external_id do
+    let(:attr_value) { subject_record.external_id }
+  end
+end

--- a/spec/support/examples/jsonapi_filter_by_name.rb
+++ b/spec/support/examples/jsonapi_filter_by_name.rb
@@ -1,0 +1,5 @@
+RSpec.shared_examples :jsonapi_filter_by_name do
+  include_examples :jsonapi_filter_by, :name do
+    let(:attr_value) { subject_record.name }
+  end
+end


### PR DESCRIPTION
Changes in Admin API:

- added filters by name and/or external_id (if resource respond to it)
- Destination resource filter by `external_id`, `prefix`, `rateplan_id`
- Dialpeer resource filter by `external_id`, `prefix`, `routing_group_id`