### PR TITLE
Pass current_user to delayed jobs to store it in audit logs

### DIFF
--- a/app/jobs/async_batch_destroy_job.rb
+++ b/app/jobs/async_batch_destroy_job.rb
@@ -2,14 +2,16 @@ class AsyncBatchDestroyJob
   include BatchJobsLog
   BATCH_SIZE = 1000
 
-  attr_reader :model_class, :sql_query
+  attr_reader :model_class, :sql_query, :who_is
 
-  def initialize(model_class, sql_query)
+  def initialize(model_class, sql_query, who_is)
     @model_class = model_class
     @sql_query = sql_query
+    @who_is = who_is
   end
 
   def perform
+    set_audit_log_data
     model_class.constantize.transaction do
       begin
         scoped_records = model_class.constantize.find_by_sql(sql_query + " LIMIT #{BATCH_SIZE}")
@@ -24,22 +26,6 @@ class AsyncBatchDestroyJob
 
   def max_attempts
     3
-  end
-
-  def success(job)
-    LogicLog.create!(
-      source: 'Batch destroy job ' + job.id.to_s,
-      level: 0,
-      msg: 'success'
-    )
-  end
-
-  def failure(job)
-    LogicLog.create!(
-      source: 'Batch destroy job ' + job.id.to_s,
-      level: 0,
-      msg: job.last_error
-    )
   end
 
 end

--- a/app/jobs/async_batch_update_job.rb
+++ b/app/jobs/async_batch_update_job.rb
@@ -2,29 +2,29 @@ class AsyncBatchUpdateJob
   include BatchJobsLog
   BATCH_SIZE = 1000
 
-  attr_reader :model_class, :sql_query, :changes
+  attr_reader :model_class, :sql_query, :changes, :who_is
 
-  def initialize(model_class, sql_query, changes)
+  def initialize(model_class, sql_query, changes, who_is)
     @model_class = model_class
     @sql_query = sql_query
     @changes = changes
-    @last_transaction = ''
+    @who_is = who_is
   end
 
   def perform
+    set_audit_log_data
     model_class.constantize.transaction do
-      total_count = model_class.constantize.count_by_sql total_count_sql
-      sql_query_reordered = order_by_id_sql
+      total_count = model_class.constantize.count_by_sql count_sql_query
 
-      ((total_count.to_f / BATCH_SIZE).ceil).times do |batch_number|
+      (total_count.to_f / BATCH_SIZE).ceil.times do |batch_number|
         offset = batch_number * BATCH_SIZE
-        scoped_records = model_class.constantize.find_by_sql(sql_query_reordered + " OFFSET #{offset} LIMIT #{BATCH_SIZE}")
+        scoped_records = model_class.constantize.find_by_sql(order_by_id_sql + " OFFSET #{offset} LIMIT #{BATCH_SIZE}")
         scoped_records.each { |record| record.update!(changes) }
       end
     end
   end
 
-  def total_count_sql
+  def count_sql_query
     sql_query.gsub(/^SELECT .* FROM/, 'SELECT COUNT(*) FROM')
              .gsub(/ORDER BY .* (ASC)|(DESC)/, '')
   end

--- a/lib/batch_jobs_log.rb
+++ b/lib/batch_jobs_log.rb
@@ -16,8 +16,8 @@ module BatchJobsLog
   end
 
   def set_audit_log_data
-    ::PaperTrail.whodunnit = who_is.try(:id)
-    ::PaperTrail.controller_info = { ip: who_is.try(:current_sign_in_ip) }
+    ::PaperTrail.whodunnit = who_is[:whodunnit]
+    ::PaperTrail.controller_info = who_is[:controller_info]
   end
 
 end

--- a/lib/batch_jobs_log.rb
+++ b/lib/batch_jobs_log.rb
@@ -1,17 +1,23 @@
 module BatchJobsLog
   def success(job)
     LogicLog.create!(
-      source: self.class.to_s + ' ' + job.id.to_s,
+      source: "#{self.class} #{job.id}",
       level: 0,
-      msg: 'success'
+      msg: 'Success'
     )
   end
 
   def failure(job)
     LogicLog.create!(
-      source: self.class.to_s + ' ' + job.id.to_s,
+      source: "#{self.class} #{job.id}",
       level: 0,
       msg: job.last_error
     )
   end
+
+  def set_audit_log_data
+    ::PaperTrail.whodunnit = who_is.try(:id)
+    ::PaperTrail.controller_info = { ip: who_is.try(:current_sign_in_ip) }
+  end
+
 end

--- a/lib/resource_dsl/acts_as_async_destroy.rb
+++ b/lib/resource_dsl/acts_as_async_destroy.rb
@@ -9,7 +9,8 @@ module ResourceDSL
       scoped_collection_action :async_destroy,
                                title: 'Delete batch' do
         Delayed::Job.enqueue AsyncBatchDestroyJob.new(model_class,
-                                                      scoped_collection_records.except(:eager_load).to_sql),
+                                                      scoped_collection_records.except(:eager_load).to_sql,
+                                                      current_admin_user),
                              queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_destroy.job_scheduled')
         head :ok

