### PR TITLE
Add filters by routing_tag_ids

### DIFF
--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -86,6 +86,7 @@ ActiveAdmin.register Destination do
 
   filter :external_id_eq, label: 'EXTERNAL_ID'
 
+  acts_as_filter_by_routing_tag_ids
 
 
   permit_params :enabled, :prefix, :dst_number_min_length, :dst_number_max_length, :rateplan_id, :next_rate, :connect_fee,

--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -210,6 +210,8 @@ ActiveAdmin.register Dialpeer do
   filter :external_id
   filter :exclusive_route, as: :select, collection: [["Yes", true], ["No", false]]
 
+  acts_as_filter_by_routing_tag_ids
+
 
   form do |f|
     f.semantic_errors *f.object.errors.keys

--- a/app/admin/routing/routing_tag_detection_rules.rb
+++ b/app/admin/routing/routing_tag_detection_rules.rb
@@ -79,4 +79,5 @@ ActiveAdmin.register Routing::RoutingTagDetectionRule do
   filter :src_area, input_html: {class: 'chosen'}
   filter :dst_area, input_html: {class: 'chosen'}
 
+  acts_as_filter_by_routing_tag_ids
 end

--- a/app/models/concerns/routing_tag_ids_scopeable.rb
+++ b/app/models/concerns/routing_tag_ids_scopeable.rb
@@ -1,0 +1,19 @@
+module RoutingTagIdsScopeable
+  extend ActiveSupport::Concern
+
+  included do
+
+    scope :routing_tag_ids_covers, ->(*id) do
+      where("yeti_ext.tag_compare(routing_tag_ids, ARRAY[#{id.join(',')}])>0")
+    end
+
+    scope :tagged, ->(value) do
+      if ActiveRecord::Type::Boolean.new.type_cast_from_user(value)
+        where("routing_tag_ids <> '{}'") # has tags
+      else
+        where("routing_tag_ids = '{}'") # no tags
+      end
+    end
+
+  end
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -49,6 +49,8 @@ class Destination < Yeti::ActiveRecord
 
   include Yeti::NetworkDetector
 
+  include RoutingTagIdsScopeable
+
   scope :low_quality, -> { where quality_alarm: true }
 
   scope :where_customer, -> (id) do
@@ -152,7 +154,9 @@ class Destination < Yeti::ActiveRecord
 
   def self.ransackable_scopes(auth_object = nil)
     [
-        :routing_for_contains
+        :routing_for_contains,
+        :routing_tag_ids_covers,
+        :tagged
     ]
   end
 

--- a/app/models/dialpeer.rb
+++ b/app/models/dialpeer.rb
@@ -88,6 +88,7 @@ class Dialpeer < Yeti::ActiveRecord
 
   include Yeti::ResourceStatus
   include Yeti::NetworkDetector
+  include RoutingTagIdsScopeable
 
   scope :locked, -> { where locked: true }
 
@@ -197,7 +198,9 @@ class Dialpeer < Yeti::ActiveRecord
 
   def self.ransackable_scopes(auth_object = nil)
     [
-        :routing_for_contains
+        :routing_for_contains,
+        :routing_tag_ids_covers,
+        :tagged
     ]
   end
 

--- a/app/models/routing/routing_tag_detection_rule.rb
+++ b/app/models/routing/routing_tag_detection_rule.rb
@@ -24,8 +24,18 @@ class Routing::RoutingTagDetectionRule < Yeti::ActiveRecord
   array_belongs_to :routing_tags, class_name: 'Routing::RoutingTag', foreign_key: :routing_tag_ids
   array_belongs_to :tag_action_values, class_name: 'Routing::RoutingTag', foreign_key: :tag_action_value
 
+  include RoutingTagIdsScopeable
+
   def display_name
     "#{self.id}"
   end
 
+  private
+
+  def self.ransackable_scopes(auth_object = nil)
+    [
+        :routing_tag_ids_covers,
+        :tagged
+    ]
+  end
 end

--- a/config/initializers/yeti.rb
+++ b/config/initializers/yeti.rb
@@ -22,6 +22,7 @@ ActiveAdmin::ResourceDSL.send :include, ResourceDSL::BatchActionUpdate
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActsAsAsyncDestroy
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActsAsAsyncUpdate
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActsAsDelayedJobLock
+ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActsAsFilterByRoutingTagIds
 
 # ActiveAdmin::CSVBuilder.send(:include, Yeti::CSVBuilder)
 

--- a/lib/resource_dsl/acts_as_filter_by_routing_tag_ids.rb
+++ b/lib/resource_dsl/acts_as_filter_by_routing_tag_ids.rb
@@ -1,0 +1,19 @@
+module ResourceDSL
+  module ActsAsFilterByRoutingTagIds
+
+    def acts_as_filter_by_routing_tag_ids
+
+      filter :routing_tag_ids_covers, as: :select,
+        collection: ->{ Routing::RoutingTag.pluck(:name, :id) },
+        input_html: { class: 'chosen', multiple: true }
+
+      filter :routing_tag_ids_array_contains, label: 'Routing Tag IDs Contains', as: :select,
+        collection: ->{ Routing::RoutingTag.pluck(:name, :id) },
+        input_html: { class: 'chosen', multiple: true }
+
+      filter :tagged, as: :select , collection: [ ["Yes", true], ["No", false]]
+
+    end
+
+  end
+end


### PR DESCRIPTION
Add new filters for Destination, Dialpeer, RoutingTagDetectionRule:
- routing_tag_ids_convers (`yeti_ext.tag_compare`)
- routing_tag_ids_array_contaings (`@> ARRAY[...]`)
- tagged (`<> '{}'` | `= '{}'`)

![default](https://user-images.githubusercontent.com/9843321/38689541-9c69ac28-3e84-11e8-9a52-5981d19cea94.png)

