### PR TITLE
Add `routing_tag_ids` to RoutingTagDetectionRule

### DIFF
--- a/app/admin/routing/customers_auths.rb
+++ b/app/admin/routing/customers_auths.rb
@@ -186,7 +186,7 @@ ActiveAdmin.register CustomersAuth do
     column :radius_accounting_profile, sortable: 'radius_accounting_profiles.name'
 
     column :tag_action
-    column :routing_tags
+    column :display_tag_action_value
   end
 
   filter :id
@@ -384,7 +384,7 @@ ActiveAdmin.register CustomersAuth do
       tab :routing_tags do
         attributes_table do
           row :tag_action
-          row :routing_tags
+          row :display_tag_action_value
         end
       end
     end

--- a/app/admin/routing/numberlist_items.rb
+++ b/app/admin/routing/numberlist_items.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register Routing::NumberlistItem do
     column :created_at
     column :updated_at
     column :tag_action
-    column :routing_tags
+    column :display_tag_action_value
   end
 
   show do |s|
@@ -62,7 +62,7 @@ ActiveAdmin.register Routing::NumberlistItem do
       row :createa_at
       row :updated_at
       row :tag_action
-      row :routing_tags
+      row :display_tag_action_value
     end
   end
 

--- a/app/admin/routing/numberlists.rb
+++ b/app/admin/routing/numberlists.rb
@@ -51,7 +51,7 @@ ActiveAdmin.register Routing::Numberlist, as: 'Numberlist' do
     column :created_at
     column :updated_at
     column :tag_action
-    column :routing_tags
+    column :display_tag_action_value
   end
 
   show do |s|
@@ -67,7 +67,7 @@ ActiveAdmin.register Routing::Numberlist, as: 'Numberlist' do
       row :created_at
       row :updated_at
       row :tag_action
-      row :routing_tags
+      row :display_tag_action_value
     end
   end
 

--- a/app/admin/routing/routing_tag_detection_rules.rb
+++ b/app/admin/routing/routing_tag_detection_rules.rb
@@ -9,14 +9,18 @@ ActiveAdmin.register Routing::RoutingTagDetectionRule do
   acts_as_safe_destroy
 
   permit_params :src_area_id, :dst_area_id,
-                :tag_action_id, tag_action_value: []
+                :tag_action_id, tag_action_value: [],
+                routing_tag_ids: []
 
-  includes :src_area, :dst_area
+  includes :src_area, :dst_area, :tag_action
 
   controller do
     def update
       if params['routing_routing_tag_detection_rule']['tag_action_value'].nil?
         params['routing_routing_tag_detection_rule']['tag_action_value'] = []
+      end
+      if params['routing_routing_tag_detection_rule']['routing_tag_ids'].nil?
+        params['routing_routing_tag_detection_rule']['routing_tag_ids'] = []
       end
       super
     end
@@ -26,25 +30,32 @@ ActiveAdmin.register Routing::RoutingTagDetectionRule do
     selectable_column
     id_column
     actions
+    column :routing_tags
     column :src_area
     column :dst_area
     column :tag_action
-    column :routing_tags
+    column :display_tag_action_value
   end
 
   show do |s|
     attributes_table do
       row :id
+      row :routing_tags
       row :src_area
       row :dst_area
       row :tag_action
-      row :routing_tags
+      row :display_tag_action_value
     end
   end
 
   form do |f|
     f.semantic_errors *f.object.errors.keys
     f.inputs do
+      f.input :routing_tag_ids, as: :select,
+        collection: RoutingTagDetectionRuleDecorator.decorate(f.object).routing_tag_options,
+        multiple: true,
+        include_hidden: false,
+        input_html: { class: 'chosen' }
       f.input :src_area
       f.input :dst_area
       f.input :tag_action

--- a/app/decorators/routing_tag_action_decorator.rb
+++ b/app/decorators/routing_tag_action_decorator.rb
@@ -2,7 +2,7 @@ module RoutingTagActionDecorator
 
   # TODO: this is very very bad for index page
   # replace with has_many :routing_tags
-  def routing_tags
+  def display_tag_action_value
     model.tag_action_value.map do |id|
       h.content_tag(:span, Routing::RoutingTag.find(id).name, class: 'status_tag ok')
     end.join('&nbsp;').html_safe

--- a/app/decorators/routing_tag_detection_rule_decorator.rb
+++ b/app/decorators/routing_tag_detection_rule_decorator.rb
@@ -5,5 +5,6 @@ class RoutingTagDetectionRuleDecorator < Draper::Decorator
 
   # TODO: must be another way to share decorated methods
   include RoutingTagActionDecorator
+  include RoutingTagIdsDecorator
 
 end

--- a/app/models/routing/routing_tag_detection_rule.rb
+++ b/app/models/routing/routing_tag_detection_rule.rb
@@ -7,6 +7,7 @@
 #  src_area_id      :integer
 #  tag_action_id    :integer
 #  tag_action_value :integer          default([]), not null, is an Array
+#  routing_tag_ids  :integer          default([]), not null, is an Array
 #
 
 class Routing::RoutingTagDetectionRule < Yeti::ActiveRecord
@@ -14,6 +15,7 @@ class Routing::RoutingTagDetectionRule < Yeti::ActiveRecord
   self.table_name='class4.routing_tag_detection_rules'
 
   validates_with TagActionValueValidator
