### PR TITLE
Migrations with stop pionts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ And run tests:
 ```sh
 $ bundle exec rspec
 ```
+
+# Migrations
+
+When you run several migrations in a row, you may wish to stop at some point. In this case you should add `stop_step` method to the migration:
+
+```ruby
+# example /db/migrate/20171105085529_one.rb
+def change
+  # do something
+end
+
+def stop_step
+  true
+end
+```
+
+In this case all migrations after this one will no be performed. To continue migration process you should run `rake db:migrate` command again.
+
+If you do not want to migrate with stops, use env-variable IGNORE_STOPS=true
+
+```sh
+IGNORE_STOPS=true bundle exec rake db:migrate
+```

--- a/config/initializers/yeti.rb
+++ b/config/initializers/yeti.rb
@@ -1,6 +1,7 @@
 Delayed::Worker.destroy_failed_jobs = false
 
 Dir[File.join(Rails.root, "lib", "ext", "**", "*.rb")].each { |s| require s }
+Dir[File.join(Rails.root, "lib", "active_record", "**", "*.rb")].each { |s| require s }
 Dir[File.join(Rails.root, "lib", "active_admin", "**", "*.rb")].each { |s| require s }
 Dir[File.join(Rails.root, "lib", "resource_dsl", "**", "*.rb")].each { |s| require s }
 

--- a/lib/active_record/migrator.rb
+++ b/lib/active_record/migrator.rb
@@ -1,0 +1,25 @@
+module ActiveRecord
+  class Migrator
+    def migrate
+      if !target && @target_version && @target_version > 0
+        raise UnknownMigrationVersionError.new(@target_version)
+      end
+
+      runnable.each do |migration|
+        Base.logger.info "Migrating to #{migration.name} (#{migration.version})" if Base.logger
+
+        begin
+          execute_migration_in_transaction(migration, @direction)
+        rescue => e
+          canceled_msg = use_transaction?(migration) ? "this and " : ""
+          raise StandardError, "An error has occurred, #{canceled_msg}all later migrations canceled:\n\n#{e}", e.backtrace
+        end
+
+        if @direction == :up && !ENV["IGNORE_STOPS"] && migration.send(:migration).try(:stop_step)
+          puts "IMPORTANT: Now update and restart your servers. And after that run `rake db:migrate` again."
+          break
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When running several migrations at once, now it is possible to stop at any point, preventing future migrations. 

How to test it:

create several migrations
```sh
$ bundle exec rails g migration One
$ bundle exec rails g migration Two
$ bundle exec rails g migration Three
```

In second migration add method

```ruby
def stop_step
  true
end
```

Then run command `$ bundle exec rake db:migrate` and you will see

```text
"Timezone Europe/Kiev"
== 20171105085529 One: migrating ==============================================
== 20171105085529 One: migrated (0.0000s) =====================================

== 20171105085555 Two: migrating ==============================================
== 20171105085555 Two: migrated (0.0000s) =====================================

IMPORTANT: Now update and restart your servers. And after that run `rake db:migrate` again.
```

Then run `$ bundle exec rake db:migrate` again and you should see

```text
== 20171105085608 Three: migrating ============================================
== 20171105085608 Three: migrated (0.0000s) ===================================
```