### PR TITLE
Add CONSTRAINT to CustomersAuth ip_not_empyt

### DIFF
--- a/app/models/customers_auth.rb
+++ b/app/models/customers_auth.rb
@@ -34,13 +34,13 @@
 #  dst_number_radius_rewrite_result :string
 #  radius_accounting_profile_id     :integer
 #  transport_protocol_id            :integer
-#  dst_number_min_length            :integer          default(0), not null
 #  dst_number_max_length            :integer          default(100), not null
 #  check_account_balance            :boolean          default(TRUE), not null
 #  require_incoming_auth            :boolean          default(FALSE), not null
 #  tag_action_id                    :integer
 #  tag_action_value                 :integer          default([]), not null, is an Array
-#  ip                               :inet             default([]), is an Array
+#  dst_number_min_length            :integer          default(0), not null
+#  ip                               :inet             default(["\"127.0.0.0/8\""]), is an Array
 #  src_prefix                       :string           default(["\"\""]), is an Array
 #  dst_prefix                       :string           default(["\"\""]), is an Array
 #  uri_domain                       :string           default([]), is an Array
@@ -97,6 +97,8 @@ class CustomersAuth < Yeti::ActiveRecord
 
   validates :ip, :src_prefix, :dst_prefix, :uri_domain, :from_domain, :to_domain, :x_yeti_auth,
             array_uniqueness: true
+
+  validates_presence_of :ip
 
 
   validates_uniqueness_of :name, allow_blank: :false

--- a/app/models/customers_auth_normalized.rb
+++ b/app/models/customers_auth_normalized.rb
@@ -7,7 +7,7 @@
 #  customer_id                      :integer          not null
 #  rateplan_id                      :integer          not null
 #  enabled                          :boolean          default(TRUE), not null
-#  ip                               :inet
+#  ip                               :inet             not null
 #  account_id                       :integer
 #  gateway_id                       :integer          not null
 #  src_rewrite_rule                 :string

