### PR TITLE
Add new methods for Admin-API "account" resource

### DIFF
--- a/app/models/cdr/auth_log.rb
+++ b/app/models/cdr/auth_log.rb
@@ -16,7 +16,7 @@
 #  origination_proto_id  :integer
 #  username              :string
 #  realm                 :string
-#  method                :string
+#  request_method        :string
 #  ruri                  :string
 #  from_uri              :string
 #  to_uri                :string

--- a/app/resources/api/rest/admin/account_resource.rb
+++ b/app/resources/api/rest/admin/account_resource.rb
@@ -1,5 +1,6 @@
 class Api::Rest::Admin::AccountResource < ::BaseResource
   attributes :name, :min_balance, :max_balance, :external_id,
+             :balance_low_threshold, :balance_high_threshold, :send_balance_notifications_to,
              :origination_capacity, :termination_capacity, :send_invoices_to
 
   has_one :contractor
@@ -12,11 +13,22 @@ class Api::Rest::Admin::AccountResource < ::BaseResource
 
   filter :name
 
+  def send_invoices_to=(value)
+    _model.send_invoices_to = Array.wrap(value)
+  end
+
+  def send_balance_notifications_to=(value)
+    _model.send_balance_notifications_to = Array.wrap(value)
+  end
+
   def self.updatable_fields(_context)
     [
       :name,
       :min_balance,
       :max_balance,
+      :balance_low_threshold,
+      :balance_high_threshold,
+      :send_balance_notifications_to,
       :vat,
       :origination_capacity,
       :termination_capacity,

--- a/spec/acceptance/rest/admin/api/accounts_spec.rb
+++ b/spec/acceptance/rest/admin/api/accounts_spec.rb
@@ -11,7 +11,7 @@ resource 'Accounts' do
   let(:type) { 'accounts' }
 
   required_params = %i(name min-balance max-balance)
-  optional_params = %i(origination-capacity termination-capacity send-invoices-to, external-id)
+  optional_params = %i(origination-capacity termination-capacity send-invoices-to external-id balance-low-threshold balance-high-threshold send-balance-notifications-to)
 
   required_relationships = %i(contractor timezone)
   optional_relationships = %i(
@@ -43,6 +43,10 @@ resource 'Accounts' do
     let(:name) { 'name' }
     let(:'min-balance') { 1 }
     let(:'max-balance') { 10 }
+    let(:'balance-low-threshold') { 90 }
+    let(:'balance-high-threshold') { 95 }
+    let(:'send-balance-notifications-to') { Billing::Contact.collection.map(&:id) }
+
     let(:timezone) { wrap_relationship(:'timezones', 1) }
     let(:contractor) { wrap_relationship(:contractors, create(:contractor, vendor: true).id) }
 

--- a/spec/controllers/api/rest/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/accounts_controller_spec.rb
@@ -35,6 +35,12 @@ describe Api::Rest::Admin::AccountsController, type: :controller do
 
       it { expect(response.status).to eq(200) }
       it { expect(response_data['id']).to eq(account.id.to_s) }
+      it 'has balance threshold attributes' do
+        expect(response_data['attributes']).to include(
+          'balance-low-threshold',
+          'balance-high-threshold',
+          'send-balance-notifications-to')
+      end
     end
 
     context 'when account does not exist' do
@@ -56,10 +62,15 @@ describe Api::Rest::Admin::AccountsController, type: :controller do
 
     context 'when attributes are valid' do
       let(:attributes) do
-        { name: 'name',
+        {
+          name: 'name',
           'min-balance': 1,
           'external-id': 100,
-          'max-balance': 10 }
+          'max-balance': 10,
+          'balance-low-threshold': 90,
+          'balance-high-threshold': 95,
+          'send-balance-notifications-to': Array.wrap(Billing::Contact.collection.first.id)
+        }
       end
 
       let(:relationships) do
@@ -92,7 +103,15 @@ describe Api::Rest::Admin::AccountsController, type: :controller do
     end
 
     context 'when attributes are valid' do
-      let(:attributes) { { name: 'name' } }
+      let(:attributes) do
+        {
+          name: 'name',
+          'balance-low-threshold': 90,
+          'balance-high-threshold': 95,
+          'send-balance-notifications-to': Billing::Contact.collection.first.id,
+          'send-invoices-to': Billing::Contact.collection.first.id
+        }
+      end
 
       it { expect(response.status).to eq(200) }
       it { expect(account.reload.name).to eq('name') }


### PR DESCRIPTION
[Closes #341]

Admin-API Account-resource new methods:

* balance-low-threshold / Integer /
* balance-high-threshold / Integer /
* send-balance-notifications-to
  / Array of IDs from Billing::Contact.collection /