### PR TITLE
Change display of column routing_tag_mode

### DIFF
--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -147,7 +147,6 @@ ActiveAdmin.register Destination do
     column :quality_alarm
     column :rateplan, sortable: 'rateplans.name'
     column :routing_tags
-    column :routing_tag_mode
     column :valid_from do |c|
       c.decorated_valid_from
     end

--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -119,7 +119,6 @@ ActiveAdmin.register Dialpeer do
     end
     column :routing_group, sortable: 'routing_groups.name'
     column :routing_tags
-    column :routing_tag_mode
     column :priority
     column :force_hit_rate
     column :exclusive_route

--- a/app/admin/routing/routing_tag_detection_rules.rb
+++ b/app/admin/routing/routing_tag_detection_rules.rb
@@ -41,7 +41,6 @@ ActiveAdmin.register Routing::RoutingTagDetectionRule do
     id_column
     actions
     column :routing_tags
-    column :routing_tag_mode
     column :src_area
     column :dst_area
     column :src_prefix

--- a/app/decorators/routing_tag_ids_decorator.rb
+++ b/app/decorators/routing_tag_ids_decorator.rb
@@ -3,12 +3,13 @@ module RoutingTagIdsDecorator
   # TODO: this is very very bad for index page
   # replace with has_many :routing_tags
   def routing_tags
+    separator_character = routing_tag_mode.and? ? ' & ' : ' <b>|</b> '
     unless model.routing_tag_ids.present?
       return h.content_tag(:span, 'NOT TAGGED', class: 'status_tag')
     end
     model.routing_tags.map do |tag|
       h.content_tag(:span, tag.name, class: 'status_tag ok')
-    end.join('&nbsp;').html_safe
+    end.join(separator_character).html_safe
   end
 
   def routing_tag_options

--- a/app/models/routing/routing_tag_mode.rb
+++ b/app/models/routing/routing_tag_mode.rb
@@ -17,4 +17,8 @@ class Routing::RoutingTagMode < Yeti::ActiveRecord
   end
 
   after_initialize { readonly! }
+
+  def and?
+    id == CONST::AND
+  end
 end

--- a/spec/models/routing/routing_tag_mode.rb
+++ b/spec/models/routing/routing_tag_mode.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Routing::RoutingTagMode, type: :model do
+
+  describe '#and?' do
+
+    subject { described_class.new(id: id).and? }
+
+    context 'AND' do
+      let(:id) { 1 }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'OR' do
+      let(:id) { 0 }
+      it { is_expected.to eq(false) }
+    end
+
+  end
+
+end


### PR DESCRIPTION
For Dialpeer, Destination and RoutingTagDetectionRule
change the way of display `routing_tag_mode`-column:

1. Remove column `routing_tag_mode` from index page
2. Change display of `routing_tags` column:
  * **UA & US** --> when mode is AND
  * **UA | US** --> when mode is OR

![default](https://user-images.githubusercontent.com/9843321/39373980-05c027d2-4a52-11e8-9560-8fcc0f913563.png)
