### PR TITLE
Batch actions transactions

### DIFF
--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -94,7 +94,8 @@ ActiveAdmin.register Destination do
                 :initial_interval, :next_interval, :dp_margin_fixed,
                 :dp_margin_percent, :rate_policy_id, :reverse_billing, :initial_rate,
                 :reject_calls, :use_dp_intervals, :test, :profit_control_mode_id,
-                :valid_from, :valid_till, :asr_limit, :acd_limit, :short_calls_limit, :batch_prefix, :routing_tag_id
+                :valid_from, :valid_till, :asr_limit, :acd_limit, :short_calls_limit, :batch_prefix, :routing_tag_id,
+                :reverse_billing
 
   includes :rateplan, :rate_policy, :profit_control_mode, :routing_tag, network_prefix: [:country, :network]
 

--- a/app/assets/stylesheets/active_admin/components/active_admin_scoped_collection_actions.css.scss
+++ b/app/assets/stylesheets/active_admin/components/active_admin_scoped_collection_actions.css.scss
@@ -1,6 +1,16 @@
 .ui-dialog.active_admin_dialog_mass_update_by_filter {
-  form ul li label {
-    display: inline-block;
+  width: auto!important;
+  form ul li {
+    label, select, input{
+      display: inline-block;
+    }
+    select, input:not([type='checkbox']){
+      float: right;
+      width: 235px;
+    }
+    select{
+      width: 255px;
+    }
   }
 }
 

--- a/app/jobs/async_batch_destroy_job.rb
+++ b/app/jobs/async_batch_destroy_job.rb
@@ -1,4 +1,5 @@
 class AsyncBatchDestroyJob
+  include BatchJobsLog
   BATCH_SIZE = 1000
 
   attr_reader :model_class, :sql_query
@@ -23,6 +24,22 @@ class AsyncBatchDestroyJob
 
   def max_attempts
     3
+  end
+
+  def success(job)
+    LogicLog.create!(
+      source: 'Batch destroy job ' + job.id.to_s,
+      level: 0,
+      msg: 'success'
+    )
+  end
+
+  def failure(job)
+    LogicLog.create!(
+      source: 'Batch destroy job ' + job.id.to_s,
+      level: 0,
+      msg: job.last_error
+    )
   end
 
 end

--- a/app/jobs/async_batch_destroy_job.rb
+++ b/app/jobs/async_batch_destroy_job.rb
@@ -1,13 +1,28 @@
-class AsyncBatchDestroyJob < ActiveJob::Base
-  queue_as :batch_actions
-
+class AsyncBatchDestroyJob
   BATCH_SIZE = 1000
 
-  def perform(model_class, sql_query)
-    begin
-      scoped_records = model_class.constantize.find_by_sql(sql_query + " LIMIT #{BATCH_SIZE}")
-      scoped_records.each { |record| record.destroy! }
-    end until scoped_records.empty?
+  attr_reader :model_class, :sql_query
+
+  def initialize(model_class, sql_query)
+    @model_class = model_class
+    @sql_query = sql_query
+  end
+
+  def perform
+    model_class.constantize.transaction do
+      begin
+        scoped_records = model_class.constantize.find_by_sql(sql_query + " LIMIT #{BATCH_SIZE}")
+        scoped_records.each { |record| record.destroy! }
+      end until scoped_records.empty?
+    end
+  end
+
+  def reschedule_at(time, attempts)
+    10.seconds.from_now
+  end
+
+  def max_attempts
+    3
   end
 
 end

--- a/app/jobs/async_batch_update_job.rb
+++ b/app/jobs/async_batch_update_job.rb
@@ -1,4 +1,5 @@
 class AsyncBatchUpdateJob
+  include BatchJobsLog
   BATCH_SIZE = 1000
 
   attr_reader :model_class, :sql_query, :changes
@@ -7,6 +8,7 @@ class AsyncBatchUpdateJob
     @model_class = model_class
     @sql_query = sql_query
     @changes = changes
+    @last_transaction = ''
   end
 
   def perform

--- a/app/jobs/async_batch_update_job.rb
+++ b/app/jobs/async_batch_update_job.rb
@@ -1,32 +1,47 @@
-class AsyncBatchUpdateJob < ActiveJob::Base
-  queue_as :batch_actions
-
+class AsyncBatchUpdateJob
   BATCH_SIZE = 1000
 
-  def perform(model_class, sql_query, changes)
-    total_count = model_class.constantize.count_by_sql(total_count_sql sql_query)
-    sql_query_reordered = order_by_id_sql sql_query
+  attr_reader :model_class, :sql_query, :changes
 
-    ((total_count.to_f / BATCH_SIZE).ceil).times do |batch_number|
-      offset = batch_number * BATCH_SIZE
-      scoped_records = model_class.constantize.find_by_sql(sql_query_reordered + " OFFSET #{offset} LIMIT #{BATCH_SIZE}")
-      scoped_records.each { |record| record.update!(changes) }
-    end
-
+  def initialize(model_class, sql_query, changes)
+    @model_class = model_class
+    @sql_query = sql_query
+    @changes = changes
   end
 
-  def total_count_sql(sql_query)
+  def perform
+    model_class.constantize.transaction do
+      total_count = model_class.constantize.count_by_sql total_count_sql
+      sql_query_reordered = order_by_id_sql
+
+      ((total_count.to_f / BATCH_SIZE).ceil).times do |batch_number|
+        offset = batch_number * BATCH_SIZE
+        scoped_records = model_class.constantize.find_by_sql(sql_query_reordered + " OFFSET #{offset} LIMIT #{BATCH_SIZE}")
+        scoped_records.each { |record| record.update!(changes) }
+      end
+    end
+  end
+
+  def total_count_sql
     sql_query.gsub(/^SELECT .* FROM/, 'SELECT COUNT(*) FROM')
              .gsub(/ORDER BY .* (ASC)|(DESC)/, '')
   end
 
   # Some records are sorted by updated_at column by default, and that breaks our OFFSET setting, because freshly
   # updated records go up in query queue. To avoid that we change default ordering to order by id.
-  def order_by_id_sql(sql_query)
+  def order_by_id_sql
     order_by_id_path = sql_query[/FROM\s(.*?)(\s|\z)/m, 1] + '."id"'
     result_sql = sql_query.gsub(/ORDER BY .* (ASC)|(DESC)/, "ORDER BY #{order_by_id_path} ASC")
     result_sql += " ORDER BY #{order_by_id_path} ASC" unless sql_query.include? 'ORDER'
     result_sql
+  end
+
+  def reschedule_at(time, attempts)
+    10.seconds.from_now
+  end
+
+  def max_attempts
+    3
   end
 
 end

--- a/lib/batch_jobs_log.rb
+++ b/lib/batch_jobs_log.rb
@@ -1,0 +1,17 @@
+module BatchJobsLog
+  def success(job)
+    LogicLog.create!(
+      source: self.class.to_s + ' ' + job.id.to_s,
+      level: 0,
+      msg: 'success'
+    )
+  end
+
+  def failure(job)
+    LogicLog.create!(
+      source: self.class.to_s + ' ' + job.id.to_s,
+      level: 0,
+      msg: job.last_error
+    )
+  end
+end

--- a/lib/resource_dsl/acts_as_async_destroy.rb
+++ b/lib/resource_dsl/acts_as_async_destroy.rb
@@ -8,8 +8,9 @@ module ResourceDSL
 
       scoped_collection_action :async_destroy,
                                title: 'Delete batch' do
-        AsyncBatchDestroyJob.perform_later(model_class,
-                                           scoped_collection_records.except(:eager_load).to_sql)
+        Delayed::Job.enqueue AsyncBatchDestroyJob.new(model_class,
+                                                      scoped_collection_records.except(:eager_load).to_sql),
+                             queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_destroy.job_scheduled')
         head :ok
       end

--- a/lib/resource_dsl/acts_as_async_update.rb
+++ b/lib/resource_dsl/acts_as_async_update.rb
@@ -9,9 +9,10 @@ module ResourceDSL
                                title: 'Update batch',
                                class: 'scoped_collection_action_button ui',
                                form: attrs_to_update do
-        AsyncBatchUpdateJob.perform_later(model_class,
-                                          scoped_collection_records.except(:eager_load).to_sql,
-                                          params[:changes])
+        Delayed::Job.enqueue AsyncBatchUpdateJob.new(model_class,
+                                                     scoped_collection_records.except(:eager_load).to_sql,
+                                                     params[:changes]),
+                             queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_update.job_scheduled')
         head :ok
       end

--- a/lib/resource_dsl/acts_as_async_update.rb
+++ b/lib/resource_dsl/acts_as_async_update.rb
@@ -11,7 +11,7 @@ module ResourceDSL
                                form: attrs_to_update do
         Delayed::Job.enqueue AsyncBatchUpdateJob.new(model_class,
                                                      scoped_collection_records.except(:eager_load).to_sql,
-                                                     params[:changes]),
+                                                     params[:changes].permit!),
                              queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_update.job_scheduled')
         head :ok

