### PR TITLE
Dialpeer can be linked with Gateway only with flag allow_termination …

### DIFF
--- a/app/admin/equipment/gateways.rb
+++ b/app/admin/equipment/gateways.rb
@@ -106,6 +106,11 @@ ActiveAdmin.register Gateway do
     render text: view_context.options_from_collection_for_select(@gateways, :id, :display_name)
   end
 
+  collection_action :for_termination do
+    @gateways = Gateway.for_termination(params[:contractor_id].to_i)
+    render text: view_context.options_from_collection_for_select(@gateways, :id, :display_name)
+  end
+
   index do
     selectable_column
     id_column

--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -194,7 +194,7 @@ ActiveAdmin.register Dialpeer do
               input_html: {
                   class: 'chosen',
                   onchange: remote_chosen_request(:get, with_contractor_accounts_path, {contractor_id: "$(this).val()"}, :dialpeer_account_id) +
-                      remote_chosen_request(:get, for_origination_gateways_path, {contractor_id: "$(this).val()"}, :dialpeer_gateway_id) +
+                      remote_chosen_request(:get, for_termination_gateways_path, {contractor_id: "$(this).val()"}, :dialpeer_gateway_id) +
                       remote_chosen_request(:get, with_contractor_gateway_groups_path, {contractor_id: "$(this).val()"}, :dialpeer_gateway_group_id)
               }
       f.input :account, collection: (f.object.vendor.nil? ? [] : f.object.vendor.accounts),

--- a/spec/models/gateway_spec.rb
+++ b/spec/models/gateway_spec.rb
@@ -45,4 +45,33 @@ describe Gateway, type: :model do
 
   end
 
+  context 'scope :for_termination' do
+
+    before do
+      # in scope
+      @record = create(:gateway, is_shared: false, allow_termination: true, name: 'b-gateway')
+      @record_2 = create(:gateway, is_shared: true, allow_termination: true, name: 'a-gateway')
+    end
+
+    # out of scope
+    before do
+      # other vendor
+      create(:gateway, allow_termination: true)
+      # shared but not for termination
+      create(:gateway, allow_termination: false, is_shared: true)
+      # same vendor but not for termination
+      create(:gateway, allow_termination: false, contractor: vendor)
+    end
+
+    let(:vendor) { @record.vendor }
+
+    subject do
+      described_class.for_termination(vendor.id)
+    end
+
+    it 'allow_termination is mandatory, then look for shared or vendors gateways, order by name' do
+      expect(subject.pluck(:id)).to match_array([@record_2.id, @record.id])
+    end
+
+  end
 end


### PR DESCRIPTION
…and (shared or same customer)

The SQL for selecting gateways is:

```sql
SELECT "gateways".* 
FROM "gateways" 
INNER JOIN "contractors" 
  ON "contractors"."id" = "gateways"."contractor_id" AND "contractors"."vendor" = 't' 
WHERE (gateways.allow_termination AND (gateways.contractor_id=1 OR gateways.is_shared))  
ORDER BY "gateways"."name" ASC
```

Alwo I would like to add validation on Dialpeer model

```ruby
unless self.gateway.allow_termination
  self.errors.add(:gateway, 'must be allowed for termination')
end
```

This validation can be added here tomorrow, or in separate PR. In second case this PR can be merged sooner.