### PR TITLE
Hotfix links

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -112,7 +112,7 @@ table th, table td {
     <h2>Admin API resources</h2>
     <ul>
       <li>
-        <a href="doc/api/admin/index.html">Admin API documentation</a>
+        <a href="api/admin/index.html">Admin API documentation</a>
       </li>
     </ul>
   </div>
@@ -121,7 +121,7 @@ table th, table td {
     <h2>Customer API resources</h2>
     <ul>
       <li>
-        <a href="doc/api/customer/v1/index.html">Customer API documentation</a>
+        <a href="api/customer/v1/index.html">Customer API documentation</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
https://demo.yeti-switch.org/doc has broken links.

/doc/doc/api/... instead of /doc/api