### PR TITLE
Fix authorization when "allowed_ips" has subnet

### DIFF
--- a/app/models/system/api_access.rb
+++ b/app/models/system/api_access.rb
@@ -53,7 +53,7 @@ class System::ApiAccess < ActiveRecord::Base
   # Auth
 
   def authenticate_ip(remote_ip)
-    allowed_ips.any? { |ip| ip.include?(remote_ip) }
+    allowed_ips.any? { |ip| IPAddr.new(ip).include?(remote_ip) }
   end
 
   def self.from_token_request(request)

--- a/spec/controllers/api/rest/customer/v1/auth_controller_spec.rb
+++ b/spec/controllers/api/rest/customer/v1/auth_controller_spec.rb
@@ -15,11 +15,11 @@ describe Api::Rest::Customer::V1::AuthController, type: :controller do
   before { request.remote_addr = remote_ip }
 
   describe 'POST create' do
+    let(:attributes) { { login: user.login, password: user.password } }
+
     before { post :create, params: { auth: attributes } }
 
     context 'when attributes are valid' do
-      let(:attributes) { { login: user.login, password: user.password } }
-
       it { expect(response.status).to eq(201) }
       it { expect(response_body).to include(:jwt) }
     end
@@ -37,8 +37,21 @@ describe Api::Rest::Customer::V1::AuthController, type: :controller do
     end
 
     context 'when IP is not allowed' do
-      let(:attributes) { { login: user.login, password: user.password } }
       let(:remote_ip) { '127.0.0.2' }
+
+      it { expect(response).to return_404_with_empty_body }
+    end
+
+    context 'Issue#338: 0.0.0.0/0 allows requests from any IP' do
+      let!(:user) { create :api_access, allowed_ips: ['0.0.0.0/0'] }
+      let(:remote_ip) { '104.81.225.117' }
+
+      it { expect(response.status).to eq(201) }
+    end
+
+    context 'Issue#338: request from IP not matches the mask' do
+      let!(:user) { create :api_access, allowed_ips: ['192.168.0.0/24'] }
+      let(:remote_ip) { '192.169.1.1' }
 
       it { expect(response).to return_404_with_empty_body }
     end


### PR DESCRIPTION
[Closes #338]

System::ApiAccess#authenticate_ip

Case:
allowed_ips="0.0.0.0/0" should allow requests from any IP

This error appeared after introducing the change:
- `lib/active_record/connection_adapters/postgresql/oid/inet.rb`