### PR TITLE
Add spec for CustomersAuthNormalized.column_names

### DIFF
--- a/spec/models/customers_auth_normalized_spec.rb
+++ b/spec/models/customers_auth_normalized_spec.rb
@@ -378,4 +378,19 @@ RSpec.describe CustomersAuthNormalized, type: :model do
 
   end
 
+
+  describe '.column_names' do
+    subject do
+      described_class.column_names - ['customers_auth_id']
+    end
+
+    let(:customers_auth_column_names) do
+      CustomersAuth.column_names
+    end
+
+    it 'columns should match with original CustomersAuth model' do
+      expect(subject).to match_array(customers_auth_column_names)
+    end
+  end
+
 end


### PR DESCRIPTION
Test if colums of CustomersAuthNormalized match CustomerAuth columns

The missing column is `external_id` and test fails.

@dmitry-sinina, you are now working with routing. Do you want add missing column by yourself or should I do it in this PR?