### PR TITLE
Customers Api: Check Rate resource

### DIFF
--- a/app/controllers/api/rest/customer/v1/check_rate_controller.rb
+++ b/app/controllers/api/rest/customer/v1/check_rate_controller.rb
@@ -1,0 +1,2 @@
+class Api::Rest::Customer::V1::CheckRateController < Api::Rest::Customer::V1::BaseController
+end

--- a/app/models/jsonapi_model/base.rb
+++ b/app/models/jsonapi_model/base.rb
@@ -1,0 +1,37 @@
+require 'securerandom'
+
+module JsonapiModel
+  class Base
+    include ActiveModel::Model
+    attr_reader :id
+
+    class << self
+      def inherited(_subclass)
+      end
+
+      def call(args = {})
+        new(args).call
+      end
+    end
+
+    def initialize(**_args)
+      @id = SecureRandom.uuid
+    end
+
+    def call
+      fail NotImplementedError.new('call needs to be implemented in subclasses and return self')
+    end
+
+    def self.all
+      new
+    end
+
+    def order(*_args)
+      [self]
+    end
+
+    def count(*_args)
+      1
+    end
+  end
+end

--- a/app/models/jsonapi_model/check_rate.rb
+++ b/app/models/jsonapi_model/check_rate.rb
@@ -1,0 +1,67 @@
+module JsonapiModel
+  class CheckRate < Base
+    attr_accessor :rateplan_id, :number, :rates
+
+    validates_presence_of :rateplan_id, :number
+    validate do
+      errors.add(:rateplan_id, 'Rateplan not found') unless rateplan
+    end
+
+    def initialize(**params)
+      super
+
+      @errors = ActiveModel::Errors.new(self)
+      @rateplan_id = params[:rateplan_id]
+      @number = params[:number]
+    end
+
+    def call
+      get_rates
+      self
+    end
+
+    def save(*args)
+      begin
+        get_rates
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+        Rails.logger.error(e.record.errors)
+        return false
+      end
+      true
+    end
+
+    def rateplan
+      Rateplan.find_by(uuid: @rateplan_id) if Rateplan.where(uuid: @rateplan_id).exists?
+    end
+
+    def self.all
+      raise JSONAPI::Exceptions::RecordNotFound.new(nil)
+    end
+
+    def self.find(id)
+      raise JSONAPI::Exceptions::RecordNotFound.new(nil)
+    end
+
+    private
+
+    def get_rates
+      @rates = rateplan.number_rates(@number).map { |el|
+        el.slice!('uuid',
+                 'prefix',
+                 'initial_rate',
+                 'initial_interval',
+                 'next_rate',
+                 'next_interval',
+                 'connect_fee',
+                 'reject_calls',
+                 'valid_from',
+                 'valid_till',
+                 'network_prefix_id',
+                 'routing_tag_name')
+        el['id'] = el.delete('uuid')
+        el
+      }
+    end
+
+  end
+end

--- a/app/resources/api/rest/customer/v1/check_rate_resource.rb
+++ b/app/resources/api/rest/customer/v1/check_rate_resource.rb
@@ -1,0 +1,8 @@
+class Api::Rest::Customer::V1::CheckRateResource < BaseResource
+  model_name 'JsonapiModel::CheckRate'
+
+  key_type :uuid
+
+  attributes :rateplan_id, :number, :rates
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Yeti::Application.routes.draw do
             jsonapi_resources :accounts
             jsonapi_resources :rateplans
             jsonapi_resources :rates
+            jsonapi_resource :check_rate, only: [:create]
             jsonapi_resources :cdrs
            end
         end

--- a/spec/acceptance/rest/customer/api/v1/check_rate_spec.rb
+++ b/spec/acceptance/rest/customer/api/v1/check_rate_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'CheckRate', document: :customer_v1 do
+  header 'Accept', 'application/vnd.api+json'
+  header 'Content-Type', 'application/vnd.api+json'
+  header 'Authorization', :auth_token
+
+  let(:api_access) { create :api_access }
+  let(:customer) { api_access.customer }
+  let(:auth_token) { ::Knock::AuthToken.new(payload: { sub: api_access.id }).token }
+  let(:type) { 'check-rates' }
+
+  let(:customers_auth) do
+    create(:customers_auth, customer_id: customer.id)
+  end
+
+  let!(:rateplan) { customers_auth.rateplan.reload }
+
+  before do
+    create :destination, rateplan: rateplan, prefix: '444', routing_tag: create(:routing_tag)
+  end
+
+  post '/api/rest/customer/v1/check-rate' do
+    parameter :type, 'Resource type (check-rates)', scope: :data, required: true
+
+    required_params = %i(rateplan-id number)
+
+    jsonapi_attributes(required_params, [])
+
+    let(:number) { '44444444' }
+    let(:'rateplan-id') { rateplan.uuid }
+
+    example_request 'get rates for number' do
+      expect(status).to eq(201)
+    end
+  end
+
+end

