### PR TITLE
speed up gateways index page

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -1,6 +1,11 @@
 module ActiveAdmin
   module ViewHelpers
     module DisplayHelper
+      STATUS_TAG_CACHE = [
+          '<span class="status_tag yes">Yes</span>'.html_safe.freeze,
+          '<span class="status_tag no">No</span>'.html_safe.freeze
+      ].freeze
+      BOOLEAN_VALUES = [true, false].freeze
 
       alias_method :original_pretty_format, :pretty_format
 
@@ -11,6 +16,15 @@ module ActiveAdmin
         end
 
         original_pretty_format(object)
+      end
+
+      def boolean_status_tag(value)
+        STATUS_TAG_CACHE[value ? 0 : 1]
+      end
+
+      def is_boolean_val?(value)
+        BOOLEAN_VALUES.include?(value)
+        # value.is_a?(TrueClass) || value.is_a?(FalseClass)
       end
 
     end

--- a/lib/active_admin/views/components/table_for.rb
+++ b/lib/active_admin/views/components/table_for.rb
@@ -143,17 +143,13 @@ module ActiveAdmin
                 elsif item.respond_to? :[]
                   item[data]
                 end
-        value = pretty_format(value) if data.is_a?(Symbol)
-        value = status_tag value if is_boolean? data, item
-        value
-      end
-
-      def is_boolean?(data, item)
-        if item.respond_to? :has_attribute?
-          item.has_attribute?(data) &&
-              item.column_for_attribute(data) &&
-              item.column_for_attribute(data).type == :boolean
+        if helpers.is_boolean_val?(value)
+          value = helpers.boolean_status_tag(value)
+        elsif data.is_a?(Symbol)
+           value = helpers.pretty_format(value)
         end
+
+        value
       end
 
       # Returns an array for the current sort order


### PR DESCRIPTION
using cached status_tag for boolean value and faster check if value is boolean

side-effect: `nil` boolean values will be shown as empty cell (before it was status_tag 'No')

speedup from 4 to 2.8 seconds in development environment