### PR TITLE
Change default ORDER for CDR to "time_start DESC"

### DIFF
--- a/app/models/cdr/cdr.rb
+++ b/app/models/cdr/cdr.rb
@@ -174,6 +174,8 @@ class Cdr::Cdr < Cdr::Base
   belongs_to :sign_orig_transport_protocol, class_name: Equipment::TransportProtocol, foreign_key: :sign_orig_transport_protocol_id
   belongs_to :sign_term_transport_protocol, class_name: Equipment::TransportProtocol, foreign_key: :sign_term_transport_protocol_id
 
+  default_scope { order('time_start desc') }
+
   scope :success, -> { where success: true }
   scope :failure, -> { where success: false }
 

--- a/app/models/cdr/cdr_archive.rb
+++ b/app/models/cdr/cdr_archive.rb
@@ -144,4 +144,5 @@
 class Cdr::CdrArchive < Cdr::Cdr
   self.table_name = 'cdr.cdr_archive'
 
+  default_scope { order('time_start desc') }
 end

--- a/app/models/cdr_export.rb
+++ b/app/models/cdr_export.rb
@@ -59,7 +59,7 @@ class CdrExport < Yeti::ActiveRecord
   alias_attribute :export_type, :type
 
   def export_sql
-    Cdr::Cdr.select(fields.join(', ')).order('time_start desc').ransack(filters).result.to_sql
+    Cdr::Cdr.select(fields.join(', ')).ransack(filters).result.to_sql
   end
 
   def completed?

--- a/spec/models/cdr/cdr_archive_spec.rb
+++ b/spec/models/cdr/cdr_archive_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe Cdr::CdrArchive, type: :model do
+
+  describe 'default ORDER BY' do
+    subject { described_class.all.to_sql }
+
+    it 'default ORDER is time_start DESC' do
+      expect(subject).to end_with('ORDER BY time_start desc')
+    end
+  end
+end

--- a/spec/models/cdr/cdr_spec.rb
+++ b/spec/models/cdr/cdr_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Cdr::Cdr, type: :model do
 
   it { expect(described_class.count).to eq(0) }
 
+  describe 'default ORDER BY' do
+    subject { described_class.all.to_sql }
+
+    it 'default ORDER is time_start DESC' do
+      expect(subject).to end_with('ORDER BY time_start desc')
+    end
+  end
+
   describe 'Function "switch.writecdr()"' do
 
     before do


### PR DESCRIPTION
Affected models:
* Cdr::Cdr
* Cdr::CdrArchive
* CdrExport (it was already order by time_start_desc; just moved ordering method to `Cdr::Cdr` model)

This change should increase speed :turtle: of CDR loading in ActiveAdmin