--- a/lib/resource_dsl/acts_as_delayed_job_lock.rb
+++ b/lib/resource_dsl/acts_as_delayed_job_lock.rb
@@ -5,7 +5,7 @@ module ResourceDSL
       controller do
 
         def update
-          if Delayed::Job.where(queue: :batch_actions).any?
+          if Delayed::Job.where(queue: :batch_actions, failed_at: nil).any?
             flash[:error] = I18n.t('flash.actions.batch_actions.editing_prohibited')
             redirect_to action: :show
           else
@@ -14,7 +14,7 @@ module ResourceDSL
         end
 
         def destroy
-          if Delayed::Job.where(queue: :batch_actions).any?
+          if Delayed::Job.where(queue: :batch_actions, failed_at: nil).any?
             flash[:error] = I18n.t('flash.actions.batch_actions.destroying_prohibited')
             redirect_to :back
           else

--- a/spec/jobs/async_batch_destroy_job_spec.rb
+++ b/spec/jobs/async_batch_destroy_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AsyncBatchDestroyJob, type: :job do
     include_context :init_destination, id: 2, initial_rate: 0.5
     include_context :init_destination, id: 3, initial_rate: 0.7
 
-    subject { described_class.new.perform(model_class, sql_query)}
+    subject { described_class.new(model_class, sql_query).perform}
 
     before :each do
       stub_const('AsyncBatchDestroyJob::BATCH_SIZE', 2)

--- a/spec/jobs/async_batch_update_job_spec.rb
+++ b/spec/jobs/async_batch_update_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AsyncBatchUpdateJob, type: :job do
     include_context :init_destination, id: 2, initial_rate: 0.5
     include_context :init_destination, id: 3, initial_rate: 0.7
 
-    subject { described_class.new.perform(model_class, sql_query, changes)}
+    subject { described_class.new(model_class, sql_query, changes).perform}
 
     before :each do
       stub_const('AsyncBatchUpdateJob::BATCH_SIZE', 2)


### PR DESCRIPTION
cherry pick PR #183  from `master`-branch to `1.5`

@stekatk 

> Batch job are now wrapped in transaction to be executed completely or not at all (in case of error).
> Failed batch jobs don't lock update/destroy actions now, only active job do this.
> It's possible to set up attempts number and reschedule time for update and destroy jobs.
> Logic logs for batch jobs added.
> 
> Improved batch update css modal a bit.
