### PR TITLE
Remove Semantic Logger. Rollback to SysLogger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,11 +67,14 @@ gem 'sass-globbing'
 gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'unicorn'
-gem 'rails_semantic_logger' # Net::TCPClient uses only semantic_logger
-gem 'syslog_protocol' # required for remote logging using the Syslog protol
+gem 'syslog-logger'
 #gem 'odf-report', github: 'sandrods/odf-report'
 gem 'odf-report', github: 'yeti-switch/odf-report'
 gem 'zip-zip'
+
+group :development do
+  gem 'quiet_assets'
+end
 
 #group :development do
   gem 'sourcify'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,8 @@ GEM
     polyamorous (1.2.0)
       activerecord (>= 3.0)
     public_suffix (2.0.5)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -376,9 +378,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_semantic_logger (4.1.3)
-      rails (>= 4.0)
-      semantic_logger (~> 4.1)
     railties (4.2.9)
       actionpack (= 4.2.9)
       activesupport (= 4.2.9)
@@ -443,8 +442,6 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    semantic_logger (4.2.0)
-      concurrent-ruby (~> 1.0)
     sexp_processor (4.5.0)
     sourcify (0.5.0)
       file-tail (>= 1.0.5)
@@ -462,7 +459,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    syslog_protocol (0.9.2)
+    syslog-logger (1.6.8)
     text (1.3.0)
     therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
@@ -547,8 +544,8 @@ DEPENDENCIES
   parallel
   pg
   poltergeist
+  quiet_assets
   rails (~> 4.2.9)
-  rails_semantic_logger
   ransack (~> 1.4.0)
   responders (~> 2.2.0)
   rspec-rails (~> 3.4.2)
@@ -559,7 +556,7 @@ DEPENDENCIES
   selenium-webdriver (~> 2.53)
   sourcify
   sprockets (= 2.11.0)
-  syslog_protocol
+  syslog-logger
   therubyracer (~> 0.12.1)
   thin
   uglifier (>= 1.3)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -32,7 +32,7 @@ class Node < ActiveRecord::Base
   end
 
   def api
-    @api ||= YetisNode::Client.new(self.rpc_endpoint, transport: :json_rpc, logger: logger)
+    @api ||= YetisNode::Client.new(self.rpc_endpoint, transport: :json_rpc)
   end
 
   def total_calls_count

--- a/app/models/realtime_data/active_node.rb
+++ b/app/models/realtime_data/active_node.rb
@@ -19,9 +19,9 @@ class RealtimeData::ActiveNode < Node
 
   def api
     @api ||= if rpc_endpoint.present?
-               YetisNode::Client.new(rpc_endpoint, transport: :json_rpc, logger: logger)
+               YetisNode::Client.new(rpc_endpoint, transport: :json_rpc)
              else
-               YetisNode::Client.new(rpc_uri, logger: logger)
+               YetisNode::Client.new(rpc_uri)
              end
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,8 +21,6 @@ Yeti::Application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
-  config.rails_semantic_logger.quiet_assets = true
-
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,15 +45,11 @@ Yeti::Application.configure do
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # write logs only to syslog
-  # http://rocketjob.github.io/semantic_logger/rails.html#disable-default-rails-file-logging
-  config.rails_semantic_logger.add_file_appender = false
-  config.semantic_logger.add_appender(
-    appender: SemanticLogger::Appender::Syslog.new(
-      application: 'YETI-admin',
-      facility: ::Syslog::LOG_LOCAL7
-    )
-  )
+  # Use a different logger for distributed setups
+  config.logger =  Logger::Syslog.new('YETI-admin', Syslog::LOG_LOCAL7)
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
 
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Semantic Logger has some problems in production with unicorn https://rocketjob.github.io/semantic_logger/forking.html

Got error:
```
E, [2017-12-03T16:09:17.208876 #20618] ERROR -- : syslog already open (RuntimeError)
```
---
This PR removes Semantic Logger. And rollback to SysLogger.
