### PR TITLE
Rewrite `cdr.cdr` table partitioning to Ruby

### DIFF
--- a/app/models/concerns/pg_cdr_partitioning.rb
+++ b/app/models/concerns/pg_cdr_partitioning.rb
@@ -1,0 +1,94 @@
+module PgCdrPartitioning
+
+  class Partition
+    attr_accessor :connection, :date_from, :date_to, :name, :table_name
+
+    def initialize(connection:, date_from:)
+      self.connection = connection
+      self.date_from = date_from.beginning_of_month
+      self.date_to = date_from.next_month.beginning_of_month
+      self.name = "cdr_" + date_from.strftime('%Y%m')
+      self.table_name = "cdr.#{name}"
+    end
+
+    def create
+      connection.execute %Q{
+        CREATE TABLE #{table_name} (
+          CONSTRAINT #{name}_time_start_check CHECK (
+            time_start >= '#{date_from.to_s(:db)} 00:00:00+00'
+              AND time_start < '#{date_to.to_s(:db)} 00:00:00+00'
+          )
+        ) INHERITS (cdr.cdr);
+      }
+    end
+
+    def add_partition_info(info_table)
+      connection.execute %Q{
+        INSERT INTO #{info_table}(date_start, date_stop, name, writable, readable) VALUES ('#{date_from.to_s(:db)}', '#{date_to.to_s(:db)}', '#{table_name}', 't', 't');
+      }
+    end
+
+    def reindex
+      add_primary_key unless primary_key?
+      time_start_index = column_index(:time_start)
+
+      if time_start_index.present?
+        connection.remove_index(table_name, name: time_start_index.name)
+      end
+      connection.add_index(table_name, :time_start, using: 'btree')
+    end
+
+    def exists?
+      connection.table_exists?(table_name)
+    end
+
+    private
+
+    def primary_key?
+      connection.index_exists?(table_name, :id, unique: true)
+    end
+
+    def column_index(column_name)
+      connection.indexes(table_name).detect do |ind|
+        ind.columns.include?(column_name)
+      end
+    end
+
+    def add_primary_key
+      connection.execute %Q{
+        ALTER TABLE #{table_name} ADD PRIMARY KEY (id);
+      }
+    end
+  end
+
+
+  def create_partition(date_from)
+    party = Partition.new(connection: connection, date_from: date_from)
+    unless party.exists?
+      party.create
+      party.reindex
+      party.add_partition_info(table_name)
+      reload_cdr_i_tgf
+    end
+  end
+
+  def reload_cdr_i_tgf
+    cases = active.order(:date_start).map do |t|
+      "(NEW.time_start >= '#{t.date_start} 00:00:00+00' AND NEW.time_start < '#{t.date_stop} 00:00:00+00') THEN
+          INSERT INTO #{t.name} VALUES (NEW.*);"
+    end
+
+    connection.execute %Q{
+      CREATE OR REPLACE FUNCTION cdr.cdr_i_tgf() RETURNS trigger AS $trg$
+      BEGIN
+        IF #{ cases.join("\n        ELSIF ")  }
+        ELSE
+          RAISE EXCEPTION 'cdr.cdr_i_tg: time_start out of range.';
+        END IF;
+      RETURN NULL;
+      END; $trg$
+      LANGUAGE plpgsql VOLATILE COST 100;
+    } if cases.any?
+  end
+
+end

