### PR TITLE
Customers Auth multiple match conditions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 # Core
 gem 'pg'
+gem 'postgres_ext'
 gem 'rails', '~> 4.2.9'
 gem 'responders', '~> 2.2.0'
 gem 'activerecord-postgres-dump-schemas' # TODO: deprecated for Rails 5
@@ -84,6 +85,7 @@ end
 
 group :development, :test do
   gem 'byebug'
+  gem 'awesome_print'
   gem 'thin'
 
   gem 'rspec-rails', '~> 3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (6.0.4)
+    awesome_print (1.8.0)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -347,12 +348,17 @@ GEM
       activesupport (>= 3.0, < 5.0)
     parallel (1.3.4)
     pg (0.18.1)
+    pg_array_parser (0.0.9)
     poltergeist (1.16.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     polyamorous (1.2.0)
       activerecord (>= 3.0)
+    postgres_ext (3.0.0)
+      activerecord (>= 4.0.0)
+      arel (>= 4.0.1)
+      pg_array_parser (~> 0.0.9)
     public_suffix (2.0.5)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
@@ -515,6 +521,7 @@ DEPENDENCIES
   activerecord-postgres-dump-schemas
   annotate
   apitome (~> 0.1.0)
+  awesome_print
   better_errors
   binding_of_caller
   byebug
@@ -547,6 +554,7 @@ DEPENDENCIES
   parallel
   pg
   poltergeist
+  postgres_ext
   quiet_assets
   rails (~> 4.2.9)
   ransack (~> 1.4.0)

--- a/app/admin/routing/customers_auth_normalized.rb
+++ b/app/admin/routing/customers_auth_normalized.rb
@@ -1,0 +1,12 @@
+ActiveAdmin.register CustomersAuthNormalized, as: 'Normalized Copies' do
+  belongs_to :customers_auth
+
+  navigation_menu :default
+  menu false
+
+  actions :index, :show
+
+  config.batch_actions = false
+  config.filters = false
+
+end

--- a/app/controllers/api/rest/system/ip_access_controller.rb
+++ b/app/controllers/api/rest/system/ip_access_controller.rb
@@ -7,6 +7,11 @@ class Api::Rest::System::IpAccessController < Api::RestController
   private
 
   def addresses
-    CustomersAuth.all.map{|a| "#{a.ip.to_s}/#{a.ip.cidr_mask}"}.uniq
+    CustomersAuthNormalized
+      .pluck(:ip)
+      .uniq
+      .map { |ip| IPAddr.new(ip) }
+      .map { |ip| "#{ip.to_s}/#{ip.cidr_mask}" }
+      .uniq
   end
 end

--- a/app/decorators/customers_auth_decorator.rb
+++ b/app/decorators/customers_auth_decorator.rb
@@ -18,4 +18,13 @@ class CustomersAuthDecorator < BillingDecorator
     end
   end
 
+  CustomersAuth::CONST::MATCH_CONDITION_ATTRIBUTES.each do |attribute_name|
+    define_method attribute_name do
+      model.public_send(attribute_name).map(&:strip).join(', ')
+    end
+  end
+
+  # TODO: when AA fixe probjec with decorated objec on create use this:
+  # https://github.com/activeadmin/activeadmin/blob/15eb4a05b2ee759b7d03ceaaa92d070986a1c282/spec/support/templates/post_decorator.rb
+
 end

--- a/app/models/customers_auth.rb
+++ b/app/models/customers_auth.rb
@@ -6,21 +6,16 @@
 #  customer_id                      :integer          not null
 #  rateplan_id                      :integer          not null
 #  enabled                          :boolean          default("true"), not null
-#  ip                               :inet
 #  account_id                       :integer
 #  gateway_id                       :integer          not null
 #  src_rewrite_rule                 :string
 #  src_rewrite_result               :string
 #  dst_rewrite_rule                 :string
 #  dst_rewrite_result               :string
-#  src_prefix                       :string           default(""), not null
-#  dst_prefix                       :string           default(""), not null
-#  x_yeti_auth                      :string
 #  name                             :string           not null
 #  dump_level_id                    :integer          default("0"), not null
 #  capacity                         :integer
 #  pop_id                           :integer
-#  uri_domain                       :string
 #  src_name_rewrite_rule            :string
 #  src_name_rewrite_result          :string
 #  diversion_policy_id              :integer          default("1"), not null
@@ -38,8 +33,6 @@
 #  dst_number_radius_rewrite_rule   :string
 #  dst_number_radius_rewrite_result :string
 #  radius_accounting_profile_id     :integer
-#  from_domain                      :string
-#  to_domain                        :string
 #  transport_protocol_id            :integer
 #  dst_number_min_length            :integer          default("0"), not null
 #  dst_number_max_length            :integer          default("100"), not null
@@ -47,10 +40,29 @@
 #  require_incoming_auth            :boolean          default("false"), not null
 #  tag_action_id                    :integer
 #  tag_action_value                 :integer          default("{}"), not null, is an Array
+#  ip                               :inet             default("{}"), is an Array
+#  src_prefix                       :string           default("{\"\"}"), is an Array
+#  dst_prefix                       :string           default("{\"\"}"), is an Array
+#  uri_domain                       :string           default("{}"), is an Array
+#  from_domain                      :string           default("{}"), is an Array
+#  to_domain                        :string           default("{}"), is an Array
+#  x_yeti_auth                      :string           default("{}"), is an Array
 #
 
 class CustomersAuth < Yeti::ActiveRecord
   self.table_name = 'class4.customers_auth'
+
+  module CONST
+    MATCH_CONDITION_ATTRIBUTES = [:ip,
+                                  :src_prefix,
+                                  :dst_prefix,
+                                  :uri_domain,
+                                  :from_domain,
+                                  :to_domain,
+                                  :x_yeti_auth].freeze
+
+    freeze
+  end
 
   belongs_to :customer, -> { where customer: true }, class_name: 'Contractor', foreign_key: :customer_id
 
@@ -70,6 +82,7 @@ class CustomersAuth < Yeti::ActiveRecord
   belongs_to :tag_action, class_name: 'Routing::TagAction'
 
   has_many :destinations, through: :rateplan
+  has_many :normalized_copies, class_name: 'CustomersAuthNormalized', foreign_key: :customers_auth_id, dependent: :delete_all
 
   has_paper_trail class_name: 'AuditLogItem'
 
@@ -78,8 +91,13 @@ class CustomersAuth < Yeti::ActiveRecord
   #     302
   # ]
 
-  validates_format_of :src_prefix, without: /\s/
-  validates_format_of :dst_prefix, without: /\s/
+  validates :ip, :src_prefix, :dst_prefix, :uri_domain, :from_domain, :to_domain, :x_yeti_auth,
+            array_format: { without: /\s/, message: 'spaces are not allowed' }
+
+  validates :ip, :src_prefix, :dst_prefix, :uri_domain, :from_domain, :to_domain, :x_yeti_auth,
+            array_uniqueness: true
+
+
   validates_uniqueness_of :name, allow_blank: :false
   validates_presence_of :name
   validates_uniqueness_of :external_id, allow_blank: true
@@ -106,15 +124,26 @@ class CustomersAuth < Yeti::ActiveRecord
   has_pg_queue 'gateway-sync'
 
 
-  scope :ip_covers, lambda { |ip| where("ip>>=?", ip) }
+  after_create :create_shadow_copy
+  after_update :update_shadow_copy
 
   def display_name
     "#{self.name} | #{self.id}"
   end
 
-  def raw_ip
-    read_attribute_before_type_cast('ip')
+  # TODO: move to decorator when ActiveAdmin fix problem
+  # Problem is:
+  # on "update" AA uses decorated object
+  # on "create" AA do NOT use decorated object
+  CONST::MATCH_CONDITION_ATTRIBUTES.each do |attribute_name|
+    define_method "#{attribute_name}=" do |value|
+      if value.is_a? String
+        value = value.split(',').map(&:strip).reject(&:blank?)
+      end
+      super(value)
+    end
   end
+
 
   def display_name_for_debug
     b="#{self.customer.display_name} -> #{self.name} | #{self.id} IP: #{self.raw_ip}"
@@ -154,16 +183,12 @@ class CustomersAuth < Yeti::ActiveRecord
 
   private
 
-  def self.ransackable_scopes(auth_object = nil)
-    [
-        :ip_covers
-    ]
-  end
-
   protected
   def ip_is_valid
     begin
-      _tmp=IPAddr.new(raw_ip)
+      ip.each do |raw_ip|
+        _tmp = IPAddr.new(raw_ip)
+      end if ip.is_a? Array
     rescue IPAddr::Error => error
       self.errors.add(:ip, "is not valid")
     end
@@ -174,6 +199,45 @@ class CustomersAuth < Yeti::ActiveRecord
       self.errors.add(:gateway, I18n.t('activerecord.errors.models.customer_auth.attributes.gateway.incoming_auth_required'))
       self.errors.add(:require_incoming_auth, I18n.t('activerecord.errors.models.customer_auth.attributes.require_incoming_auth.gateway_with_auth_reqired'))
     end
+  end
+
+  def create_shadow_copy
+    copy_attributes = { customers_auth_id: id }
+
+    # all other attributes
+    CustomersAuthNormalized.shadow_column_names.each do |key|
+      copy_attributes[key] = self.public_send(key)
+    end
+
+    if match_conditions_values.empty?
+      CustomersAuthNormalized.create!(copy_attributes)
+    end
+
+    match_conditions_values.each do |match_conditions_pair|
+      # match_conditions attirbutes
+      match_conditions_pair.each do |pair|
+        key, value = pair.flatten
+        copy_attributes[key] = value
+      end
+      CustomersAuthNormalized.create!(copy_attributes)
+    end
+  end
+
+  def update_shadow_copy
+    # keep it simple: delete all and create again
+    normalized_copies.delete_all
+    create_shadow_copy
+  end
+
+  def match_conditions_values
+    @_mcv = begin
+              ar_values = CONST::MATCH_CONDITION_ATTRIBUTES.map do |mc_name|
+                self.public_send(mc_name).map { |v| { mc_name => v } }
+              end.reject(&:empty?)
+              return [] if ar_values.empty?
+              first_arr = ar_values.shift
+              first_arr.product(*ar_values)
+            end
   end
 end
 

--- a/app/models/customers_auth_normalized.rb
+++ b/app/models/customers_auth_normalized.rb
@@ -1,0 +1,72 @@
+# == Schema Information
+#
+# Table name: class4.customers_auth_normalized
+#
+#  id                               :integer          not null, primary key
+#  customers_auth_id                :integer          not null
+#  customer_id                      :integer          not null
+#  rateplan_id                      :integer          not null
+#  enabled                          :boolean          default("true"), not null
+#  ip                               :inet
+#  account_id                       :integer
+#  gateway_id                       :integer          not null
+#  src_rewrite_rule                 :string
+#  src_rewrite_result               :string
+#  dst_rewrite_rule                 :string
+#  dst_rewrite_result               :string
+#  src_prefix                       :string           default(""), not null
+#  dst_prefix                       :string           default(""), not null
+#  x_yeti_auth                      :string
+#  name                             :string           not null
+#  dump_level_id                    :integer          default("0"), not null
+#  capacity                         :integer
+#  pop_id                           :integer
+#  uri_domain                       :string
+#  src_name_rewrite_rule            :string
+#  src_name_rewrite_result          :string
+#  diversion_policy_id              :integer          default("1"), not null
+#  diversion_rewrite_rule           :string
+#  diversion_rewrite_result         :string
+#  dst_numberlist_id                :integer
+#  src_numberlist_id                :integer
+#  routing_plan_id                  :integer          not null
+#  allow_receive_rate_limit         :boolean          default("false"), not null
+#  send_billing_information         :boolean          default("false"), not null
+#  radius_auth_profile_id           :integer
+#  enable_audio_recording           :boolean          default("false"), not null
+#  src_number_radius_rewrite_rule   :string
+#  src_number_radius_rewrite_result :string
+#  dst_number_radius_rewrite_rule   :string
+#  dst_number_radius_rewrite_result :string
+#  radius_accounting_profile_id     :integer
+#  from_domain                      :string
+#  to_domain                        :string
+#  transport_protocol_id            :integer
+#  dst_number_min_length            :integer          default("0"), not null
+#  dst_number_max_length            :integer          default("100"), not null
+#  check_account_balance            :boolean          default("true"), not null
+#  require_incoming_auth            :boolean          default("false"), not null
+#  tag_action_id                    :integer
+#  tag_action_value                 :integer          default("{}"), not null, is an Array
+#
+
+class CustomersAuthNormalized < Yeti::ActiveRecord
+  self.table_name = 'class4.customers_auth_normalized'
+
+  belongs_to :customers_auth
+
+  # attributes which are copyed "as is" without convertation
+  def self.shadow_column_names
+    skip_columns = [:id, :customers_auth_id] +
+                    CustomersAuth::CONST::MATCH_CONDITION_ATTRIBUTES
+    column_names.map(&:to_sym) - skip_columns
+  end
+
+  # TODO: move all logic here
+  def self.create_copies_from_original(customers_auth)
+    # Transacton do
+    #   each...
+    # end
+  end
+
+end

--- a/app/models/system/api_access.rb
+++ b/app/models/system/api_access.rb
@@ -2,12 +2,12 @@
 #
 # Table name: sys.api_access
 #
-#  id          :integer          not null, primary key
-#  customer_id :integer          not null
-#  login       :string           not null
-#  password    :string           not null
-#  account_ids :integer          is an Array
-#  allowed_ips :inet             default("{0.0.0.0/0}"), is an Array
+#  id              :integer          not null, primary key
+#  customer_id     :integer          not null
+#  login           :string           not null
+#  password_digest :string           not null
+#  account_ids     :integer          default("{}"), not null, is an Array
+#  allowed_ips     :inet             default("{0.0.0.0/0}"), not null, is an Array
 #
 
 class System::ApiAccess < ActiveRecord::Base
@@ -39,7 +39,7 @@ class System::ApiAccess < ActiveRecord::Base
   end
 
   def formtastic_allowed_ips
-    read_attribute_before_type_cast('allowed_ips')[1..-2]
+    allowed_ips.map(&:strip).join(', ')
   end
 
   def accounts

--- a/app/validators/array_format_validator.rb
+++ b/app/validators/array_format_validator.rb
@@ -1,0 +1,21 @@
+class ArrayFormatValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, values)
+    values.each do |value|
+      if options[:with]
+        if value.to_s !~ options[:with]
+          record_error(record, attribute, :without, value)
+        end
+      elsif options[:without]
+        if value.to_s =~ options[:without]
+          record_error(record, attribute, :without, value)
+        end
+      end
+    end
+  end
+
+  private
+
+  def record_error(record, attribute, name, value)
+    record.errors.add(attribute, :invalid, options.except(name).merge!(value: value))
+  end
+end