--- a/db/migrate/20180313135314_customers_auth_ip_not_null.rb
+++ b/db/migrate/20180313135314_customers_auth_ip_not_null.rb
@@ -1,0 +1,20 @@
+class CustomersAuthIpNotNull < ActiveRecord::Migration
+  def up
+    execute %q{
+      UPDATE class4.customers_auth SET ip='{127.0.0.0/8}' WHERE ip='{}';
+      UPDATE class4.customers_auth_normalized SET ip='127.0.0.0/8' WHERE ip IS NULL;
+      
+      ALTER TABLE class4.customers_auth ALTER ip SET DEFAULT '{127.0.0.0/8}';
+      ALTER TABLE class4.customers_auth ADD CONSTRAINT ip_not_empty CHECK (ip != '{}');
+      ALTER TABLE class4.customers_auth_normalized ALTER ip SET NOT NULL;
+    }
+  end
+
+  def down
+    execute %q{
+      ALTER TABLE class4.customers_auth ALTER COLUMN ip SET DEFAULT '{}';
+      ALTER TABLE class4.customers_auth DROP CONSTRAINT ip_not_empty;
+      ALTER TABLE class4.customers_auth_normalized ALTER ip DROP NOT NULL;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -19711,14 +19711,15 @@ CREATE TABLE class4.customers_auth (
     tag_action_id smallint,
     tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
     dst_number_min_length smallint DEFAULT 0 NOT NULL,
-    ip inet[] DEFAULT '{}'::inet[],
+    ip inet[] DEFAULT '{127.0.0.0/8}'::inet[],
     src_prefix character varying[] DEFAULT '{""}'::character varying[],
     dst_prefix character varying[] DEFAULT '{""}'::character varying[],
     uri_domain character varying[] DEFAULT '{}'::character varying[],
     from_domain character varying[] DEFAULT '{}'::character varying[],
     to_domain character varying[] DEFAULT '{}'::character varying[],
     x_yeti_auth character varying[] DEFAULT '{}'::character varying[],
-    external_id bigint
+    external_id bigint,
+    CONSTRAINT ip_not_empty CHECK ((ip <> '{}'::inet[]))
 );
 
 
@@ -19751,7 +19752,7 @@ CREATE TABLE class4.customers_auth_normalized (
     customer_id integer NOT NULL,
     rateplan_id integer NOT NULL,
     enabled boolean DEFAULT true NOT NULL,
-    ip inet,
+    ip inet NOT NULL,
     account_id integer,
     gateway_id integer NOT NULL,
     src_rewrite_rule character varying,
@@ -26472,7 +26473,8 @@ ALTER TABLE ONLY sys.sensors
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
+SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import
+;
 
 INSERT INTO public.schema_migrations (version) VALUES ('20170822151410');
 
@@ -26515,4 +26517,6 @@ INSERT INTO public.schema_migrations (version) VALUES ('20180215094913');
 INSERT INTO public.schema_migrations (version) VALUES ('20180305132729');
 
 INSERT INTO public.schema_migrations (version) VALUES ('20180312205051');
+
+INSERT INTO public.schema_migrations (version) VALUES ('20180313135314');
 

--- a/spec/controllers/api/rest/system/ip_access_controller_spec.rb
+++ b/spec/controllers/api/rest/system/ip_access_controller_spec.rb
@@ -8,13 +8,13 @@ describe Api::Rest::System::IpAccessController, type: :controller  do
 
     context 'when CustomersAuth records exist' do
       before do
-        create(:customers_auth) # default ip='0.0.0.0/32'
+        create(:customers_auth) # default ip='127.0.0.0/8'
         create(:customers_auth, ip: '192.168.0.0/16')
         create(:customers_auth, ip: '2001:67c:1324:111::1/64')
       end
 
       let(:expected_response) do
-        ['0.0.0.0/32', '192.168.0.0/16', '2001:67c:1324:111::/64']
+        ['127.0.0.0/8', '192.168.0.0/16', '2001:67c:1324:111::/64']
       end
 
       it 'returns array of all CustomersAuth IPs' do

--- a/spec/factories/customers_auth.rb
+++ b/spec/factories/customers_auth.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     association :gateway
     association :account
 
-    ip { ['0.0.0.0'] }
+    #ip { ['127.0.0.0/8'] } # default
     src_rewrite_rule nil
     src_rewrite_result nil
     dst_rewrite_rule nil

--- a/spec/models/customers_auth_normalized_spec.rb
+++ b/spec/models/customers_auth_normalized_spec.rb
@@ -7,7 +7,7 @@
 #  customer_id                      :integer          not null
 #  rateplan_id                      :integer          not null
 #  enabled                          :boolean          default(TRUE), not null
-#  ip                               :inet
+#  ip                               :inet             not null
 #  account_id                       :integer
 #  gateway_id                       :integer          not null
 #  src_rewrite_rule                 :string
@@ -79,7 +79,7 @@ RSpec.describe CustomersAuthNormalized, type: :model do
     context 'when all attributes are ampty (default DB values)' do
       let(:attributes) do
         {
-          ip: [],
+          # ip: [], default 127.0.0.0/8
           src_prefix: [],
           dst_prefix: [],
           uri_domain: [],
@@ -94,7 +94,7 @@ RSpec.describe CustomersAuthNormalized, type: :model do
       it 'create copy with empty match-conditions attributes' do
         subject
         expect(described_class.take).to have_attributes(
-          ip: nil,
+          ip: '127.0.0.0/8',
           src_prefix: '',
           dst_prefix: '',
           uri_domain: nil,
@@ -160,7 +160,7 @@ RSpec.describe CustomersAuthNormalized, type: :model do
     context 'when only SRC_PREFIXES is filled with several values' do
       let(:attributes) do
         {
-          ip: [],
+          # ip: [], default
           src_prefix: ['src-1', 'src-2'],
           dst_prefix: [],
           uri_domain: [],
@@ -247,7 +247,7 @@ RSpec.describe CustomersAuthNormalized, type: :model do
     context 'when error happens with first and only denormalized copy' do
       let(:attributes) do
         {
-          ip: [],
+          # ip: [], default
           src_prefix: [],
           dst_prefix: [],
           uri_domain: [],

--- a/spec/models/customers_auth_spec.rb
+++ b/spec/models/customers_auth_spec.rb
@@ -34,13 +34,13 @@
 #  dst_number_radius_rewrite_result :string
 #  radius_accounting_profile_id     :integer
 #  transport_protocol_id            :integer
-#  dst_number_min_length            :integer          default(0), not null
 #  dst_number_max_length            :integer          default(100), not null
 #  check_account_balance            :boolean          default(TRUE), not null
 #  require_incoming_auth            :boolean          default(FALSE), not null
 #  tag_action_id                    :integer
 #  tag_action_value                 :integer          default([]), not null, is an Array
-#  ip                               :inet             default([]), is an Array
+#  dst_number_min_length            :integer          default(0), not null
+#  ip                               :inet             default(["\"127.0.0.0/8\""]), is an Array
 #  src_prefix                       :string           default(["\"\""]), is an Array
 #  dst_prefix                       :string           default(["\"\""]), is an Array
 #  uri_domain                       :string           default([]), is an Array
@@ -79,6 +79,10 @@ RSpec.describe CustomersAuth, type: :model do
         :dst_prefix, :src_prefix,
         :uri_domain, :from_domain, :to_domain,
         :x_yeti_auth
+    end
+
+    context 'ip' do
+      it { is_expected.not_to allow_value([]).for(:ip) }
     end
   end
 


### PR DESCRIPTION
- [x] Add constraint/validation on `CustomersAuth#ip` => can not be empty array
- [x] Change default value to `[127.0.0.0/8]`
- [x] Migration updates all CustomersAuth with empty IP to [127.0.0.0/8] (+ normalized records)

Notice: if `ip` was `0.0.0.0/0` it will remain