+  validates_with RoutingTagIdsValidator
 
   belongs_to :src_area, class_name: Routing::Area, foreign_key: :src_area_id
   belongs_to :dst_area, class_name: Routing::Area, foreign_key: :dst_area_id

--- a/app/resources/api/rest/admin/routing/routing_tag_detection_rule_resource.rb
+++ b/app/resources/api/rest/admin/routing/routing_tag_detection_rule_resource.rb
@@ -1,7 +1,7 @@
 class Api::Rest::Admin::Routing::RoutingTagDetectionRuleResource < ::BaseResource
   model_name 'Routing::RoutingTagDetectionRule'
 
-  attributes :tag_action_value
+  attributes :tag_action_value, :routing_tag_ids
 
   has_one :src_area, class_name: 'Area'
   has_one :dst_area, class_name: 'Area'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,9 @@ en:
       equipment_registration:
         contact: "Must be in URI format (sip:user@domain or sip:domain)"
 
+  attributes:
+    display_tag_action_value: 'Tag Action Value'
+
   activerecord:
     attributes:
       customers_auth:

--- a/db/migrate/20180316061214_add_routing_tag_ids_to_rtdr.rb
+++ b/db/migrate/20180316061214_add_routing_tag_ids_to_rtdr.rb
@@ -1,0 +1,13 @@
+class AddRoutingTagIdsToRtdr < ActiveRecord::Migration
+  def up
+    execute %q{
+      ALTER TABLE class4.routing_tag_detection_rules ADD routing_tag_ids smallint[] NOT NULL DEFAULT '{}'::smallint[];
+    }
+  end
+
+  def down
+    execute %q{
+      ALTER TABLE class4.routing_tag_detection_rules DROP routing_tag_ids;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -20697,7 +20697,8 @@ CREATE TABLE class4.routing_tag_detection_rules (
     dst_area_id integer,
     src_area_id integer,
     tag_action_id smallint,
-    tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL
+    tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
+    routing_tag_ids smallint[] DEFAULT '{}'::smallint[] NOT NULL
 );
 
 
@@ -26473,7 +26474,8 @@ ALTER TABLE ONLY sys.sensors
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
+SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import
+;
 
 INSERT INTO public.schema_migrations (version) VALUES ('20170822151410');
 
@@ -26518,4 +26520,6 @@ INSERT INTO public.schema_migrations (version) VALUES ('20180305132729');
 INSERT INTO public.schema_migrations (version) VALUES ('20180312205051');
 
 INSERT INTO public.schema_migrations (version) VALUES ('20180313135314');
+
+INSERT INTO public.schema_migrations (version) VALUES ('20180316061214');
 

--- a/spec/acceptance/rest/admin/api/routing/routing_tag_detection_rules_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/routing_tag_detection_rules_spec.rb
@@ -11,7 +11,7 @@ resource 'Routing RoutingTagDetectionRules' do
 
   required_params = %i()
 
-  optional_params = %i(tag_action_value)
+  optional_params = %i(tag-action-value routing-tag-ids)
 
   required_relationships = %i()
   optional_relationships = %i(src-area dst-area tag-action)

--- a/spec/controllers/api/rest/admin/routing/routing_tag_detection_rules_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/routing/routing_tag_detection_rules_controller_spec.rb
@@ -81,4 +81,12 @@ describe Api::Rest::Admin::Routing::RoutingTagDetectionRulesController, type: :c
     end
   end
 
+  describe 'editable routing_tag_ids' do
+    include_examples :jsonapi_resource_with_routing_tag_ids do
+      let(:record) do
+        create(:routing_tag_detection_rule,
+               routing_tag_ids: tag_ids)
+      end
+    end
+  end
 end

--- a/spec/features/routing_tag_detection_rules/edit_rtdr_spec.rb
+++ b/spec/features/routing_tag_detection_rules/edit_rtdr_spec.rb
@@ -9,4 +9,10 @@ describe 'Edit RoutingTagDetectionRule', type: :feature do
                       factory: :routing_tag_detection_rule
   end
 
+  context 'unset "Routin Tag IDs"' do
+    include_examples :test_unset_routing_tag_ids,
+                      controller_name: :routing_routing_tag_detection_rules,
+                      factory: :routing_tag_detection_rule
+
+  end
 end

--- a/spec/models/routing/routing_tag_detection_rule_spec.rb
+++ b/spec/models/routing/routing_tag_detection_rule_spec.rb
@@ -7,6 +7,7 @@
 #  src_area_id      :integer
 #  tag_action_id    :integer
 #  tag_action_value :integer          default([]), not null, is an Array
+#  routing_tag_ids  :integer          default([]), not null, is an Array
 #
 
 require 'spec_helper'
@@ -14,6 +15,10 @@ require 'spec_helper'
 RSpec.describe Routing::RoutingTagDetectionRule, type: :model do
 
   context '#validations' do
+
+    context 'validate routing_tag_ids' do
+      include_examples :test_model_with_routing_tag_ids
+    end
 
     include_examples :test_model_with_tag_action
 


### PR DESCRIPTION
Add column `RoutingTagDetectionRule#routing_tag_ids` (Array)
it behaves the same way as in Destination/Dialpeer

Fix title of column `tag_action_value` in ActiveAdmin resources

![rtdr_show](https://user-images.githubusercontent.com/9843321/37512660-71a458be-290b-11e8-8ba2-814bb22a5642.gif)