### PR TITLE
require net/http in ping_callback_url_job

### DIFF
--- a/app/jobs/worker/ping_callback_url_job.rb
+++ b/app/jobs/worker/ping_callback_url_job.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module Worker
   class PingCallbackUrlJob < ActiveJob::Base
     class TryAgainError < RuntimeError


### PR DESCRIPTION
looks like webmock requires it so spec is passing