--- a/db/secondbase/migrate/20180611140540_remove_cdr_partition_functions.rb
+++ b/db/secondbase/migrate/20180611140540_remove_cdr_partition_functions.rb
@@ -1,0 +1,153 @@
+class RemoveCdrPartitionFunctions < ActiveRecord::Migration[5.1]
+  def up
+    execute %q{
+      DROP FUNCTION sys.cdrtable_tgr_reload();
+      DROP FUNCTION sys.cdr_reindex(character varying, character varying);
+      DROP FUNCTION sys.cdr_createtable(integer);
+    }
+  end
+
+  def down
+    execute %q{
+      CREATE FUNCTION sys.cdrtable_tgr_reload() RETURNS void
+          LANGUAGE plpgsql
+          AS $_$
+      DECLARE
+      v_tbname varchar;
+      v_sql1 varchar:='CREATE OR REPLACE FUNCTION cdr.cdr_i_tgf() RETURNS trigger AS $trg$
+      BEGIN  [MEAT]
+      RETURN NULL;
+      END; $trg$ LANGUAGE plpgsql VOLATILE COST 100';
+      --v_sql2 varchar:='ALTER FUNCTION cdrs.cdrs_i_tgf() OWNER TO accadmin;';
+      v_tb_row record;
+      v_meat varchar;
+      v_prfx varchar;
+      v_counter integer;
+      BEGIN
+              v_meat:='';
+              v_counter:='1';
+              PERFORM * FROM sys.cdr_tables WHERE active;
+              IF NOT FOUND THEN
+                  RAISE EXCEPTION 'no tables for write data';
+              end IF;
+              FOR v_tb_row IN SELECT * FROM sys.cdr_tables WHERE active ORDER BY date_start LOOP
+                      IF v_counter=1 THEN
+                              v_prfx='IF ';
+                      ELSE
+                              v_prfx='ELSIF ';
+                      END IF;
+                      v_meat:=v_meat||v_prfx||'( NEW.time_start >= '''||v_tb_row.date_start||' 00:00:00+00'' AND NEW.time_start < '''||v_tb_row.date_stop||' 00:00:00+00'' ) THEN INSERT INTO '||v_tb_row.name||' VALUES (NEW.*);'|| E'\n';
+                      v_counter:=v_counter+1;
+              END LOOP;
+              v_meat:=v_meat||' ELSE '|| E'\n'||' RAISE EXCEPTION ''cdr.cdr_i_tg: time_start out of range.''; '||E'\n'||' END IF;';
+              v_sql1:=REPLACE(v_sql1,'[MEAT]',v_meat);
+              set standard_conforming_strings=on;
+              EXECUTE v_sql1;
+            --  EXECUTE v_sql2;
+              RAISE NOTICE 'sys.cdrtable_tgr_reload: CDR trigger reloaded';
+             -- RETURN 'OK';
+      END;
+      $_$;
+
+
+      CREATE FUNCTION sys.cdr_reindex(i_schema character varying, i_tbname character varying) RETURNS void
+          LANGUAGE plpgsql
+          AS $$
+      DECLARE
+      v_c integer;
+      v_sql varchar;
+      v_indname varchar;
+      BEGIN
+              SELECT into v_c count(*) from pg_tables where schemaname=i_schema and tablename=i_tbname;
+              IF v_c=0 THEN
+                      RAISE EXCEPTION 'sys.cdr_reindex: table % not exist',i_tbname;
+              ELSE
+                      -- CHECK primary key
+                      SELECT into v_indname conname from pg_catalog.pg_constraint  where conname like i_tbname||'_pkey%';
+                      IF NOT FOUND THEN
+                              v_sql:='ALTER TABLE '||i_tbname||' ADD PRIMARY KEY (id);';
+                              EXECUTE v_sql;
+                              RAISE NOTICE 'sys.cdr_reindex: % add primary key' ,i_tbname;
+                      END IF;
+      /*
+                      -- UNIQUE index on out_call_id;
+                      SELECT into v_indname indexname FROM pg_catalog.pg_indexes WHERE schemaname=i_schemae AND tablename=i_tbname AND indexdef LIKE '%(out_call_id)%';
+                      IF NOT FOUND THEN
+                              v_sql:='CREATE UNIQUE INDEX ON '||i_schemae||'.'||i_tbname||' USING btree (out_call_id);';
+                              RAISE NOTICE 'sys.cdr_reindex: % add index out_call_id' ,i_tbname;
+                              EXECUTE v_sql;
+                      ELSE
+                              v_sql:='CREATE UNIQUE INDEX ON '||i_schemae||'.'||i_tbname||' USING btree (out_call_id);';
+                              EXECUTE v_sql;
+                              v_sql:='DROP INDEX cdrs.'||v_indname;
+                              EXECUTE v_sql;
+                              RAISE NOTICE 'sys.cdr_reindex: % reindex out_call_id' ,i_tbname;
+                      END IF;
+      */
+                      -- index on time_inviteprocessed;
+                      SELECT into v_indname indexname FROM pg_catalog.pg_indexes WHERE schemaname=i_schema AND tablename=i_tbname AND indexdef LIKE '%(time_start)%';
+                      IF NOT FOUND THEN
+                              v_sql:='CREATE INDEX ON '||i_schema||'.'||i_tbname||' USING btree (time_start);';
+                              EXECUTE v_sql;
+                              RAISE NOTICE 'sys.cdr_reindex: % add index time_start' ,i_tbname;
+                      ELSE
+                              v_sql:='CREATE INDEX ON '||i_schema||'.'||i_tbname||' USING btree (time_start);';
+                              EXECUTE v_sql;
+                              v_sql:='DROP INDEX '||i_schema||'.'||v_indname;
+                              EXECUTE v_sql;
+                              RAISE NOTICE 'sys.cdr_reindex: % reindex time_invite' ,i_tbname;
+                      END IF;
+
+              END IF;
+              RETURN ;
+      END;
+      $$;
+
+
+      CREATE FUNCTION sys.cdr_createtable(i_offset integer) RETURNS void
+          LANGUAGE plpgsql COST 10000
+          AS $$
+      DECLARE
+      v_tbname varchar;
+      v_ftbname varchar;
+      v_tdate varchar;
+      v_start varchar;
+      v_end varchar;
+      v_c integer;
+      v_sql varchar;
+
+      BEGIN
+              -- get tablename for next month;
+              v_tdate:=to_char(now()+'1 month'::interval - i_offset * '1 month'::interval ,'YYYYMM');
+              v_start:=to_char(now()+'1 month'::interval - i_offset * '1 month'::interval ,'YYYY-MM-01');
+              v_end:=to_char(now()+'2 month'::interval - i_offset * '1 month'::interval,'YYYY-MM-01');
+
+              v_tbname:='cdr_'||v_tdate;
+              v_ftbname:='cdr.'||v_tbname::varchar;
+
+              -- CHECK if table exists
+              SELECT into v_c count(*) from pg_tables where schemaname='cdr' and tablename=v_tbname;
+              IF v_c>0 THEN
+                      RAISE NOTICE 'sys.cdr_createtable: next table % already created',v_tbname;
+                      RETURN;
+              ELSE
+                      v_sql:='CREATE TABLE '||v_ftbname||'(
+                      CONSTRAINT '||v_tbname||'_time_start_check CHECK (
+                              time_start >= '''||v_start||' 00:00:00+00''
+                              AND time_start < '''||v_end||' 00:00:00+00''
+                      )
+                      ) INHERITS (cdr.cdr)';
+                      EXECUTE v_sql;
+                      v_sql:='ALTER TABLE '||v_ftbname||' ADD PRIMARY KEY(id)';
+                      EXECUTE v_sql;
+                      RAISE NOTICE 'sys.cdr_createtable: next table % creating started',v_tbname;
+                      PERFORM sys.cdr_reindex('cdr',v_tbname);
+                      -- update trigger
+                      INSERT INTO sys.cdr_tables(date_start,date_stop,"name",writable,readable) VALUES (v_start,v_end,v_ftbname,'t','t');
+                      PERFORM sys.cdrtable_tgr_reload();
+              END IF;
+      END;
+      $$;
+    }
+  end
+end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -728,14 +728,18 @@ $$;
 CREATE FUNCTION cdr.cdr_i_tgf() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-BEGIN  IF ( NEW.time_start >= '2018-04-01 00:00:00+00' AND NEW.time_start < '2018-05-01 00:00:00+00' ) THEN INSERT INTO cdr.cdr_201804 VALUES (NEW.*);
