### PR TITLE
Fix redirect_to :back after upgrading Rails 5

### DIFF
--- a/app/admin/billing/invoices.rb
+++ b/app/admin/billing/invoices.rb
@@ -49,7 +49,7 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
         logger.warn { e.message }
         logger.warn { e.backtrace.join("\n") }
         flash[:error] = e.message
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
     end
 
@@ -67,10 +67,10 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
     if resource.approvable?
       resource.approve
       flash[:notice] = 'Invoice approved'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     else
       flash[:notice] = 'Invoice can' 't be approved'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 
@@ -79,10 +79,10 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
     if resource.regenerate_document_allowed?
       resource.regenerate_document
       flash[:notice] = 'Documents regenerated'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     else
       flash[:notice] = 'Documents can''t be regenerated'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 
@@ -93,7 +93,7 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
       send_data doc.data, type: 'application/vnd.oasis.opendocument.text', filename: "#{doc.filename}.odt"
     else
       flash[:notice] = 'File not found'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 
@@ -103,7 +103,7 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
       send_data doc.csv_data, type: 'text/csv', filename: "#{doc.filename}.csv"
     else
       flash[:notice] = 'File not found'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 
@@ -113,7 +113,7 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
       send_data doc.xls_data, type: 'text/csv', filename: "#{doc.filename}.xls"
     else
       flash[:notice] = 'File not found'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 
@@ -123,7 +123,7 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
       send_data doc.pdf_data, type: 'application/pdf', filename: "#{doc.filename}.pdf"
     else
       flash[:notice] = 'File not found'
-      redirect_to(:back)
+      redirect_back fallback_location: root_path
     end
   end
 

--- a/app/admin/equipment/lnp_database.rb
+++ b/app/admin/equipment/lnp_database.rb
@@ -22,7 +22,7 @@ ActiveAdmin.register Lnp::Database do
       Rails.logger.warn { e.backtrace.join("\n") }
       flash[:warning] = e.message
     end
-    redirect_to :back
+    redirect_back fallback_location: root_path
   end
 
   index do

--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -129,7 +129,7 @@ ActiveAdmin.register Routing::Destination, as: 'Destination' do
       resource.clear_quality_alarm
       flash[:notice] = "#{active_admin_config.resource_label} Alarm cleared"
     end
-    redirect_to(:back)
+    redirect_back fallback_location: root_path
   end
 
   action_item :clear_quality_alarm, only: [:show, :edit] do

--- a/app/admin/system/nodes.rb
+++ b/app/admin/system/nodes.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register Node do
         destroy!
       rescue ActiveRecord::ActiveRecordError => e
         flash[:error] = e.message
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
     end
   end

--- a/app/admin/system/sensor.rb
+++ b/app/admin/system/sensor.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register System::Sensor do
         destroy!
       rescue ActiveRecord::ActiveRecordError => e
         flash[:error] = e.message
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
     end
   end

--- a/app/admin/system/smtp_connection.rb
+++ b/app/admin/system/smtp_connection.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register System::SmtpConnection do
       Rails.logger.warn { e.backtrace.join("\n") }
       flash[:warning] = e.message
     end
-    redirect_to :back
+    redirect_back fallback_location: root_path
   end
 
   index do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_back(default = root_url)
     if !request.env["HTTP_REFERER"].blank? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
-      redirect_to :back
+      redirect_back fallback_location: root_path
     else
       redirect_to default
     end

--- a/app/controllers/concerns/rescuers.rb
+++ b/app/controllers/concerns/rescuers.rb
@@ -10,12 +10,12 @@ module Concerns::Rescuers
 
     # rescue_from ImportDisabled do |e|
     #   flash[:notice] = e.message
-    #   redirect_to :back
+    #   redirect_back fallback_location: root_path
     # end
 
     rescue_from ApplicationController::ImportDisabled do |e|
       flash[:notice] = e.message
-      redirect_to :back
+      redirect_back fallback_location: root_path
     end
 
 

--- a/lib/resource_dsl/acts_as_batch_changeable.rb
+++ b/lib/resource_dsl/acts_as_batch_changeable.rb
@@ -44,7 +44,7 @@ module ResourceDSL
             flash[:notice] = "#{params[:attribute].humanize} was successfully changed"
           end
         end
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
     end
   end

--- a/lib/resource_dsl/acts_as_delayed_job_lock.rb
+++ b/lib/resource_dsl/acts_as_delayed_job_lock.rb
@@ -16,7 +16,7 @@ module ResourceDSL
         def destroy
           if Delayed::Job.where(queue: :batch_actions, failed_at: nil).any?
             flash[:error] = I18n.t('flash.actions.batch_actions.destroying_prohibited')
