### PR TITLE
Calls monitoring

### DIFF
--- a/app/jobs/jobs/calls_monitoring.rb
+++ b/app/jobs/jobs/calls_monitoring.rb
@@ -84,10 +84,10 @@ module Jobs
         initial_interval = attrs.fetch("#{key}_initial_interval").to_i #TODO: check if needed cast to int
         next_interval = attrs.fetch("#{key}_next_interval").to_i #TODO: check if needed cast to int
         connect_fee = attrs.fetch("#{key}_fee").to_f
-
+        vat =  key == 'destination' ? attrs.fetch("customer_acc_vat", 0) : 0
         initial_interval_billing = connect_fee + initial_interval * i_per_second_rate
         next_interval_billing = (duration > initial_interval ? 1 : 0) * ((duration - initial_interval).to_f / next_interval).ceil * next_interval * n_per_second_rate
-        initial_interval_billing + next_interval_billing
+        (initial_interval_billing + next_interval_billing) * (1 + vat / 100.0)
       end
 
     end #END CallCollection
@@ -108,6 +108,7 @@ module Jobs
         :destination_next_interval,
         :destination_next_rate,
         :destination_fee,
+        :customer_acc_vat,
 
         :vendor_acc_id,
         :dialpeer_fee,

--- a/app/models/gateway.rb
+++ b/app/models/gateway.rb
@@ -222,6 +222,18 @@ class Gateway < Yeti::ActiveRecord
   scope :originations, -> { where(allow_origination: true) }
   scope :terminations, -> { where(allow_termination: true) }
 
+
+  scope :disabled_for_origination, -> {
+      where(
+        Gateway.arel_table[:allow_origination].eq(false).or(Gateway.arel_table[:enabled].eq(false))
+      )
+  }
+  scope :disabled_for_termination, -> {
+    where(
+      Gateway.arel_table[:allow_termination].eq(false).or(Gateway.arel_table[:enabled].eq(false))
+    )
+  }
+
   def fire_lock(stat)
     transaction do
       self.locked = true

--- a/spec/jobs/calls_monitoring_spec.rb
+++ b/spec/jobs/calls_monitoring_spec.rb
@@ -2,26 +2,51 @@ require 'spec_helper'
 
 describe Jobs::CallsMonitoring do
 
-  shared_context :customer_acc do |balance: 1_000, max_balance: nil, vat: 0, min_balance: 0|
-    let(:account) do
-      create(:account,
-             balance: balance,
-             min_balance: min_balance,
-             max_balance: max_balance || (balance * 2),
-             vat: vat,
-             contractor: create(:customer))
-    end
+  let(:account_balance) do
+    1_000
   end
 
-  shared_context :vendor_acc do |balance: 1_000, max_balance: nil|
-    let(:vendor_acc) do
-        create(:account,
-             balance: balance,
-             min_balance: 0,
-             max_balance: max_balance || (balance * 2),
-             contractor: create(:vendor))
-    end
+  let(:vendor_balance) do
+    1_000
   end
+
+  let!(:codec_group) do
+    create(:codec_group)
+  end
+
+  let!(:origin_gateway) do
+    create(:gateway,
+           enabled: true,
+           allow_origination: true,
+           codec_group: codec_group,
+           contractor: account.contractor)
+  end
+
+  let!(:term_gateway) do
+    create(:gateway,
+           enabled: true,
+           allow_termination: true,
+           codec_group: codec_group,
+           contractor: vendor_acc.contractor)
+  end
+
+  let!(:account) do
+    create(:account,
+           balance: account_balance,
+           min_balance: 0,
+           max_balance: account_balance * 2,
+           vat: 0,
+           contractor: create(:customer))
+  end
+
+  let!(:vendor_acc) do
+    create(:account,
+           balance: vendor_balance,
+           min_balance: 0,
+           max_balance: vendor_balance * 2,
+           contractor: create(:vendor))
+  end
+
 
   shared_examples :keep_emergency_calls do
     let(:customer_acc_check_balance) { false }
@@ -89,7 +114,11 @@ describe Jobs::CallsMonitoring do
           'dialpeer_next_rate' => '0.0000',
           'customer_acc_check_balance' => customer_acc_check_balance,
           'destination_reverse_billing' => false,
-          'dialpeer_reverse_billing' => false
+          'dialpeer_reverse_billing' => false,
+
+          'orig_gw_id' =>  origin_gateway.id,
+          'term_gw_id' =>  term_gateway.id
+
         },
         {
           'local_tag' => 'reverse-call',
@@ -116,8 +145,12 @@ describe Jobs::CallsMonitoring do
           'dialpeer_next_rate' => '0.0000',
           'customer_acc_check_balance' => customer_acc_check_balance,
           'destination_reverse_billing' => true,
-          'dialpeer_reverse_billing' => true
-        }
+          'dialpeer_reverse_billing' => true,
+
+          'orig_gw_id' =>  origin_gateway.id,
+          'term_gw_id' =>  term_gateway.id
+
+      }
       ]
     end
 
@@ -129,25 +162,51 @@ describe Jobs::CallsMonitoring do
     end
 
     context 'when Customer and Vendor have enough money' do
-      include_context :customer_acc
-      include_context :vendor_acc
-
       include_examples :keep_calls
     end
 
-    context 'when Customer' do
-      include_context :customer_acc, balance: 0
-      include_context :vendor_acc
-
+    context 'when origin gw disabled for origination' do
+      before do
+        origin_gateway.update!(allow_origination: false)
+      end
       include_examples :drop_calls
     end