-ELSIF ( NEW.time_start >= '2018-05-01 00:00:00+00' AND NEW.time_start < '2018-06-01 00:00:00+00' ) THEN INSERT INTO cdr.cdr_201805 VALUES (NEW.*);
-ELSIF ( NEW.time_start >= '2018-06-01 00:00:00+00' AND NEW.time_start < '2018-07-01 00:00:00+00' ) THEN INSERT INTO cdr.cdr_201806 VALUES (NEW.*);
- ELSE 
- RAISE EXCEPTION 'cdr.cdr_i_tg: time_start out of range.'; 
- END IF;
-RETURN NULL;
-END; $$;
+      BEGIN
+        IF (NEW.time_start >= '2018-05-01 00:00:00+00' AND NEW.time_start < '2018-06-01 00:00:00+00') THEN
+          INSERT INTO cdr.cdr_201805 VALUES (NEW.*);
+        ELSIF (NEW.time_start >= '2018-06-01 00:00:00+00' AND NEW.time_start < '2018-07-01 00:00:00+00') THEN
+          INSERT INTO cdr.cdr_201806 VALUES (NEW.*);
+        ELSIF (NEW.time_start >= '2018-07-01 00:00:00+00' AND NEW.time_start < '2018-08-01 00:00:00+00') THEN
+          INSERT INTO cdr.cdr_201807 VALUES (NEW.*);
+        ELSE
+          RAISE EXCEPTION 'cdr.cdr_i_tg: time_start out of range.';
+        END IF;
+      RETURN NULL;
+      END; $$;
 
 
 --