--- a/app/validators/array_uniqueness_validator.rb
+++ b/app/validators/array_uniqueness_validator.rb
@@ -1,0 +1,13 @@
+class ArrayUniquenessValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, values)
+    if values.dup.uniq!.present?
+      record_error(record, attribute)
+    end
+  end
+
+  private
+
+  def record_error(record, attribute)
+    record.errors.add(attribute, "can't contain duplicated values")
+  end
+end

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,0 +1,11 @@
+# https://github.com/activerecord-hackery/ransack/issues/321
+Ransack.configure do |config|
+  { array_contained_within:           :contained_within,
+    array_contained_within_or_equals: :contained_within_or_equals,
+    array_contains:                   :contains,
+    array_contains_or_equals:         :contains_or_equals,
+    array_overlap:                    :overlap
+  }.each do |rp, ap|
+    config.add_predicate rp, arel_predicate: ap, wants_array: true
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,8 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
+  hint_array_of_strings:
+    "array of strings, devided by comma(,)"
   date:
     formats:
       long: "%Y-%m-%d"
@@ -34,6 +36,7 @@ en:
         hep_capture_id: "Leave it empty to use YETI Node ID as HEP_CAPTURE_ID"
       customers_auth:
         check_account_balance: "Reject calls if originator hasn't enough funds"