--- a/spec/controllers/api/rest/customer/v1/check_rate_controller_spec.rb
+++ b/spec/controllers/api/rest/customer/v1/check_rate_controller_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Api::Rest::Customer::V1::CheckRateController, type: :controller do
+
+  let(:api_access) { create(:api_access) }
+  let(:customer) { api_access.customer }
+  let(:account) { create(:account, contractor: customer) }
+
+  let(:auth_token) { ::Knock::AuthToken.new(payload: { sub: api_access.id }).token }
+
+  before do
+    request.accept = 'application/vnd.api+json'
+    request.headers['Content-Type'] = 'application/vnd.api+json'
+    request.headers['Authorization'] = auth_token
+  end
+
+  before do
+    @r1 = create :destination, rateplan: rateplan, prefix: '444', routing_tag: create(:routing_tag)
+    @r2 = create :destination, rateplan: rateplan, prefix: '4444', routing_tag: create(:routing_tag)
+    create :destination, rateplan: rateplan, prefix: '3333' # out of range
+  end
+
+  before do
+    post :create, data: { type: 'check-rates',
+                          attributes: attributes }
+  end
+
+  let(:attributes) do
+    { 'rateplan-id': rateplan.uuid, number: number }
+  end
+
+  let(:number) { '444444444' }
+  let(:rateplan) { create(:rateplan).reload }
+
+  context 'success' do
+    it 'returns two plans' do
+      expect(response_data).to a_hash_including(
+        'id' => anything,
+        'type' => 'check-rates',
+        'attributes' => a_hash_including(
+          'rateplan-id' => rateplan.uuid,
+          'number' => number,
+          'rates' => match_array(
+            [
+              a_hash_including(
+                'id' => @r1.reload.uuid,
+                'prefix' => @r1.prefix,
+                'initial_rate' => @r1.initial_rate.as_json,
+                'initial_interval' => @r1.initial_interval,
+                'next_rate' => @r1.next_rate.as_json,
+                'next_interval' => @r1.next_interval,
+                'connect_fee' => @r1.connect_fee.as_json,
+                'reject_calls' => @r1.reject_calls,
+                'valid_from' => @r1.valid_from.to_s,
+                'valid_till' => @r1.valid_till.to_s,
+                'network_prefix_id' => @r1.network_prefix_id,
+                'routing_tag_name' => @r1.routing_tag.name
+              ),
+              a_hash_including('id' => @r2.reload.uuid)
+            ]
+          )
+        )
+      )
+    end
+  end
+
+  context 'when Rateplan not exists' do
+    let(:attributes) do
+      { 'rateplan-id': '12123123', number: number }
+    end
+
+    it 'return error Rateplan not found' do
+      expect(response_body).to include(
+        errors: match_array([include(detail: "rateplan-id - Rateplan not found")])
+      )
+    end
+  end
+
+  context 'when proper rate not found for this number' do
+    let(:number) { '8888888888' }
+
+    it 'return empty rates array' do
+      expect(response_data).to a_hash_including(
+        'id' => anything,
+        'type' => 'check-rates',
+        'attributes' => a_hash_including(
+          'rateplan-id' => rateplan.uuid,
+          'number' => number,
+          'rates' => []
+        )
+      )
+    end
+  end
+
+end

--- a/spec/factories/destination.rb
+++ b/spec/factories/destination.rb
@@ -13,6 +13,8 @@ FactoryGirl.define do
     dp_margin_fixed 0
     dp_margin_percent 0
     use_dp_intervals false
+    valid_from { 1.day.ago.utc }
+    valid_till { 1.day.from_now.utc }
     association :rateplan
   end
 end

--- a/spec/factories/routing/routing_tag.rb
+++ b/spec/factories/routing/routing_tag.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :routing_tag, class: Routing::RoutingTag do
+    sequence(:name) { |n| "TAG_#{n}" }
+  end
+end


### PR DESCRIPTION
**POST** `/api/rest/customer/v1/check-rate`

Request example:

```json
{
   "data":{
      "type":"check-rates",
      "attributes":{
         "rateplan-id":21,
         "number":"44444444"
      }
   }
}
```

Response example:

````json
{
   "data":{
      "id":"7a6b999f-b9ff-422d-8d56-dc796b3d2dcf",
      "type":"check-rates",
      "links":{
         "self":"http://example.org/api/rest/customer/v1/check-rates/7a6b999f-b9ff-422d-8d56-dc796b3d2dcf"
      },
      "attributes":{
         "rateplan-id":21,
         "number":"44444444",
         "rates":[
            {
               "id":"7",
               "enabled":"t",
               "prefix":"444",
               "rateplan_id":"21",
               "next_rate":"0.0",
               "connect_fee":"0.0",
               "initial_interval":"60",
               "next_interval":"60",
               "dp_margin_fixed":"0",
               "dp_margin_percent":"0",
               "rate_policy_id":"1",
               "initial_rate":"0.0",
               "reject_calls":"f",
               "use_dp_intervals":"f",
               "valid_from":"2017-10-21 19:16:19.743227+03",
               "valid_till":"2017-10-23 19:16:19.743722+03",
               "profit_control_mode_id":null,
               "network_prefix_id":null,
               "external_id":"6",
               "asr_limit":"0",
               "acd_limit":"0",
               "short_calls_limit":"0",
               "quality_alarm":"f",
               "routing_tag_id":"1",
               "uuid":"56a6d1d8-b744-11e7-9e27-0800276941cb",
               "routing_tag_name":"TAG_1",
               "rank":"1"
            }
         ]
      }
   }
}
```

@dmitry-sinina lets drop unnecessary field from response. And what do you think about ID for rate(Destination) and rateplan_id in request and response.