### PR TITLE
Skip broken Nodes when requesting for Registrations

### DIFF
--- a/app/admin/realtime_data/outgoing_registrations.rb
+++ b/app/admin/realtime_data/outgoing_registrations.rb
@@ -28,8 +28,10 @@ ActiveAdmin.register RealtimeData::OutgoingRegistration, as: 'Outgoing Registrat
       registrations = []
 
       begin
-        registrations = Yeti::OutgoingRegistrations.new(Node.all, params[:q]).search
+        searcher = Yeti::OutgoingRegistrations.new(Node.all, params[:q])
+        registrations = searcher.search(empty_on_error: true)
         registrations = Kaminari.paginate_array(registrations).page(1).per(registrations.count)
+        flash.now[:warning] = searcher.errors if searcher.errors.any?
       rescue StandardError => e
         flash.now[:warning] = e.message
       end


### PR DESCRIPTION
Skip broken node when requesting for registrations in Outgoing Registrations page