### PR TITLE
Test invoice index and new page

### DIFF
--- a/lib/active_admin/views/footer.rb
+++ b/lib/active_admin/views/footer.rb
@@ -2,12 +2,10 @@ module ActiveAdmin
   module Views
     class Footer < Component
 
-     private
+      private
 
       def powered_by_message
-
-        para "Copyright #{Date.today.year} Yeti Admin ver: #{Yeti::Application.config.app_build_info.fetch('version', 'unknown')}. Routing ver #{Yeti::ActiveRecord::DB_VER}. CDR ver #{Cdr::Base::DB_VER}.".html_safe
-
+        "Copyright #{Date.today.year} Yeti Admin ver: #{Yeti::Application.config.app_build_info.fetch('version', 'unknown')}. Routing ver #{Yeti::ActiveRecord::DB_VER}. CDR ver #{Cdr::Base::DB_VER}."
       end
 
     end

--- a/spec/factories/billing/invoice.rb
+++ b/spec/factories/billing/invoice.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+  factory :invoice, class: Billing::Invoice do
+
+    transient do
+      _acc { create(:account) }
+    end
+
+    trait :manual do
+      vendor_invoice { false }
+      start_date     { 7.days.ago.utc }
+      end_date       { 1.day.ago.utc }
+      type_id        { Billing::InvoiceType::MANUAL }
+      account        { _acc }
+      contractor     { _acc.contractor }
+    end
+  end
+end

--- a/spec/features/destinations/create_destination_spec.rb
+++ b/spec/features/destinations/create_destination_spec.rb
@@ -27,7 +27,7 @@ describe 'Create new Destinations', type: :feature do
     end
 
     it 'creates new Dialpeers and show it' do
-      page.find('input[type=submit]').click
+      click_on_submit
       expect(page).to have_css('body.show.destinations')
 
       expect(Routing::Destination.last).to have_attributes(

--- a/spec/features/invoices/index_invoices_feature_spec.rb
+++ b/spec/features/invoices/index_invoices_feature_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Index Invoices', type: :feature do
+  include_context :login_as_admin
+
+  include_examples :test_index_table_exist do
+    before do
+      @item = create(:invoice, :manual)
+      visit invoices_path
+    end
+  end
+end

--- a/spec/features/invoices/new_invoice_feature_spec.rb
+++ b/spec/features/invoices/new_invoice_feature_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'Create new Invoice', type: :feature, js: true do
+  include_context :login_as_admin
+
+  before do
+    @account = create(:account)
+    @contractor = @account.contractor
+
+    visit new_invoice_path
+  end
+
+  include_context :fill_form, 'new_billing_invoice' do
+    let(:attributes) do
+      {
+        vendor_invoice: true,
+        contractor_id: -> {
+          chosen_pick('#billing_invoice_contractor_id+div', text: @contractor.name)
+        },
+        account_id: -> {
+          chosen_pick('#billing_invoice_account_id+div', text: @account.name)
+        },
+        start_date: 1.day.ago.utc,
+        end_date: 1.hour.ago.utc
+      }
+    end
+
+    it 'creates new invoice succesfully' do
+      click_on_submit
+      expect(page).to have_css('.flash_notice', text: 'Invoice was successfully created.')
+
+      expect(Billing::Invoice.last).to have_attributes(
+        vendor_invoice: attributes[:vendor_invoice],
+        contractor_id: @contractor.id,
+        account_id: @account.id,
+        start_date: be_within(1.second).of(attributes[:start_date]),
+        end_date: be_within(1.second).of(attributes[:end_date])
+      )
+    end
+  end
+
+end

--- a/spec/support/contexts/fill_form.rb
+++ b/spec/support/contexts/fill_form.rb
@@ -16,6 +16,8 @@ RSpec.shared_context :fill_form do |form_id|
     tag_name = field.tag_name
 
     case
+    when value.is_a?(Proc)
+      value.call
     when value.is_a?(Array) && tag_name == 'select'
       value.each { |v| select(v, from: id) }
     when tag_name == 'input' && field['type'] == 'checkbox'
@@ -25,6 +27,10 @@ RSpec.shared_context :fill_form do |form_id|
     else
       field.set(value)
     end
+  end
+
+  def click_on_submit
+    page.find('input[type=submit]').click
   end
 
 end

--- a/spec/support/examples/test_index_table_exist.rb
+++ b/spec/support/examples/test_index_table_exist.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples :test_index_table_exist do
+
+  it 'has record' do
+    expect(page).to have_css('.resource_id_link', text: @item.id)
+  end
+
+end

--- a/spec/support/helpers/chosen.rb
+++ b/spec/support/helpers/chosen.rb
@@ -10,6 +10,11 @@ module Helpers
       end
       find('.active-result', text: search, exact_text: true).click
     end
+
+    def chosen_pick(css_selector, text:)
+      find(css_selector).click
+      find('ul.chosen-results li.active-result', text: text).click
+    end
   end
 end
 


### PR DESCRIPTION
This is a example of "How to write tests for New and Index pages".

Take an look at `spec/features/invoices/new_invoice_feature_spec.rb`

0. This feature-test requires JavaScript to be enabled `js: true`. Because this form has "chosen"-select with AJAX loading of Accounts. Try avoid `js: true` because it is slow... :snail: ...
1. In `before` block we prepare database records needed for New-form.
2. `include_context :fill_form, 'new_billing_invoice'`

    The "new_billing_invoice" is the HTML-id of a form: `<form id="new_billing_invoice">`
3. `let(:attributes) do` is a key-value structure, where key is a HTML id of and input-tag (excluding form-prefix).
    For example: `<input id="billing_invoice_start_date" name="billing_invoice[start_date]" ...>`
    the ID would be `start_date` taken from "billing_invoice_start_date" string.
4. The test case `it 'creates new invoice succesfully'` performs form submission and check if page has the success-massage: `Invoice was successfully created`.
    Then, if you with, you can take newly created record(Billing::Invoice.last) and validate each attribute. Or just check if it was created, like this: `expect(Billing::Invoice.count).to eq(1)`