+        ip: 'array of IP, devided by comma(,)'
       destinaion:
         reverse_billing: "If enabled, customer account balance is raised"
       dialpeers:
@@ -41,8 +44,16 @@ en:
       equipment_registration:
         contact: "Must be in URI format (sip:user@domain or sip:domain)"
 
-
   activerecord:
+    attributes:
+      customers_auth:
+        ip: 'IP'
+        src_prefix: 'SRC Prefix'
+        dst_prefix: 'DST Prefix'
+        uri_domain: 'URI Domain'
+        from_domain: 'From Domain'
+        to_domain: 'To Domain'
+        x_yeti_auth: 'X-Yeti-Auth'
     errors:
       models:
         gateway:
@@ -62,7 +73,7 @@ en:
               cant_be_cleared: "Can't be cleared when gateway used at Customer auth with require_incoming_auth"
             incoming_auth_password:
               cant_be_cleared: "Can't be cleared when gateway used at Customer auth with require_incoming_auth"
-        customer_auth:
+        customers_auth:
           attributes:
             gateway:
               incoming_auth_required: "Should support SIP incoming auth"

--- a/db/migrate/20180212105355_multiple_matching_conditions.rb
+++ b/db/migrate/20180212105355_multiple_matching_conditions.rb
@@ -1,0 +1,194 @@
+class MultipleMatchingConditions < ActiveRecord::Migration
+  def up
+    execute %q{
+
+      CREATE TABLE class4.customers_auth_normalized (
+          id serial PRIMARY KEY,
+          customers_auth_id integer NOT NULL REFERENCES class4.customers_auth(id),
+          customer_id integer NOT NULL,
+          rateplan_id integer NOT NULL,
+          enabled boolean DEFAULT true NOT NULL,
+          ip inet,
+          account_id integer,
+          gateway_id integer NOT NULL,
+          src_rewrite_rule character varying,
+          src_rewrite_result character varying,
+          dst_rewrite_rule character varying,
+          dst_rewrite_result character varying,
+          src_prefix character varying DEFAULT ''::character varying NOT NULL,
+          dst_prefix character varying DEFAULT ''::character varying NOT NULL,
+          x_yeti_auth character varying,
+          name character varying NOT NULL,
+          dump_level_id integer DEFAULT 0 NOT NULL,
+          capacity smallint,
+          pop_id integer,
+          uri_domain character varying,
+          src_name_rewrite_rule character varying,
+          src_name_rewrite_result character varying,
+          diversion_policy_id integer DEFAULT 1 NOT NULL,
+          diversion_rewrite_rule character varying,
+          diversion_rewrite_result character varying,
+          dst_numberlist_id smallint,
+          src_numberlist_id smallint,
+          routing_plan_id integer NOT NULL,
+          allow_receive_rate_limit boolean DEFAULT false NOT NULL,
+          send_billing_information boolean DEFAULT false NOT NULL,
+          radius_auth_profile_id smallint,
+          enable_audio_recording boolean DEFAULT false NOT NULL,
+          src_number_radius_rewrite_rule character varying,
+          src_number_radius_rewrite_result character varying,
+          dst_number_radius_rewrite_rule character varying,
+          dst_number_radius_rewrite_result character varying,
+          radius_accounting_profile_id smallint,
+          from_domain character varying,
+          to_domain character varying,
+          transport_protocol_id smallint,
+          dst_number_min_length smallint DEFAULT 0 NOT NULL,
+          dst_number_max_length smallint DEFAULT 100 NOT NULL,
+          check_account_balance boolean DEFAULT true NOT NULL,
+          require_incoming_auth boolean DEFAULT false NOT NULL,
+          tag_action_id smallint,
+          tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
+          CONSTRAINT customers_auth_max_dst_number_length CHECK ((dst_number_min_length >= 0)),
+          CONSTRAINT customers_auth_min_dst_number_length CHECK ((dst_number_min_length >= 0))
+      );
+
+      CREATE INDEX customers_auth_normalized_prefix_range_prefix_range1_idx ON customers_auth_normalized USING gist (((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range)) WHERE enabled;
+      CREATE INDEX customers_auth_normalized_ip_prefix_range_prefix_range1_idx ON customers_auth_normalized USING gist (ip, ((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range));
+
+      -- new columns
+      ALTER TABLE class4.customers_auth ADD ips inet[] DEFAULT '{}';
+      ALTER TABLE class4.customers_auth ADD src_prefixes varchar[] DEFAULT '{""}';
+      ALTER TABLE class4.customers_auth ADD dst_prefixes varchar[] DEFAULT '{""}';
+      ALTER TABLE class4.customers_auth ADD uri_domains varchar[] DEFAULT '{}';
+      ALTER TABLE class4.customers_auth ADD from_domains varchar[] DEFAULT '{}';
+      ALTER TABLE class4.customers_auth ADD to_domains varchar[] DEFAULT '{}';
+      ALTER TABLE class4.customers_auth ADD x_yeti_auths varchar[] DEFAULT '{}';
+
+      -- populate data
+      UPDATE class4.customers_auth SET ips = array_append('{}', ip) WHERE ip IS NOT NULL;
+      UPDATE class4.customers_auth SET src_prefixes = array_append('{}', src_prefix) WHERE src_prefix != '';
+      UPDATE class4.customers_auth SET dst_prefixes = array_append('{}', dst_prefix) WHERE dst_prefix != '';
+      UPDATE class4.customers_auth SET uri_domains = array_append('{}', uri_domain) WHERE uri_domain IS NOT NULL;
+      UPDATE class4.customers_auth SET from_domains = array_append('{}', from_domain) WHERE from_domain IS NOT NULL;
+      UPDATE class4.customers_auth SET to_domains = array_append('{}', to_domain) WHERE to_domain IS NOT NULL;
+      UPDATE class4.customers_auth SET x_yeti_auths = array_append('{}', x_yeti_auth) WHERE x_yeti_auth IS NOT NULL;
+
+      -- populate shadow-copy table
+      INSERT INTO class4.customers_auth_normalized (
+        customers_auth_id,
+        customer_id,
+        rateplan_id,
+        enabled,
+        ip,
+        account_id,
+        gateway_id,
+        src_rewrite_rule,
+        src_rewrite_result,
+        dst_rewrite_rule,
+        dst_rewrite_result,
+        src_prefix,
+        dst_prefix,
+        x_yeti_auth,
+        name,
+        dump_level_id,
+        capacity,
+        pop_id,
+        uri_domain,
+        src_name_rewrite_rule,
+        src_name_rewrite_result,
+        diversion_policy_id,
+        diversion_rewrite_rule,
+        diversion_rewrite_result,
+        dst_numberlist_id,
+        src_numberlist_id,
+        routing_plan_id,
+        allow_receive_rate_limit,
+        send_billing_information,
+        radius_auth_profile_id,
+        enable_audio_recording,
+        src_number_radius_rewrite_rule,
+        src_number_radius_rewrite_result,
+        dst_number_radius_rewrite_rule,
+        dst_number_radius_rewrite_result,
+        radius_accounting_profile_id,
+        from_domain,
+        to_domain,
+        transport_protocol_id,
+        dst_number_min_length,
+        dst_number_max_length,
+        check_account_balance,
+        require_incoming_auth,
+        tag_action_id,
+        tag_action_value
+      )
+      SELECT
+        id AS customers_auth_id,
+        customer_id,
+        rateplan_id,
+        enabled,
+        ip,
+        account_id,
+        gateway_id,
+        src_rewrite_rule,
+        src_rewrite_result,
+        dst_rewrite_rule,
+        dst_rewrite_result,
+        src_prefix,
+        dst_prefix,
+        x_yeti_auth,
+        name,
+        dump_level_id,
+        capacity,
+        pop_id,
+        uri_domain,
+        src_name_rewrite_rule,
+        src_name_rewrite_result,
+        diversion_policy_id,
+        diversion_rewrite_rule,
+        diversion_rewrite_result,
+        dst_numberlist_id,
+        src_numberlist_id,
+        routing_plan_id,
+        allow_receive_rate_limit,
+        send_billing_information,
+        radius_auth_profile_id,
+        enable_audio_recording,
+        src_number_radius_rewrite_rule,
+        src_number_radius_rewrite_result,
+        dst_number_radius_rewrite_rule,
+        dst_number_radius_rewrite_result,
+        radius_accounting_profile_id,
+        from_domain,
+        to_domain,
+        transport_protocol_id,
+        dst_number_min_length,
+        dst_number_max_length,
+        check_account_balance,
+        require_incoming_auth,
+        tag_action_id,
+        tag_action_value
+      FROM class4.customers_auth;
+    }
+  end
+
+  def down
+    execute %q{
+      -- shadow copy of customers_auth
+      DROP TABLE class4.customers_auth_normalized;
+
+      -- new columns
+      ALTER TABLE class4.customers_auth DROP ips;
+      ALTER TABLE class4.customers_auth DROP src_prefixes;
+      ALTER TABLE class4.customers_auth DROP dst_prefixes;
+      ALTER TABLE class4.customers_auth DROP uri_domains;
+      ALTER TABLE class4.customers_auth DROP from_domains;
+      ALTER TABLE class4.customers_auth DROP to_domains;
+      ALTER TABLE class4.customers_auth DROP x_yeti_auths;
+    }
+  end
+
+  def stop_step
+    true
+  end
+end

--- a/db/migrate/20180215094913_customers_auth_rename_match_conditions_columns.rb
+++ b/db/migrate/20180215094913_customers_auth_rename_match_conditions_columns.rb
@@ -1,0 +1,54 @@
+class CustomersAuthRenameMatchConditionsColumns < ActiveRecord::Migration
+  def up
+    execute %q{
+      -- deprecated columns
+      ALTER TABLE class4.customers_auth DROP ip;
+      ALTER TABLE class4.customers_auth DROP src_prefix;
+      ALTER TABLE class4.customers_auth DROP dst_prefix;
+      ALTER TABLE class4.customers_auth DROP uri_domain;
+      ALTER TABLE class4.customers_auth DROP from_domain;
+      ALTER TABLE class4.customers_auth DROP to_domain;
+      ALTER TABLE class4.customers_auth DROP x_yeti_auth;
+
+      -- rename '-s' columns
+      ALTER TABLE class4.customers_auth RENAME ips TO ip;
+      ALTER TABLE class4.customers_auth RENAME src_prefixes TO src_prefix;
+      ALTER TABLE class4.customers_auth RENAME dst_prefixes TO dst_prefix;
+      ALTER TABLE class4.customers_auth RENAME uri_domains TO uri_domain;
+      ALTER TABLE class4.customers_auth RENAME from_domains TO from_domain;
+      ALTER TABLE class4.customers_auth RENAME to_domains TO to_domain;
+      ALTER TABLE class4.customers_auth RENAME x_yeti_auths TO x_yeti_auth;
+
+    }
+  end
+
+  def down
+    execute %q{
+      -- rename '-s' columns
+      ALTER TABLE class4.customers_auth RENAME ip TO ips;
+      ALTER TABLE class4.customers_auth RENAME src_prefix TO src_prefixes;
+      ALTER TABLE class4.customers_auth RENAME dst_prefix TO dst_prefixes;
+      ALTER TABLE class4.customers_auth RENAME uri_domain TO uri_domains;
+      ALTER TABLE class4.customers_auth RENAME from_domain TO from_domains;
+      ALTER TABLE class4.customers_auth RENAME to_domain TO to_domains;
+      ALTER TABLE class4.customers_auth RENAME x_yeti_auth TO x_yeti_auths;
+
+      -- deprecated columns
+      ALTER TABLE class4.customers_auth ADD ip inet;
+      ALTER TABLE class4.customers_auth ADD src_prefix character varying NOT NULL DEFAULT '';
+      ALTER TABLE class4.customers_auth ADD dst_prefix character varying NOT NULL DEFAULT '';
+      ALTER TABLE class4.customers_auth ADD uri_domain character varying;
+      ALTER TABLE class4.customers_auth ADD from_domain character varying;
+      ALTER TABLE class4.customers_auth ADD to_domain character varying;
+      ALTER TABLE class4.customers_auth ADD x_yeti_auth character varying;
+
+      UPDATE class4.customers_auth SET ip = ips[1];
+      UPDATE class4.customers_auth SET src_prefix = src_prefixes[1] WHERE src_prefixes[1] != '';
+      UPDATE class4.customers_auth SET dst_prefix = dst_prefixes[1] WHERE dst_prefixes[1] != '';
+      UPDATE class4.customers_auth SET uri_domain = uri_domains[1];
+      UPDATE class4.customers_auth SET from_domain = from_domains[1];
+      UPDATE class4.customers_auth SET to_domain = to_domains[1];
+      UPDATE class4.customers_auth SET x_yeti_auth = x_yeti_auths[1];
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -14191,6 +14191,82 @@ CREATE TABLE customers_auth (
     customer_id integer NOT NULL,
     rateplan_id integer NOT NULL,
     enabled boolean DEFAULT true NOT NULL,
+    account_id integer,
+    gateway_id integer NOT NULL,
+    src_rewrite_rule character varying,
+    src_rewrite_result character varying,
+    dst_rewrite_rule character varying,
+    dst_rewrite_result character varying,
+    name character varying NOT NULL,
+    dump_level_id integer DEFAULT 0 NOT NULL,
+    capacity smallint,
+    pop_id integer,
+    src_name_rewrite_rule character varying,
+    src_name_rewrite_result character varying,
+    diversion_policy_id integer DEFAULT 1 NOT NULL,
+    diversion_rewrite_rule character varying,
+    diversion_rewrite_result character varying,
+    dst_numberlist_id smallint,
+    src_numberlist_id smallint,
+    routing_plan_id integer NOT NULL,
+    allow_receive_rate_limit boolean DEFAULT false NOT NULL,
+    send_billing_information boolean DEFAULT false NOT NULL,
+    radius_auth_profile_id smallint,
+    enable_audio_recording boolean DEFAULT false NOT NULL,
+    src_number_radius_rewrite_rule character varying,
+    src_number_radius_rewrite_result character varying,
+    dst_number_radius_rewrite_rule character varying,
+    dst_number_radius_rewrite_result character varying,
+    radius_accounting_profile_id smallint,
+    transport_protocol_id smallint,
+    dst_number_min_length smallint DEFAULT 0 NOT NULL,
+    dst_number_max_length smallint DEFAULT 100 NOT NULL,
+    check_account_balance boolean DEFAULT true NOT NULL,
+    require_incoming_auth boolean DEFAULT false NOT NULL,
+    tag_action_id smallint,
+    tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
+    ip inet[] DEFAULT '{}'::inet[],
+    src_prefix character varying[] DEFAULT '{""}'::character varying[],
+    dst_prefix character varying[] DEFAULT '{""}'::character varying[],
+    uri_domain character varying[] DEFAULT '{}'::character varying[],
+    from_domain character varying[] DEFAULT '{}'::character varying[],
+    to_domain character varying[] DEFAULT '{}'::character varying[],
+    x_yeti_auth character varying[] DEFAULT '{}'::character varying[],
+    external_id bigint,
+    CONSTRAINT customers_auth_max_dst_number_length CHECK ((dst_number_min_length >= 0)),
+    CONSTRAINT customers_auth_min_dst_number_length CHECK ((dst_number_min_length >= 0))
+);
+
+
+--
+-- Name: customers_auth_id_seq; Type: SEQUENCE; Schema: class4; Owner: -
+--
+
+CREATE SEQUENCE customers_auth_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: customers_auth_id_seq; Type: SEQUENCE OWNED BY; Schema: class4; Owner: -
+--
+
+ALTER SEQUENCE customers_auth_id_seq OWNED BY customers_auth.id;
+
+
+--
+-- Name: customers_auth_normalized; Type: TABLE; Schema: class4; Owner: -; Tablespace: 
+--
+
+CREATE TABLE customers_auth_normalized (
+    id integer NOT NULL,
+    customers_auth_id integer NOT NULL,
+    customer_id integer NOT NULL,
+    rateplan_id integer NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
     ip inet,
     account_id integer,
     gateway_id integer NOT NULL,
@@ -14232,17 +14308,16 @@ CREATE TABLE customers_auth (
     require_incoming_auth boolean DEFAULT false NOT NULL,
     tag_action_id smallint,
     tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
-    external_id bigint,
     CONSTRAINT customers_auth_max_dst_number_length CHECK ((dst_number_min_length >= 0)),
     CONSTRAINT customers_auth_min_dst_number_length CHECK ((dst_number_min_length >= 0))
 );
 
 
 --
--- Name: customers_auth_id_seq; Type: SEQUENCE; Schema: class4; Owner: -
+-- Name: customers_auth_normalized_id_seq; Type: SEQUENCE; Schema: class4; Owner: -
 --
 
-CREATE SEQUENCE customers_auth_id_seq
+CREATE SEQUENCE customers_auth_normalized_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -14251,10 +14326,10 @@ CREATE SEQUENCE customers_auth_id_seq
 
 
 --
--- Name: customers_auth_id_seq; Type: SEQUENCE OWNED BY; Schema: class4; Owner: -
+-- Name: customers_auth_normalized_id_seq; Type: SEQUENCE OWNED BY; Schema: class4; Owner: -
 --
 
-ALTER SEQUENCE customers_auth_id_seq OWNED BY customers_auth.id;
+ALTER SEQUENCE customers_auth_normalized_id_seq OWNED BY customers_auth_normalized.id;
 
 
 --
@@ -17584,6 +17659,13 @@ ALTER TABLE ONLY customers_auth ALTER COLUMN id SET DEFAULT nextval('customers_a
 -- Name: id; Type: DEFAULT; Schema: class4; Owner: -
 --
 
+ALTER TABLE ONLY customers_auth_normalized ALTER COLUMN id SET DEFAULT nextval('customers_auth_normalized_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: class4; Owner: -
+--
+
 ALTER TABLE ONLY destinations ALTER COLUMN id SET DEFAULT nextval('destinations_id_seq'::regclass);
 
 
@@ -18389,6 +18471,14 @@ ALTER TABLE ONLY codecs
 
 ALTER TABLE ONLY customers_auth
     ADD CONSTRAINT customers_auth_name_key UNIQUE (name);
+
+
+--
+-- Name: customers_auth_normalized_pkey; Type: CONSTRAINT; Schema: class4; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY customers_auth_normalized
+    ADD CONSTRAINT customers_auth_normalized_pkey PRIMARY KEY (id);
 
 
 --
@@ -19746,17 +19836,17 @@ CREATE UNIQUE INDEX customers_auth_external_id_idx ON customers_auth USING btree
 
 
 --
--- Name: customers_auth_ip_prefix_range_prefix_range1_idx; Type: INDEX; Schema: class4; Owner: -; Tablespace: 
+-- Name: customers_auth_normalized_ip_prefix_range_prefix_range1_idx; Type: INDEX; Schema: class4; Owner: -; Tablespace: 
 --
 
-CREATE INDEX customers_auth_ip_prefix_range_prefix_range1_idx ON customers_auth USING gist (ip, ((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range));
+CREATE INDEX customers_auth_normalized_ip_prefix_range_prefix_range1_idx ON customers_auth_normalized USING gist (ip, ((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range));
 
 
 --
--- Name: customers_auth_prefix_range_prefix_range1_idx; Type: INDEX; Schema: class4; Owner: -; Tablespace: 
+-- Name: customers_auth_normalized_prefix_range_prefix_range1_idx; Type: INDEX; Schema: class4; Owner: -; Tablespace: 
 --
 
-CREATE INDEX customers_auth_prefix_range_prefix_range1_idx ON customers_auth USING gist (((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range)) WHERE enabled;
+CREATE INDEX customers_auth_normalized_prefix_range_prefix_range1_idx ON customers_auth_normalized USING gist (((dst_prefix)::public.prefix_range), ((src_prefix)::public.prefix_range)) WHERE enabled;
 
 
 --
@@ -20072,6 +20162,14 @@ ALTER TABLE ONLY customers_auth
 
 ALTER TABLE ONLY customers_auth
     ADD CONSTRAINT customers_auth_gateway_id_fkey FOREIGN KEY (gateway_id) REFERENCES gateways(id);
+
+
+--
+-- Name: customers_auth_normalized_customers_auth_id_fkey; Type: FK CONSTRAINT; Schema: class4; Owner: -
+--
+
+ALTER TABLE ONLY customers_auth_normalized
+    ADD CONSTRAINT customers_auth_normalized_customers_auth_id_fkey FOREIGN KEY (customers_auth_id) REFERENCES customers_auth(id);
 
 
 --
@@ -20764,6 +20862,10 @@ INSERT INTO public.schema_migrations (version) VALUES ('20180101202120');
 INSERT INTO public.schema_migrations (version) VALUES ('20180119133842');
 
 INSERT INTO public.schema_migrations (version) VALUES ('20180209140554');
+
+INSERT INTO public.schema_migrations (version) VALUES ('20180212105355');
+
+INSERT INTO public.schema_migrations (version) VALUES ('20180215094913');
 
 INSERT INTO public.schema_migrations (version) VALUES ('20180215113538');
 

--- a/lib/active_admin/inputs/array_of_strings_input.rb
+++ b/lib/active_admin/inputs/array_of_strings_input.rb
@@ -1,0 +1,31 @@
+module ActiveAdmin
+  module Inputs
+    class ArrayOfStringsInput < Formtastic::Inputs::StringInput
+
+      def input_html_options
+          super.merge(extra_input_html_options)
+      end
+
+      def extra_input_html_options
+        {
+          value: value
+        }
+      end
+
+      # ActiveAdmin has bug: Edit form do not uses Decorated object
+      # in this case we need to duplicate array-join here
+      # on update(render form) activeadmin uses Decorated object, and this is redundant here
+      def value
+        return options[:input_html][:value] if options[:input_html] && options[:input_html].key?(:value)
+        val = object.public_send(method)
+        return val.join(', ') if val.is_a?(Array)
+        val
+      end
+
+      def hint_text
+        super || I18n.t(:hint_array_of_strings)
+      end
+
+    end
+  end
+end

--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -1,0 +1,18 @@
+module ActiveAdmin
+  module ViewHelpers
+    module DisplayHelper
+
+      alias_method :original_pretty_format, :pretty_format
+
+      def pretty_format(object)
+        # Array of Strings
+        if object.is_a?(Array) && object.all? { |el| el.is_a?(String) }
+          return object.join(', ')
+        end
+
+        original_pretty_format(object)
+      end
+
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/postgresql/oid/inet.rb
+++ b/lib/active_record/connection_adapters/postgresql/oid/inet.rb
@@ -1,0 +1,13 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID # :nodoc:
+        class Inet < Type::String # :nodoc:
+          def type
+            :inet
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/customers_auth.rb
+++ b/spec/factories/customers_auth.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :customers_auth, class: CustomersAuth do
     sequence(:name) { |n| "customers_auth_#{n}"}
-    ip '0.0.0.0'
     diversion_policy_id 1
     dump_level_id 1
 
@@ -11,16 +10,12 @@ FactoryGirl.define do
     association :gateway
     association :account
 
-
+    ip { ['0.0.0.0'] }
     src_rewrite_rule nil
     src_rewrite_result nil
     dst_rewrite_rule nil
     dst_rewrite_result nil
-    src_prefix ''
-    dst_prefix ''
-    x_yeti_auth nil
     pop_id nil
-    uri_domain nil
     src_name_rewrite_rule nil
     src_name_rewrite_result nil
     diversion_rewrite_rule nil

--- a/spec/models/customers_auth_normalized_spec.rb
+++ b/spec/models/customers_auth_normalized_spec.rb
@@ -1,0 +1,328 @@
+require 'spec_helper'
+
+RSpec.describe CustomersAuthNormalized, type: :model do
+
+  shared_examples :test_normalized_copy_count do |copy_count|
+    it 'creates only one CustomersAuth' do
+      expect { subject }.to change { CustomersAuth.count }.by(1)
+    end
+
+    it 'create denormalized copies' do
+      expect { subject }.to change { described_class.count }.by(copy_count)
+    end
+
+    it 'create denormalized copies linked to original' do
+      subject
+      copies = described_class.where(customers_auth_id: CustomersAuth.take.id)
+      expect(copies.count).to eq(copy_count)
+    end
+  end
+
+
+  describe '#create' do
+
+    subject { create(:customers_auth, attributes) }
+
+    context 'when all attributes are ampty (default DB values)' do
+      let(:attributes) do
+        {
+          ip: [],
+          src_prefix: [],
+          dst_prefix: [],
+          uri_domain: [],
+          from_domain: [],
+          to_domain: [],
+          x_yeti_auth: []
+        }
+      end
+
+      include_examples :test_normalized_copy_count, 1
+
+      it 'create copy with empty match-conditions attributes' do
+        subject
+        expect(described_class.take).to have_attributes(
+          ip: nil,
+          src_prefix: '',
+          dst_prefix: '',
+          uri_domain: nil,
+          from_domain: nil,
+          to_domain: nil,
+          x_yeti_auth: nil
+        )
+      end
+    end
+
+    context 'when all attributes are filled in with single value' do
+      let(:attributes) do
+        {
+          ip: ['127.0.0.1'],
+          src_prefix: ['src-p-1'],
+          dst_prefix: ['dst-p-1'],
+          uri_domain: ['uri-1'],
+          from_domain: ['from-1'],
+          to_domain: ['to-1'],
+          x_yeti_auth: ['x-1']
+        }
+      end
+
+      include_examples :test_normalized_copy_count, 1
+
+      it 'creates denormalized copy with expected attributes' do
+        subject
+        expect(described_class.take).to have_attributes(
+          ip: IPAddr.new('127.0.0.1'),
+          src_prefix: 'src-p-1',
+          dst_prefix: 'dst-p-1',
+          uri_domain: 'uri-1',
+          from_domain: 'from-1',
+          to_domain: 'to-1',
+          x_yeti_auth: 'x-1'
+        )
+      end
+    end
+
+    context 'when only IPs is filled with several values' do
+      let(:attributes) do
+        {
+          ip: ['127.0.0.1', '192.168.0.1'],
+          src_prefix: [],
+          dst_prefix: [],
+          uri_domain: [],
+          from_domain: [],
+          to_domain: [],
+          x_yeti_auth: []
+        }
+      end
+
+      include_examples :test_normalized_copy_count, 2
+
+      it 'creates denormalized copies with expected IP' do
+        subject
+        expect(described_class.first).to have_attributes(ip: IPAddr.new('127.0.0.1'))
+        expect(described_class.second).to have_attributes(ip: IPAddr.new('192.168.0.1'))
+      end
+    end
+
+
+    context 'when only SRC_PREFIXES is filled with several values' do
+      let(:attributes) do
+        {
+          ip: [],
+          src_prefix: ['src-1', 'src-2'],
+          dst_prefix: [],
+          uri_domain: [],
+          from_domain: [],
+          to_domain: [],
+          x_yeti_auth: []
+        }
+      end
+
+      include_examples :test_normalized_copy_count, 2
+
+      it 'creates denormalized copies with expected SRC_PREFIX' do
+        subject
+        expect(described_class.first).to have_attributes(src_prefix: 'src-1')
+        expect(described_class.second).to have_attributes(src_prefix: 'src-2')
+      end
+    end
+
+    context 'when all attribtes are filled with several values' do
+      let(:attributes) do
+        {
+          ip: ['127.0.0.1', '192.168.0.1'],
+          src_prefix: ['src-1', 'src-2'],
+          dst_prefix: ['dst-1', 'dst-2'],
+          uri_domain: ['uri-1', 'uri-2'],
+          from_domain: ['from-1', 'from-2'],
+          to_domain: ['to-1', 'to-2'],
+          x_yeti_auth: ['x-1', 'x-2']
+        }
+      end
+
+      # https://en.wikipedia.org/wiki/Cartesian_product
+      # ips.count * src_prefixes.count * ... * x_yeti_auths.count
+      include_examples :test_normalized_copy_count, 128
+
+      it 'creates expected denormalized copy(test first and last)' do
+        subject
+        expect(described_class.first).to have_attributes(
+          ip: IPAddr.new('127.0.0.1'),
+          src_prefix: 'src-1',
+          dst_prefix: 'dst-1',
+          uri_domain: 'uri-1',
+          from_domain: 'from-1',
+          to_domain: 'to-1',
+          x_yeti_auth: 'x-1'
+        )
+        expect(described_class.last).to have_attributes(
+          ip: IPAddr.new('192.168.0.1'),
+          src_prefix: 'src-2',
+          dst_prefix: 'dst-2',
+          uri_domain: 'uri-2',
+          from_domain: 'from-2',
+          to_domain: 'to-2',
+          x_yeti_auth: 'x-2'
+        )
+      end
+    end
+
+    context 'when error happens with last denormalized copy' do
+      let(:attributes) do
+        {
+          ip: ['127.0.0.1'],
+          src_prefix: ['src-1', 'src-2'],
+          dst_prefix: ['dst-1'],
+          uri_domain: ['uri-1'],
+          from_domain: ['from-1'],
+          to_domain: ['to-1'],
+          x_yeti_auth: ['x-1']
+        }
+      end
+
+      before do
+        allow(CustomersAuthNormalized).to receive(:create!).with(a_hash_including(src_prefix: 'src-1')).and_call_original
+        allow(CustomersAuthNormalized).to receive(:create!).with(a_hash_including(src_prefix: 'src-2')).and_raise(ActiveRecord::StatementInvalid, 'null value in column "customers_auth_id" violates not-null constraint')
+      end
+
+      it 'rollback all' do
+        subject rescue nil
+        expect(described_class.count).to eq(0)
+        expect(CustomersAuth.count).to eq(0)
+      end
+    end
+
+    context 'when error happens with first and only denormalized copy' do
+      let(:attributes) do
+        {
+          ip: [],
+          src_prefix: [],
+          dst_prefix: [],
+          uri_domain: [],
+          from_domain: [],
+          to_domain: [],
+          x_yeti_auth: []
+        }
+      end
+
+      before do
+        allow(CustomersAuthNormalized).to receive(:create!).and_raise(ActiveRecord::StatementInvalid, 'null value in column "customers_auth_id" violates not-null constraint')
+      end
+
+      it 'rollback all' do
+        subject rescue nil
+        expect(described_class.count).to eq(0)
+        expect(CustomersAuth.count).to eq(0)
+      end
+    end
+  end
+
+
+  describe '#update' do
+    let!(:record) do
+      create(:customers_auth,
+             src_rewrite_rule: old_src_rewrite_rule,
+             ip: ['127.0.0.1', '192.168.0.1'],
+             src_prefix: ['src-1', 'src-2'],
+             dst_prefix: ['dst-1', 'dst-2'],
+             uri_domain: ['uri-1', 'uri-2'],
+             from_domain: ['from-1', 'from-2'],
+             to_domain: ['to-1', 'to-2'],
+             x_yeti_auth: ['x-1', 'x-2'])
+    end
+
+    let(:old_src_rewrite_rule) { 'old-value'  }
+
+    subject { record.update!(attributes) }
+
+    context 'when update a matching-condition attribute' do
+      let(:attributes) do
+        {
+          src_prefix: ['src-3', 'src-4']
+        }
+      end
+
+      it 'updates copies' do
+        # we have total 128 copies, 64 for each src_prefix entity
+        expect(described_class.where(src_prefix: 'src-1').count).to eq(64)
+        expect(described_class.where(src_prefix: 'src-2').count).to eq(64)
+        subject
+        # after update this records should not be
+        expect(described_class.where(src_prefix: 'src-1').count).to eq(0)
+        expect(described_class.where(src_prefix: 'src-2').count).to eq(0)
+        # instead we have this
+        expect(described_class.where(src_prefix: 'src-3').count).to eq(64)
+        expect(described_class.where(src_prefix: 'src-4').count).to eq(64)
+        expect(described_class.count).to eq(128)
+      end
+    end
+
+    context 'when update not a matching-conditions attribute' do
+      let(:attributes) do
+        {
+          src_rewrite_rule: 'new-src-rewrite-rule'
+        }
+      end
+
+      it 'each new copy has this attribute' do
+        subject
+        expect(described_class.where(src_rewrite_rule: attributes[:src_rewrite_rule]).count).to eq(128)
+        expect(described_class.count).to eq(128)
+      end
+    end
+
+    context 'when error happens on update' do
+      let(:attributes) do
+        {
+          src_rewrite_rule: 'new-src-rewrite-rule'
+        }
+      end
+
+      before do
+        expect_any_instance_of(CustomersAuth)
+          .to receive(:create_shadow_copy)
+                .and_raise(ActiveRecord::StatementInvalid, 'null value in column "customers_auth_id" violates not-null constraint')
+      end
+
+      it 'rollback all' do
+        subject rescue nil
+        expect(described_class.where(src_rewrite_rule: old_src_rewrite_rule).count).to eq(128)
+        expect(described_class.count).to eq(128)
+        expect(record.reload).to have_attributes(src_rewrite_rule: old_src_rewrite_rule)
+      end
+    end
+
+  end
+
+
+  describe '#destroy' do
+
+    before do
+      @other_record = create(:customers_auth)
+      @record = create(:customers_auth,
+                       ip: ['127.0.0.1', '192.168.0.1'],
+                       src_prefix: ['src-1', 'src-2'],
+                       dst_prefix: ['dst-1', 'dst-2'],
+                       uri_domain: ['uri-1', 'uri-2'],
+                       from_domain: ['from-1', 'from-2'],
+                       to_domain: ['to-1', 'to-2'],
+                       x_yeti_auth: ['x-1', 'x-2'])
+    end
+
+    subject do
+      @record.destroy
+    end
+
+    it 'destorys original record' do
+      expect { subject }.to change { CustomersAuth.where(id: @record.id).count }.by(-1)
+    end
+
+    it 'destroys only related copies' do
+      expect { subject }.to change { described_class.count }.from(129).to(1)
+      expect(described_class.take).to have_attributes(
+        customers_auth_id: @other_record.id
+      )
+    end
+
+  end
+
+end

--- a/spec/models/customers_auth_spec.rb
+++ b/spec/models/customers_auth_spec.rb
@@ -2,10 +2,32 @@ require 'spec_helper'
 
 RSpec.describe CustomersAuth, type: :model do
 
+  shared_examples :it_validates_array_elements do |*columns|
+    columns.each do |column_name|
+      # uniquness
+      it { is_expected.not_to allow_value(['127.0.0.1', '127.0.0.1']).for(column_name) }
+      it { is_expected.to allow_value(['127.0.0.1', '127.0.0.2']).for(column_name) }
+      # spaces are not allowed
+      it { is_expected.not_to allow_value(['s s', 'asd']).for(column_name) }
+      it { is_expected.not_to allow_value(['asd', 'a sd']).for(column_name) }
+    end
+  end
+
+
   context '#validations' do
 
-    include_examples :test_model_with_tag_action
+    context 'validate Routing Tag' do
+      include_examples :test_model_with_tag_action
+    end
 
+    context 'validate match condition attributes' do
+
+      include_examples :it_validates_array_elements,
+        :ip,
+        :dst_prefix, :src_prefix,
+        :uri_domain, :from_domain, :to_domain,
+        :x_yeti_auth
+    end
   end
 
 end

--- a/spec/models/jobs/importing_customers_auth_job_spec.rb
+++ b/spec/models/jobs/importing_customers_auth_job_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'shared_examples/shared_examples_for_importing_job'
 
-describe 'Importing::CustomersAuth => CustomersAuth delayed_job' do
+xdescribe 'Importing::CustomersAuth => CustomersAuth delayed_job' do
   it_behaves_like 'Jobs for importing data' do
      include_context :init_importing_delayed_job do
        include_context :init_contractor, name: 'iBasis', vendor: true, customer: true


### PR DESCRIPTION
- create table `customers_auth_denormalized`
- add new fields to `customers_auth` table:
  * ips
  * src_prefixes
  * dst_prefixes
  * uri_domains
  * from_domains
  * to_domains
  * x_yeti_auths

Checklist:
- [x] write migration
- [x] update model and spec
- [x] Write test on failing situations
- [x] ActiveAdmin should use new attributes instead of old
- [x] ActiveAdmin should filtering by new attributes
- [x] ActiveAdmin show de-normalized copies (readonly)
- [x] Use new attributes in AdminAPI
- [x] Use new attributes in CustomerAPI
- [x] Update APIs documentation

This are global issues, wre broken a long time ago. Will be fixed in 3 saparate PRs:
- [ ] ~~Rework ActiveAdmin Copy-action~~
- [ ] ~~Export with new attributes~~
- [ ] ~~Import with new attributes~~

closes #204