### PR TITLE
fix Import of Destination/Dialpeers/CustomersAuth

### DIFF
--- a/db/migrate/20180404135210_importing_remove_not_null_constraint.rb
+++ b/db/migrate/20180404135210_importing_remove_not_null_constraint.rb
@@ -1,0 +1,33 @@
+class ImportingRemoveNotNullConstraint < ActiveRecord::Migration
+  def up
+    execute %q{
+      ALTER TABLE data_import.import_customers_auth
+        ALTER tag_action_value_names DROP DEFAULT,
+        ALTER tag_action_value_names DROP NOT NULL;
+
+      ALTER TABLE data_import.import_destinations
+        ALTER routing_tag_names DROP DEFAULT,
+        ALTER routing_tag_names DROP NOT NULL;
+
+      ALTER TABLE data_import.import_dialpeers
+        ALTER routing_tag_names DROP DEFAULT,
+        ALTER routing_tag_names DROP NOT NULL;
+    }
+  end
+
+  def down
+    execute %q{
+      ALTER TABLE data_import.import_customers_auth
+        ALTER tag_action_value_names SET DEFAULT '',
+        ALTER tag_action_value_names SET NOT NULL;
+
+      ALTER TABLE data_import.import_destinations
+        ALTER routing_tag_names SET DEFAULT '',
+        ALTER routing_tag_names SET NOT NULL;
+
+      ALTER TABLE data_import.import_dialpeers
+        ALTER routing_tag_names SET DEFAULT '',
+        ALTER routing_tag_names SET NOT NULL;
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21076,7 +21076,7 @@ CREATE TABLE data_import.import_customers_auth (
     tag_action_id smallint,
     tag_action_value smallint[] DEFAULT '{}'::smallint[] NOT NULL,
     tag_action_name character varying,
-    tag_action_value_names character varying DEFAULT ''::character varying NOT NULL,
+    tag_action_value_names character varying,
     dst_number_min_length integer,
     dst_number_max_length integer
 );
@@ -21134,7 +21134,7 @@ CREATE TABLE data_import.import_destinations (
     short_calls_limit real,
     reverse_billing boolean,
     routing_tag_ids smallint[] DEFAULT '{}'::smallint[] NOT NULL,
-    routing_tag_names character varying DEFAULT ''::character varying NOT NULL,
+    routing_tag_names character varying,
     dst_number_min_length integer,
     dst_number_max_length integer
 );
@@ -21201,7 +21201,7 @@ CREATE TABLE data_import.import_dialpeers (
     exclusive_route boolean,
     reverse_billing boolean,
     routing_tag_ids smallint[] DEFAULT '{}'::smallint[] NOT NULL,
-    routing_tag_names character varying DEFAULT ''::character varying NOT NULL,
+    routing_tag_names character varying,
     dst_number_min_length integer,
     dst_number_max_length integer
 );
@@ -26559,7 +26559,8 @@ ALTER TABLE ONLY sys.sensors
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
+SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import
+;
 
 INSERT INTO public.schema_migrations (version) VALUES ('20170822151410');
 
@@ -26612,4 +26613,6 @@ INSERT INTO public.schema_migrations (version) VALUES ('20180318143341');
 INSERT INTO public.schema_migrations (version) VALUES ('20180320120746');
 
 INSERT INTO public.schema_migrations (version) VALUES ('20180403104223');
+
+INSERT INTO public.schema_migrations (version) VALUES ('20180404135210');
 

--- a/lib/resource_dsl/acts_as_import.rb
+++ b/lib/resource_dsl/acts_as_import.rb
@@ -32,7 +32,7 @@ module ResourceDSL
 
       options[:template_object] = Importing::Model.new(
           # "proc" prevents error on `rake db:structure:dump`
-          unique_columns_proc: proc { config.resource_class.column_names - ["id"] },
+          unique_columns_proc: proc { options[:resource_class].import_attributes },
           csv_options: {col_sep: ",", row_sep: nil, quote_char: nil}
       )
 

--- a/spec/models/importing/importing_customers_auth_spec.rb
+++ b/spec/models/importing/importing_customers_auth_spec.rb
@@ -49,6 +49,21 @@ describe Importing::CustomersAuth do
     end
   end
 
+  context 'when tag_action_value_names is NULL' do
+    include_context :init_importing_customers_auth, {
+      tag_action_value_names: nil,
+      tag_action_value: []
+    }
+
+    it 'tag_action_value is empty array' do
+      subject
+      expect(preview_item.reload).to have_attributes(
+        tag_action_value_names: nil,
+        tag_action_value: []
+      )
+    end
+  end
+
   it_behaves_like 'after_import_hook when real items match' do
     include_context :init_importing_customers_auth, name: 'SameName'
     include_context :init_customers_auth, name: 'SameName'

--- a/spec/models/importing/importing_destination_spec.rb
+++ b/spec/models/importing/importing_destination_spec.rb
@@ -31,6 +31,21 @@ describe Importing::Destination do
     end
   end
 
+  context 'when routing_tag_names is NULL' do
+    include_context :init_importing_destination, {
+      routing_tag_names: nil,
+      routing_tag_ids: []
+    }
+
+    it 'routing_tag_ids is empty array' do
+      subject
+      expect(preview_item.reload).to have_attributes(
+        routing_tag_names: nil,
+        routing_tag_ids: []
+      )
+    end
+  end
+
   it_behaves_like 'after_import_hook when real items match' do
     include_context :init_importing_destination, prefix: '373900'
     include_context :init_destination, prefix: '373900'

--- a/spec/models/importing/importing_dialpeer_spec.rb
+++ b/spec/models/importing/importing_dialpeer_spec.rb
@@ -39,6 +39,21 @@ describe Importing::Dialpeer do
     end
   end
 
+  context 'when tag_action_value_names is NULL' do
+    include_context :init_importing_dialpeer, {
+      routing_tag_names: nil,
+      routing_tag_ids: []
+    }
+
+    it 'routing_tag_ids is empty array' do
+      subject
+      expect(preview_item.reload).to have_attributes(
+        routing_tag_names: nil,
+        routing_tag_ids: []
+      )
+    end
+  end
+
   it_behaves_like 'after_import_hook when real items match' do
     include_context :init_importing_dialpeer, prefix: '111'
     include_context :init_dialpeer, prefix: '111'


### PR DESCRIPTION
* fix error with routing_tag_names and tag_action_value_names (drop constraint NOT NULL)
* display attributes only available for importing in "Unique columns values" check-boxes

