### PR TITLE
Fix Gateways-dropdown in Dialpeer edit-form

### DIFF
--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -239,7 +239,7 @@ ActiveAdmin.register Dialpeer do
       f.input :connect_fee
       f.input :reverse_billing
 
-      f.input :gateway, collection: (f.object.vendor.nil? ? [] : f.object.vendor.for_origination_gateways),
+      f.input :gateway, collection: (f.object.vendor.nil? ? [] : f.object.vendor.for_termination_gateways),
               include_blank: "None" ,
               input_html: {class: 'chosen'}
 

--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -48,6 +48,10 @@ class Contractor < ActiveRecord::Base
     Gateway.for_origination(id)
   end
 
+  def for_termination_gateways
+    Gateway.for_termination(id)
+  end
+
   private
 
   def vendor_or_customer?


### PR DESCRIPTION
ActiveAdmin page edit Dialpeer was with wrong collection
for Gateways - old version "for_origination"-gateways.

Change it to "for_termination"-gateways.
In this case it uses new logic with shared gateways.