### PR TITLE
substitute underscore with tilde in Makefile on chlog generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ else
 		[ "$$tag" != "HEAD" ] && ver="$$NEXT"; \
 		[ "$$tag" = "HEAD" ] && ver="$(version)"; \
 		[ "$$tag" = "HEAD" ] && [ $(commit_number_since_release) -eq 0 ] && continue; \
-		ver="$$(echo $$ver | sed 's/-rc/~rc/' | sed 's/-master/~master/')"; \
+		ver="$$(echo $$ver | sed 's/_/~/g')"; \
 		echo "Appending version $${ver} from $${PREV} to $${NEXT}"; \
 		changelog-git \
 			-q \


### PR DESCRIPTION
underscore is ok in git tag, but not ok in debian version. So we can use it to denote tilde in tag names.