### PR TITLE
Rename CallsMonitoring CDR check_account attribute

### DIFF
--- a/app/jobs/jobs/calls_monitoring.rb
+++ b/app/jobs/jobs/calls_monitoring.rb
@@ -16,13 +16,13 @@ module Jobs
 
       def normal_calls
         collection.select do |c|
-         c[call_reverse_billing_key] == false && c['check_account_balance']
+         c[call_reverse_billing_key] == false && c['customer_acc_check_balance']
         end
       end
 
       def reverse_calls
         collection.select do |c|
-         c[call_reverse_billing_key] == true && c['check_account_balance']
+         c[call_reverse_billing_key] == true && c['customer_acc_check_balance']
         end
       end
 
@@ -116,11 +116,11 @@ module Jobs
         :dialpeer_next_interval,
         :dialpeer_next_rate,
 
-        :check_account_balance,
+        :customer_acc_check_balance,
         :destination_reverse_billing,
         :dialpeer_reverse_billing,
 
-         :duration
+        :duration
     ].freeze
 
     def after_start

--- a/spec/jobs/calls_monitoring_spec.rb
+++ b/spec/jobs/calls_monitoring_spec.rb
@@ -23,7 +23,7 @@ describe Jobs::CallsMonitoring do
   end
 
   shared_examples :keep_emergency_calls do
-    let(:check_account_balance) { false }
+    let(:customer_acc_check_balance) { false }
     include_examples :keep_calls
   end
 
@@ -57,7 +57,7 @@ describe Jobs::CallsMonitoring do
       double('Yeti::CdrsFilter', raw_cdrs: [ {'node_id' => 1}, {'node_id' => 2} ])
     end
 
-    let(:check_account_balance) { true }
+    let(:customer_acc_check_balance) { true }
 
     let(:cdr_list_unsorted) do
       [
@@ -83,7 +83,7 @@ describe Jobs::CallsMonitoring do
           'dialpeer_initial_rate' => '0.0000',
           'dialpeer_next_interval' => 30,
           'dialpeer_next_rate' => '0.0000',
-          'check_account_balance' => check_account_balance,
+          'customer_acc_check_balance' => customer_acc_check_balance,
           'destination_reverse_billing' => false,
           'dialpeer_reverse_billing' => false
         },
@@ -109,7 +109,7 @@ describe Jobs::CallsMonitoring do
           'dialpeer_initial_rate' => '0.0000',
           'dialpeer_next_interval' => 30,
           'dialpeer_next_rate' => '0.0000',
-          'check_account_balance' => check_account_balance,
+          'customer_acc_check_balance' => customer_acc_check_balance,
           'destination_reverse_billing' => true,
           'dialpeer_reverse_billing' => true
         }


### PR DESCRIPTION
Rename CDR attribute in CallsMonitoring job.
From `check_account_balance` to `customer_acc_check_balance`