### PR TITLE
Account#destroy handles related Dialpeers and Payments correctly

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -41,9 +41,12 @@ class Account < Yeti::ActiveRecord
   belongs_to :customer_invoice_template, class_name: 'Billing::InvoiceTemplate', foreign_key: 'customer_invoice_template_id'
   belongs_to :timezone, class_name: 'System::Timezone', foreign_key: :timezone_id
 
-  has_many :payments
+  has_many :payments, dependent: :destroy
   has_many :invoices, class_name: 'Billing::Invoice'
   has_many :api_access, ->(record) { unscope(:where).where("? = ANY(#{table_name}.account_ids)", record.id) }, class_name: 'System::ApiAccess', autosave: false
+  has_many :customers_auths, dependent: :restrict_with_error
+  has_many :dialpeers, dependent: :restrict_with_error
+
 
   has_paper_trail class_name: 'AuditLogItem'
 


### PR DESCRIPTION
IMPORTANT: **1.4 branch**

This PR resolves issue when call `Account#destroy`

1. if Account has related Payments, they will be destroyed too
2. if Account has related Dialpeers, the destroy method will return error
3. same for CustomersAuth