--- a/lib/resource_dsl/acts_as_async_destroy.rb
+++ b/lib/resource_dsl/acts_as_async_destroy.rb
@@ -10,10 +10,14 @@ module ResourceDSL
                                title: 'Delete batch' do
         Delayed::Job.enqueue AsyncBatchDestroyJob.new(model_class,
                                                       scoped_collection_records.except(:eager_load).to_sql,
-                                                      current_admin_user),
+                                                      @paper_trail_info),
                              queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_destroy.job_scheduled')
         head :ok
+      end
+
+      before_filter do
+        @paper_trail_info = { whodunnit: current_admin_user.id, controller_info: info_for_paper_trail }
       end
     end
 

--- a/lib/resource_dsl/acts_as_async_update.rb
+++ b/lib/resource_dsl/acts_as_async_update.rb
@@ -1,8 +1,7 @@
-# When including this module without acts_as_async_destroy, add following strings to resource register file:
-# config.batch_actions = true
-# config.scoped_collection_actions_if = -> { true }
-
 module ResourceDSL
+  # When including this module without acts_as_async_destroy, add following strings to resource register file:
+  # config.batch_actions = true
+  # config.scoped_collection_actions_if = -> { true }
   module ActsAsAsyncUpdate
     def acts_as_async_update(model_class, attrs_to_update)
       scoped_collection_action :async_update,
@@ -12,16 +11,19 @@ module ResourceDSL
         Delayed::Job.enqueue AsyncBatchUpdateJob.new(model_class,
                                                      scoped_collection_records.except(:eager_load).to_sql,
                                                      params[:changes].permit!,
-                                                     current_admin_user),
+                                                     @paper_trail_info),
                              queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_update.job_scheduled')
         head :ok
+      end
+
+      before_filter do
+        @paper_trail_info = { whodunnit: current_admin_user.id, controller_info: info_for_paper_trail }
       end
     end
 
     def boolean_select
       [ ['Yes', 't'], ['No', 'f'] ]
     end
-
   end
 end

--- a/lib/resource_dsl/acts_as_async_update.rb
+++ b/lib/resource_dsl/acts_as_async_update.rb
@@ -11,7 +11,8 @@ module ResourceDSL
                                form: attrs_to_update do
         Delayed::Job.enqueue AsyncBatchUpdateJob.new(model_class,
                                                      scoped_collection_records.except(:eager_load).to_sql,
-                                                     params[:changes].permit!),
+                                                     params[:changes].permit!,
+                                                     current_admin_user),
                              queue: 'batch_actions'
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_update.job_scheduled')
         head :ok

--- a/spec/jobs/async_batch_destroy_job_spec.rb
+++ b/spec/jobs/async_batch_destroy_job_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe AsyncBatchDestroyJob, type: :job do
       stub_const('AsyncBatchDestroyJob::BATCH_SIZE', 2)
     end
 
-    let(:who_is) { create :admin_user }
+    let(:admin) { create :admin_user }
+    let(:who_is) { { whodunnit: admin.id, controller_info: {} } }
 
     context 'incorrect class_name' do
       let(:model_class) { 'Fake' }

--- a/spec/jobs/async_batch_destroy_job_spec.rb
+++ b/spec/jobs/async_batch_destroy_job_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe AsyncBatchDestroyJob, type: :job do
     include_context :init_destination, id: 2, initial_rate: 0.5
     include_context :init_destination, id: 3, initial_rate: 0.7
 
-    subject { described_class.new(model_class, sql_query).perform}
+    subject { described_class.new(model_class, sql_query, who_is).perform }
 
     before :each do
       stub_const('AsyncBatchDestroyJob::BATCH_SIZE', 2)
     end
+
+    let(:who_is) { create :admin_user }
 
     context 'incorrect class_name' do
       let(:model_class) { 'Fake' }

--- a/spec/jobs/async_batch_update_job_spec.rb
+++ b/spec/jobs/async_batch_update_job_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe AsyncBatchUpdateJob, type: :job do
     include_context :init_destination, id: 2, initial_rate: 0.5
     include_context :init_destination, id: 3, initial_rate: 0.7
 
-    subject { described_class.new(model_class, sql_query, changes).perform}
+    subject { described_class.new(model_class, sql_query, changes, who_is).perform }
 
     before :each do
       stub_const('AsyncBatchUpdateJob::BATCH_SIZE', 2)
     end
+
+    let(:who_is) { create :admin_user }
 
     context 'incorrect class_name' do
       let(:model_class) { 'Fake' }

--- a/spec/jobs/async_batch_update_job_spec.rb
+++ b/spec/jobs/async_batch_update_job_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe AsyncBatchUpdateJob, type: :job do
       stub_const('AsyncBatchUpdateJob::BATCH_SIZE', 2)
     end
 
-    let(:who_is) { create :admin_user }
+    let(:admin) { create :admin_user }
+    let(:who_is) { { whodunnit: admin.id, controller_info: {} } }
 
     context 'incorrect class_name' do
       let(:model_class) { 'Fake' }
@@ -35,7 +36,7 @@ RSpec.describe AsyncBatchUpdateJob, type: :job do
         let(:changes) { {prefix: '300', reject_calls: false} }
 
         context 'no filter/selection' do
-          let (:sql_query) { Destination.all.to_sql }
+          let(:sql_query) { Destination.all.to_sql }
 
           it { expect {subject}.to change(Destination.where(prefix: '300', reject_calls: false), :count).by(3) }
         end


### PR DESCRIPTION
Audit logs now keep information about ip and account of user who did batch update/delete.