### PR TITLE
fix #123 acts_as_clone and Inet type copying

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,3 +39,6 @@ end
 ].each do |filename|
   execute_sql_file("db/seeds/cdr/#{filename}.sql", Cdr::Base.connection);
 end
+
+# Create partition for current+next monthes if not exists
+Cdr::Table.add_partition

--- a/lib/resource_dsl/acts_as_clone.rb
+++ b/lib/resource_dsl/acts_as_clone.rb
@@ -16,7 +16,7 @@ module ResourceDSL
 
         def copy_resource(dup_methods)
           from =  active_admin_config.resource_class.find(params[:from])
-          attributes = from.dup.attributes rescue {}
+          attributes = from.dup.attributes_before_type_cast rescue {}
           resource = scoped_collection.new
           dup_methods.each do |m|
             res = from.send(m).dup


### PR DESCRIPTION
The problem is: after clone is is the same but when casting to string it becomes without mask.

```text
self.ip => #<IPAddr: IPv4:0.0.0.0/0.0.0.0> .to_s => '0.0.0.0/0' #when read from database
self.ip => #<IPAddr: IPv4:0.0.0.0/0.0.0.0> .to_s => '0.0.0.0'   #when read with acts_as_clone
```

Proposed solution is not beautiful, but I couldn't fix it another way.  So, just for this clone operation I propose to use `acts_as_clone(:raw_ip)` method.