+
+    context 'when term gw disabled' do
+      before do
+        term_gateway.disable!
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when term gw disabled for termination' do
+      before do
+        term_gateway.update!(allow_termination: false)
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when origin gw disabled' do
+      before do
+        origin_gateway.disable!
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when Customer has zero balance' do
+      let(:account_balance) do
+        0
+      end
+      include_examples :drop_calls
+     end
 
     context 'when Customer has money for the call' do
       let(:cdr_list_unsorted) do
         super().select{|c| c['local_tag'] == 'normal-call'}
       end
-      include_context :customer_acc, balance: 1.02
-      include_context :vendor_acc
+      let(:account_balance) do
+        1.02
+      end
 
       include_examples :keep_calls
 
@@ -157,16 +216,22 @@ describe Jobs::CallsMonitoring do
       let(:cdr_list_unsorted) do
         super().select{|c| c['local_tag'] == 'normal-call'}
       end
-      include_context :customer_acc, balance: 1.02, vat: 30
-      include_context :vendor_acc
+      let(:account_balance) do
+        1.02
+      end
+
+      before do
+        account.update!(vat: 30)
+      end
 
       include_examples :drop_calls
 
     end
 
     context 'when Vendor has no money for the call' do
-      include_context :customer_acc
-      include_context :vendor_acc, balance: 0
+      let(:vendor_balance) do
+        0
+      end
 
       include_examples :drop_calls
     end
@@ -174,15 +239,19 @@ describe Jobs::CallsMonitoring do
     context 'Customer calls' do
 
       context 'when calls cost is within mim-max balance' do
-        include_context :customer_acc, balance: 6
-        include_context :vendor_acc
+        let(:account_balance) do
+          50
+        end
 
         include_examples :keep_calls
       end
 
       context 'when calls cost is below min_balance' do
-        include_context :customer_acc, balance: 1.15, min_balance: 1.14, max_balance: 10000
-        include_context :vendor_acc
+
+        before do
+          account.update!(balance: 1.15, min_balance: 1.14, max_balance: 10000)
+        end
+
         context 'when reserved call exits' do
           include_examples :keep_calls
         end
@@ -195,15 +264,16 @@ describe Jobs::CallsMonitoring do
             expect_any_instance_of(Node).to receive(:drop_call).with('normal-call')
             subject
           end
+
           it_behaves_like :keep_emergency_calls
         end
         
       end
 
       context 'when calls cost is above max_balance' do
-        include_context :customer_acc, balance: 10, max_balance: 4
-        include_context :vendor_acc
-
+        before do
+          account.update!(balance: 10, max_balance: 4, min_balance: 1)
+        end
         it 'total calls cost exceeds max_balance. Drop reverse calls' do
           expect_any_instance_of(Node).to receive(:drop_call).with('reverse-call')
           subject
@@ -218,15 +288,13 @@ describe Jobs::CallsMonitoring do
     context 'Vendor calls' do
 
       context 'when calls cost is within mim-max balance' do
-        include_context :customer_acc
-        include_context :vendor_acc
-
         include_examples :keep_calls
       end
 
       context 'when calls cost is below min_balance' do
-        include_context :customer_acc
-        include_context :vendor_acc, balance: -6, max_balance: 100
+        before do
+          vendor_acc.update!( balance: -6, max_balance: 100)
+        end
 
         it 'total calls cost exceeds min_balance. Drop reverse calls' do
           expect_any_instance_of(Node).to receive(:drop_call).with('reverse-call')
@@ -237,8 +305,9 @@ describe Jobs::CallsMonitoring do
       end
 
       context 'when calls cost is above max_balance' do
-        include_context :customer_acc
-        include_context :vendor_acc, balance: 0, max_balance: 4
+        before do
+          vendor_acc.update!(balance: 0, max_balance: 4)
+        end
 
         it 'total calls cost exceeds max_balance. Drop normal calls' do
           expect_any_instance_of(Node).to receive(:drop_call).with('normal-call')

--- a/spec/jobs/calls_monitoring_spec.rb
+++ b/spec/jobs/calls_monitoring_spec.rb
@@ -212,6 +212,34 @@ describe Jobs::CallsMonitoring do
 
     end
 
+    context 'when vendor contractor disabled' do
+      before do
+        vendor_acc.contractor.disable!
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when vendor contractor is customer' do
+      before do
+        vendor_acc.contractor.update!(vendor: false, customer: true)
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when account contractor disabled' do
+      before do
+        account.contractor.disable!
+      end
+      include_examples :drop_calls
+    end
+
+    context 'when account contractor is vendor' do
+      before do
+        account.contractor.update!(customer: false, vendor: true)
+      end
+      include_examples :drop_calls
+    end
+
     context 'when Customer has no money for the call after vat apply' do
       let(:cdr_list_unsorted) do
         super().select{|c| c['local_tag'] == 'normal-call'}


### PR DESCRIPTION
 - drop calls if not enough balance including vat AND  customer_acc_check_balance  = true
 -  drop calls if customer_id linked to contractor that is disabled
 -  drop calls if vendor_id linked to contractor that is disabled
 -  drop calls if customer_id linked to contractor that is no more customer 
 -  drop calls if vendor_id linked to contractor that is no more vendor
 -  drop calls if orig_gw_id linked to gateway that is disabled
 -  drop calls if term_gw_id linked to gateway that is disabled
 -  drop calls if term_gw_id linked to gateway that is not allowed to terminate calls
 -  drop calls if orig_gw_id linked to gateway that t is not allowed to originate calls