-            redirect_to :back
+            redirect_back fallback_location: root_path
           else
             super
           end

--- a/lib/resource_dsl/acts_as_import.rb
+++ b/lib/resource_dsl/acts_as_import.rb
@@ -63,11 +63,11 @@ module ResourceDSL
       # before_action only: [:import] do
       #   flash[:notice] = 'Import in progress'
       #   if Importing::ImportingDelayedJob.jobs?
-      #     redirect_to :back and return
+      #     redirect_back(fallback_location: root_path) and return
       #   end
       #   if options[:resource_class].any?
       #     flash[:notice] = 'Now your preview data is ready to be imported. Choose one of the actions above'
-      #     redirect_to :back
+      #     redirect_back fallback_location: root_path
       #   end
       # end
 

--- a/lib/resource_dsl/acts_as_import_preview.rb
+++ b/lib/resource_dsl/acts_as_import_preview.rb
@@ -40,7 +40,7 @@ module ResourceDSL
       collection_action :batch_update do
         acts_as_import_resource_class.run_in_background(@paper_trail_info, :for_update)
         flash[:notice] = 'You have just run importing "Only update" in the background process, wait until it finishes'
-        redirect_to :back
+        redirect_back fallback_location: root_path
 #        redirect_to redirect_proc
       end
 
@@ -48,14 +48,14 @@ module ResourceDSL
         acts_as_import_resource_class.run_in_background(@paper_trail_info)
         flash[:notice] = 'You have just run importing "Create an update" in the background process, wait until it finishes'
 #        redirect_to redirect_proc
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
 
       collection_action :batch_insert do
         acts_as_import_resource_class.run_in_background(@paper_trail_info, :for_create)
         flash[:notice] = 'You have just run importing "Create new once" in the background process, wait until it finishes'
 #        redirect_to redirect_proc
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
 
       before_action do

--- a/lib/resource_dsl/acts_as_lock.rb
+++ b/lib/resource_dsl/acts_as_lock.rb
@@ -9,7 +9,7 @@ module ResourceDSL
           resource.unlock
           flash[:notice] = "#{active_admin_config.resource_label} unlocked"
         end
-        redirect_to(:back)
+        redirect_back fallback_location: root_path
       end
 
       action_item :unlock, only: [:show, :edit] do

--- a/lib/resource_dsl/acts_as_safe_destroy.rb
+++ b/lib/resource_dsl/acts_as_safe_destroy.rb
@@ -17,7 +17,7 @@ module ResourceDSL
                                      plural_model: active_admin_config.plural_resource_label(count: selected_ids.count).downcase)
         rescue StandardError => e
           flash[:error] = e.message
-          redirect_to :back
+          redirect_back fallback_location: root_path
         end
       end
 

--- a/lib/resource_dsl/acts_as_stat.rb
+++ b/lib/resource_dsl/acts_as_stat.rb
@@ -54,7 +54,7 @@ module ResourceDSL
           resource.statistic.destroy if resource.statistic
           flash[:notice] = "#{active_admin_config.resource_label}'s statistic was successfully truncated"
         end
-        redirect_to(:back)
+        redirect_back fallback_location: root_path
       end
 
     end
@@ -68,7 +68,7 @@ module ResourceDSL
           resource.quality_stats.delete_all if resource.quality_stats
           flash[:notice] = "#{active_admin_config.resource_label}'s statistic was successfully truncated"
         end
-        redirect_to(:back)
+        redirect_back fallback_location: root_path
       end
 
       sidebar 'Short window stats', only: [:show, :edit] do

--- a/lib/resource_dsl/acts_as_status.rb
+++ b/lib/resource_dsl/acts_as_status.rb
@@ -34,7 +34,7 @@ module ResourceDSL
           resource.save!
           flash[:notice] = "#{active_admin_config.resource_label} was successfully enabled"
         end
-        redirect_to(:back)
+        redirect_back fallback_location: root_path
       end
 
 
@@ -45,7 +45,7 @@ module ResourceDSL
           resource.save!
           flash[:notice] = "#{active_admin_config.resource_label} was successfully disabled"
         end
-        redirect_to(:back)
+        redirect_back fallback_location: root_path
       end
 
 

--- a/lib/resource_dsl/batch_action_update.rb
+++ b/lib/resource_dsl/batch_action_update.rb
@@ -17,7 +17,7 @@ module ResourceDSL
           flash[:error] = e.message
           Rails.logger.warn "UCS#batch_assign_to_group raise exception: #{e.message}\n#{e.backtrace.join("\n")}"
         end
-        redirect_to :back
+        redirect_back fallback_location: root_path
       end
 
     end


### PR DESCRIPTION
[Closes #347]

`redirect_to :back` replaced with `redirect_back` in rails 5