### PR TITLE
Fix Rateplan Copy-action

### DIFF
--- a/app/models/rateplan.rb
+++ b/app/models/rateplan.rb
@@ -41,7 +41,14 @@ class Rateplan < ActiveRecord::Base
 
 
   def send_quality_alarms_to=(send_to_ids)
-    self[:send_quality_alarms_to] = send_to_ids.reject {|i| i.blank? }
+    # This "else" statement is needed only cause of this PR
+    # https://github.com/yeti-switch/yeti-web/pull/129
+    # TODO: Rewrite PR #129 in other way and remove this hotfix here
+    if send_to_ids.is_a?(Array)
+      self[:send_quality_alarms_to] = send_to_ids.reject {|i| i.blank? }
+    else
+      self[:send_quality_alarms_to] = send_to_ids # hotfix
+    end
   end
 
   def contacts

--- a/app/models/routing/rateplan_duplicator.rb
+++ b/app/models/routing/rateplan_duplicator.rb
@@ -22,6 +22,7 @@ class Routing::RateplanDuplicator
         src=Rateplan.find(id)
         src.destinations.each do |n|
           x=n.dup
+          x.uuid = nil
           x.rateplan_id=dst.id
           x.save!
         end

--- a/lib/resource_dsl/acts_as_clone.rb
+++ b/lib/resource_dsl/acts_as_clone.rb
@@ -59,11 +59,14 @@ module ResourceDSL
       controller do
 
         protected
+
         def fill_resource(klass)
           resource = scoped_collection.new
           @source_object ||= klass.find(params[:from])
           attributes = @source_object.attributes rescue {}
-          attributes.map { |k, v| resource.send("#{k}=", v) }
+          attributes
+            .reject { |k| k == 'uuid' } # TODO: improve this
+            .map { |k, v| resource.send("#{k}=", v) }
           set_resource_ivar(resource)
         end
 

--- a/spec/features/rateplans/copy_rateplan_spec.rb
+++ b/spec/features/rateplans/copy_rateplan_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'Copy Rateplan action', type: :feature do
+
+  # TODO: move login admin to `shared_context :login_as_admin`
+  let(:admin_user) { create :admin_user }
+  before { login_as(admin_user, scope: :admin_user) }
+
+  shared_examples :cloned_rateplan_is_valid do
+
+    it 'creates new Rateplan with identical fields, except UUID' do
+      subject
+      expect(rateplan.send_quality_alarms_to).to eq(send_to_ids)
+      expect(rateplan.destinations.count).to eq(0)
+      expect(Rateplan.count).to eq(2)
+      expect(Rateplan.last).to have_attributes(
+        name: new_name,
+        profit_control_mode_id: rateplan.profit_control_mode_id,
+        send_quality_alarms_to: send_to_ids
+      )
+    end
+
+  end
+
+  context 'success' do
+
+    before do
+      create :admin_user, username: 'test send_to_ids'
+    end
+
+    let!(:rateplan) do
+      create(:rateplan,
+             send_quality_alarms_to: send_to_ids
+            ).reload # after_save
+    end
+
+    let(:new_name) { rateplan.name + '_copy' }
+
+    before { visit rateplan_path(rateplan.id) }
+
+    before do
+      click_link('Copy', exact_text: true)
+      within '#new_rateplan' do
+        fill_in('rateplan_name', with: new_name)
+      end
+    end
+
+    subject do
+      find('input[type=submit]').click
+      find('h3', text: 'Rateplan Details') # wait page reload
+    end
+
+    context 'when "Send quality alarms to" is empty' do
+
+      let(:send_to_ids) { [] }
+
+      include_examples :cloned_rateplan_is_valid
+    end
+
+    context 'when "Send quality alarms to" has values' do
+
+      # assign two Admins to "Send quality alarms to"
+      let(:send_to_ids) { AdminUser.all.pluck(:id) }
+
+      include_examples :cloned_rateplan_is_valid
+    end
+
+  end
+
+end

--- a/spec/features/rateplans/copy_rateplan_with_destinations_spec.rb
+++ b/spec/features/rateplans/copy_rateplan_with_destinations_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'Copy Rateplan action', type: :feature do
+
+  # TODO: move login admin to `shared_context :login_as_admin`
+  let(:admin_user) { create :admin_user }
+  before { login_as(admin_user, scope: :admin_user) }
+
+
+  context 'success' do
+
+    let!(:rateplan) do
+      create(:rateplan)
+    end
+
+    before do
+      create_list(:destination, 2, rateplan: rateplan)
+    end
+
+    let(:new_name) { rateplan.name + '_copy' }
+
+    before { visit rateplan_path(rateplan.id) }
+
+    before do
+      click_link('Copy with destinations', exact_text: true)
+      within '#new_routing_rateplan_duplicator' do
+        fill_in('Name', with: new_name)
+        find('input[type=submit]').click
+      end
+      find('h2', text: 'Rateplans') # wait page load
+    end
+
+    context 'when "Send quality alarms to" is empty' do
+
+      it 'creates new Rateplan with duplicated Destinations' do
+        expect(rateplan.reload.destinations.count).to eq(2)
+        expect(Rateplan.count).to eq(2)
+        expect(Rateplan.last.destinations.count).to eq(2)
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
fixes #190

Fix "Copy" and "Copy with Destinations" actions
in ActiveAdmin page `/destinations`

Error appeared because of `uuid` field
in Rateplan and Destination models