@@ -3520,56 +3524,6 @@ $$;
 
 
 --
--- Name: cdr_createtable(integer); Type: FUNCTION; Schema: sys; Owner: -
---
-
-CREATE FUNCTION sys.cdr_createtable(i_offset integer) RETURNS void
-    LANGUAGE plpgsql COST 10000
-    AS $$
-DECLARE
-v_tbname varchar;
-v_ftbname varchar;
-v_tdate varchar;
-v_start varchar;
-v_end varchar;
-v_c integer;
-v_sql varchar;
-
-BEGIN
-        -- get tablename for next month;
-        v_tdate:=to_char(now()+'1 month'::interval - i_offset * '1 month'::interval ,'YYYYMM');
-        v_start:=to_char(now()+'1 month'::interval - i_offset * '1 month'::interval ,'YYYY-MM-01');
-        v_end:=to_char(now()+'2 month'::interval - i_offset * '1 month'::interval,'YYYY-MM-01');
-
-        v_tbname:='cdr_'||v_tdate;
-        v_ftbname:='cdr.'||v_tbname::varchar;
-
-        -- CHECK if table exists
-        SELECT into v_c count(*) from pg_tables where schemaname='cdr' and tablename=v_tbname;
-        IF v_c>0 THEN
-                RAISE NOTICE 'sys.cdr_createtable: next table % already created',v_tbname;
-                RETURN;
-        ELSE
-                v_sql:='CREATE TABLE '||v_ftbname||'(
-                CONSTRAINT '||v_tbname||'_time_start_check CHECK (
-                        time_start >= '''||v_start||' 00:00:00+00''
-                        AND time_start < '''||v_end||' 00:00:00+00''
-                )
-                ) INHERITS (cdr.cdr)';
-                EXECUTE v_sql;
-                v_sql:='ALTER TABLE '||v_ftbname||' ADD PRIMARY KEY(id)';
-                EXECUTE v_sql;
-                RAISE NOTICE 'sys.cdr_createtable: next table % creating started',v_tbname;
-                PERFORM sys.cdr_reindex('cdr',v_tbname);
-                -- update trigger
-                INSERT INTO sys.cdr_tables(date_start,date_stop,"name",writable,readable) VALUES (v_start,v_end,v_ftbname,'t','t');
-                PERFORM sys.cdrtable_tgr_reload();
-        END IF;
-END;
-$$;
-
-
---
 -- Name: cdr_export_data(character varying); Type: FUNCTION; Schema: sys; Owner: -
 --
 
