### PR TITLE
Update gem "active_admin_datetimepicker" 0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,10 @@ gem 'draper', '~>  2.1.0'
 gem 'activeadmin', git: 'https://github.com/yeti-switch/active_admin.git'
 gem 'novus-nvd3-rails', git: 'https://github.com/yeti-switch/nvd3-community-rails.git'
 gem 'active_admin_theme'
-gem 'active_admin_import' , '3.0.0.pre'
+gem 'active_admin_import', '3.0.0.pre'
 gem 'active_admin_scoped_collection_actions'
-gem 'active_admin_datetimepicker', git: 'https://github.com/activeadmin-plugins/activeadmin_datetimepicker.git', ref: '16f2d40484172a5fdb0a4a7c0a12add51a762bd0'
+# latest version compatible with current(old) ActiveAdmin
+gem 'active_admin_datetimepicker', '0.5.0'
 gem 'active_admin_date_range_preset', git: 'https://github.com/workgena/active_admin_date_range_preset.git'
 
 gem 'yetis_node', git: 'https://github.com/yeti-switch/yetis_node.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
       activeadmin
 
 GIT
-  remote: https://github.com/activeadmin-plugins/activeadmin_datetimepicker.git
-  revision: 16f2d40484172a5fdb0a4a7c0a12add51a762bd0
-  ref: 16f2d40484172a5fdb0a4a7c0a12add51a762bd0
-  specs:
-    active_admin_datetimepicker (0.1.1)
-      xdan-datetimepicker-rails (~> 2.4)
-
-GIT
   remote: https://github.com/cschiewek/devise_ldap_authenticatable
   revision: 472735c0455f2b0cff1cf6e860f591ec07b0d7c0
   specs:
@@ -123,6 +115,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_admin_datetimepicker (0.5.0)
+      xdan-datetimepicker-rails (~> 2.5.1)
     active_admin_import (3.0.0.pre)
       activerecord-import (~> 0.8.0)
       rails (>= 4.0)
@@ -511,7 +505,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_admin_date_range_preset!
-  active_admin_datetimepicker!
+  active_admin_datetimepicker (= 0.5.0)
   active_admin_import (= 3.0.0.pre)
   active_admin_scoped_collection_actions
   active_admin_sidebar!


### PR DESCRIPTION
Fixes JavaScript error on some pages, for example Edit Destination.

Version `0.5.0` is latest version
which is compatible with current(yeti fork) ActiveAdmin

All recent releases are compatible with ActiveAdmin 1.x
but not with older one