@@ -3599,109 +3553,6 @@ BEGIN
     execute 'COPY '||i_tbname||' TO '''||v_file||''' WITH CSV HEADER QUOTE AS ''"'' FORCE QUOTE *';
 END;
 $$;
-
-
---
--- Name: cdr_reindex(character varying, character varying); Type: FUNCTION; Schema: sys; Owner: -
---
-
-CREATE FUNCTION sys.cdr_reindex(i_schema character varying, i_tbname character varying) RETURNS void
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-v_c integer;
-v_sql varchar;
-v_indname varchar;
-BEGIN
-        SELECT into v_c count(*) from pg_tables where schemaname=i_schema and tablename=i_tbname;
-        IF v_c=0 THEN
-                RAISE EXCEPTION 'sys.cdr_reindex: table % not exist',i_tbname;
-        ELSE
-                -- CHECK primary key
-                SELECT into v_indname conname from pg_catalog.pg_constraint  where conname like i_tbname||'_pkey%';
-                IF NOT FOUND THEN
-                        v_sql:='ALTER TABLE '||i_tbname||' ADD PRIMARY KEY (id);';
-                        EXECUTE v_sql;
-                        RAISE NOTICE 'sys.cdr_reindex: % add primary key' ,i_tbname;
-                END IF;
-/*
-                -- UNIQUE index on out_call_id;
-                SELECT into v_indname indexname FROM pg_catalog.pg_indexes WHERE schemaname=i_schemae AND tablename=i_tbname AND indexdef LIKE '%(out_call_id)%';
-                IF NOT FOUND THEN
-                        v_sql:='CREATE UNIQUE INDEX ON '||i_schemae||'.'||i_tbname||' USING btree (out_call_id);';
-                        RAISE NOTICE 'sys.cdr_reindex: % add index out_call_id' ,i_tbname;
-                        EXECUTE v_sql;
-                ELSE
-                        v_sql:='CREATE UNIQUE INDEX ON '||i_schemae||'.'||i_tbname||' USING btree (out_call_id);';
-                        EXECUTE v_sql;
-                        v_sql:='DROP INDEX cdrs.'||v_indname;
-                        EXECUTE v_sql;
-                        RAISE NOTICE 'sys.cdr_reindex: % reindex out_call_id' ,i_tbname;
-                END IF;
-*/
-                -- index on time_inviteprocessed;
-                SELECT into v_indname indexname FROM pg_catalog.pg_indexes WHERE schemaname=i_schema AND tablename=i_tbname AND indexdef LIKE '%(time_start)%';
-                IF NOT FOUND THEN
-                        v_sql:='CREATE INDEX ON '||i_schema||'.'||i_tbname||' USING btree (time_start);';
-                        EXECUTE v_sql;
-                        RAISE NOTICE 'sys.cdr_reindex: % add index time_start' ,i_tbname;
-                ELSE
-                        v_sql:='CREATE INDEX ON '||i_schema||'.'||i_tbname||' USING btree (time_start);';
-                        EXECUTE v_sql;
-                        v_sql:='DROP INDEX '||i_schema||'.'||v_indname;
-                        EXECUTE v_sql;
-                        RAISE NOTICE 'sys.cdr_reindex: % reindex time_invite' ,i_tbname;
-                END IF;
-
-        END IF;
-        RETURN ;
-END;
-$$;
-
-
---
--- Name: cdrtable_tgr_reload(); Type: FUNCTION; Schema: sys; Owner: -
---
-
-CREATE FUNCTION sys.cdrtable_tgr_reload() RETURNS void
-    LANGUAGE plpgsql
-    AS $_$
-DECLARE
-v_tbname varchar;
-v_sql1 varchar:='CREATE OR REPLACE FUNCTION cdr.cdr_i_tgf() RETURNS trigger AS $trg$
-BEGIN  [MEAT]
-RETURN NULL;
-END; $trg$ LANGUAGE plpgsql VOLATILE COST 100';
---v_sql2 varchar:='ALTER FUNCTION cdrs.cdrs_i_tgf() OWNER TO accadmin;';
-v_tb_row record;
-v_meat varchar;
-v_prfx varchar;
-v_counter integer;
-BEGIN
-        v_meat:='';
-        v_counter:='1';
-        PERFORM * FROM sys.cdr_tables WHERE active;
-        IF NOT FOUND THEN
-            RAISE EXCEPTION 'no tables for write data';
-        end IF;
-        FOR v_tb_row IN SELECT * FROM sys.cdr_tables WHERE active ORDER BY date_start LOOP
-                IF v_counter=1 THEN
-                        v_prfx='IF ';
-                ELSE
-                        v_prfx='ELSIF ';
-                END IF;
-                v_meat:=v_meat||v_prfx||'( NEW.time_start >= '''||v_tb_row.date_start||' 00:00:00+00'' AND NEW.time_start < '''||v_tb_row.date_stop||' 00:00:00+00'' ) THEN INSERT INTO '||v_tb_row.name||' VALUES (NEW.*);'|| E'\n';
-                v_counter:=v_counter+1;
-        END LOOP;
-        v_meat:=v_meat||' ELSE '|| E'\n'||' RAISE EXCEPTION ''cdr.cdr_i_tg: time_start out of range.''; '||E'\n'||' END IF;';
-        v_sql1:=REPLACE(v_sql1,'[MEAT]',v_meat);
-        set standard_conforming_strings=on;
-        EXECUTE v_sql1;
-      --  EXECUTE v_sql2;
-        RAISE NOTICE 'sys.cdrtable_tgr_reload: CDR trigger reloaded';
-       -- RETURN 'OK';
-END;
-$_$;
 
 
 --
@@ -6251,6 +6102,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20180328170352'),
 ('20180425200716'),
 ('20180427194936'),
-('20180607135226');
+('20180607135226'),
+('20180611140540');
 
 

--- a/spec/models/cdr/table_spec.rb
+++ b/spec/models/cdr/table_spec.rb
@@ -1,0 +1,199 @@
+require 'spec_helper'
+
+RSpec.describe Cdr::Table, type: :model do
+
+  def destroy_partitions
+    connection = Cdr::Table.connection
+    partitions = Cdr::Table.partitions
+    Cdr::Table.transaction do
+      connection.execute("TRUNCATE #{Cdr::Table.table_name}")
+      connection.execute("DROP TABLE #{partitions.join(', ')}") if partitions.present?
+      connection.execute %q{
+        CREATE OR REPLACE FUNCTION cdr.cdr_i_tgf() RETURNS trigger AS $BODY$
+        BEGIN
+          RAISE EXCEPTION 'cdr.cdr_i_tg: time_start out of range.';
+        RETURN NULL;
+        END; $BODY$ LANGUAGE plpgsql;
+      }
+    end
+  end
+
+  describe '#add_partition' do
+
+    subject { described_class.add_partition }
+
+    context 'when partitions already created' do
+      it 'do not raise errors' do
+        expect {
+          described_class.add_partition # call create partition twice
+          subject
+        }.not_to raise_error
+      end
+    end
+
+    context 'when partitions not exists' do
+      it 'create partitions successfully' do
+        destroy_partitions
+
+        expect(described_class.partitions).to be_empty # expect partition tables not exist
+        expect(described_class.count).to eq(0) # expect cdr_table to be empty
+
+        subject
+
+        expect(described_class.partitions).not_to be_empty # expect rables to exists
+        expect(described_class.count).to eq(3) # expect cdr_tables to have three correct rows
+      end
+
+      let(:time_now) { Time.now.utc }
+      let(:prev_month) { time_now.prev_month }
+      let(:next_month) { time_now.next_month }
+
+      let(:out_of_bottom_bound) { 2.month.ago.utc.end_of_month }
+      let(:out_of_upper_bound) { 2.months.from_now.utc.beginning_of_month }
+
+      let(:table_name_prev) { 'cdr.cdr_' + prev_month.strftime('%Y%m') }
+      let(:table_name_current) { 'cdr.cdr_' + time_now.strftime('%Y%m') }
+      let(:table_name_next) { 'cdr.cdr_' + next_month.strftime('%Y%m') }
+
+      def partition_rows_count(date:)
+          Cdr::Cdr.connection.execute(
+            "SELECT id FROM cdr.cdr_#{ date.strftime('%Y%m') }"
+          ).to_a.count
+      end
+
+      it 'should Insert CDR to specific partitions' do
+        destroy_partitions
+        subject
+
+        # out of range
+        expect {
+          create(:cdr, time_start: out_of_bottom_bound)
+        }.to raise_error(ActiveRecord::StatementInvalid)
+        expect {
+          create(:cdr, time_start: out_of_upper_bound)
+        }.to raise_error(ActiveRecord::StatementInvalid)
+
+        # current month
+        expect {
+          create(:cdr, time_start: time_now.beginning_of_month)
+        }.to change { partition_rows_count(date: time_now) }.by(1)
+
+        expect {
+          create(:cdr, time_start: time_now.end_of_month)
+        }.to change { partition_rows_count(date: time_now) }.by(1)
+
+        # prev month
+        expect {
+          create(:cdr, time_start: prev_month.beginning_of_month)
+        }.to change { partition_rows_count(date: prev_month) }.by(1)
+
+        expect {
+          create(:cdr, time_start: prev_month.end_of_month)
+        }.to change { partition_rows_count(date: prev_month) }.by(1)
+
+        # next months
+        expect {
+          create(:cdr, time_start: next_month.beginning_of_month)
+        }.to change { partition_rows_count(date: next_month) }.by(1)
+
+        expect {
+          create(:cdr, time_start: next_month.end_of_month)
+        }.to change { partition_rows_count(date: next_month) }.by(1)
+      end
+
+      it '`sys.cdr_tables` contains information about partitions' do
+        destroy_partitions
+        expect(described_class.count).to eq(0)
+
+        subject
+        expect(described_class.all).to all(
+          have_attributes(readable: true, writable: true, active: true)
+        )
+        expect(described_class.all).to match([
+          have_attributes(name: table_name_prev, date_start: prev_month.beginning_of_month, date_stop: time_now.beginning_of_month),
+          have_attributes(name: table_name_current, date_start: time_now.beginning_of_month, date_stop: next_month.beginning_of_month),
+          have_attributes(name: table_name_next, date_start: next_month.beginning_of_month, date_stop: next_month.next_month.beginning_of_month)
+        ])
+      end
+
+
+
+      class CdrPrev < Cdr::Cdr
+        self.table_name = "cdr.cdr_#{ Time.now.prev_month.strftime('%Y%m') }"
+      end
+
+      class CdrCurrent < Cdr::Cdr
+        self.table_name = "cdr.cdr_#{ Time.now.strftime('%Y%m') }"
+      end
+
+      class CdrNext < Cdr::Cdr
+        self.table_name = "cdr.cdr_#{ Time.now.next_month.strftime('%Y%m') }"
+      end
+
+      shared_examples :test_cdr_partition_check_fail do |klass|
+        it 'should fail' do
+          timestamps.each do |time_start|
+            expect {
+              klass.create! build(:cdr, time_start: time_start).attributes
+            }.to raise_error(ActiveRecord::StatementInvalid)
+          end
+        end
+      end
+
+      shared_examples :test_cdr_partition_check_pass do |klass|
+        it 'should save' do
+          timestamps.each do |time_start|
+            expect {
+              klass.create! build(:cdr, time_start: time_start).attributes
+            }.to change { klass.count }.by(1)
+          end
+        end
+      end
+
+      context 'month tables constraints' do
+        after(:all) { CdrPrev.delete_all }
+
+        context 'Previous month' do
+          it_behaves_like :test_cdr_partition_check_fail, CdrPrev do
+            let(:timestamps) do
+              [prev_month.beginning_of_month - 1.second, prev_month.end_of_month + 1.second ]
+            end
+          end
+          it_behaves_like :test_cdr_partition_check_pass, CdrPrev do
+            let(:timestamps) do
+              [ out_of_bottom_bound + 1.second, prev_month.end_of_month ]
+            end
+          end
+        end
+
+        context 'Current month' do
+          it_behaves_like :test_cdr_partition_check_fail, CdrCurrent do
+            let(:timestamps) do
+              [ time_now.beginning_of_month - 1.second, time_now.end_of_month + 1.second ]
+            end
+          end
+          it_behaves_like :test_cdr_partition_check_pass, CdrCurrent do
+            let(:timestamps) do
+              [ time_now.beginning_of_month, time_now.end_of_month ]
+            end
+          end
+        end
+
+        context 'Next month' do
+          it_behaves_like :test_cdr_partition_check_fail, CdrNext do
+            let(:timestamps) do
+              [ next_month.beginning_of_month - 1.second, next_month.end_of_month + 1.second ]
+            end
+          end
+          it_behaves_like :test_cdr_partition_check_pass, CdrNext do
+            let(:timestamps) do
+              [ next_month.beginning_of_month, next_month.end_of_month ]
+            end
+          end
+        end
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Rewrite CDR table partitioning from SOL-functions to Ruby-code.

- [x] Full test coverage for CDR partitioning
- [x] Implement CDR-partition creation with Ruby code
- [x] Remove old PG-function with migration