### PR TITLE
Update README with Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ https://www.postgresql.org/download/linux/debian/
 You need to install:
 
 ```sh
-$ sudo apt-get install postgresql-9.4 postgresql-contrib-9.4 postgresql-9.4-prefix postgresql-9.4-pgq3 skytools3 skytools3-ticker
-$ sudo apt-get install -t stretch-pgdg libpq-dev
+sudo apt-get install postgresql-9.4 postgresql-contrib-9.4 postgresql-9.4-prefix postgresql-9.4-pgq3 skytools3 skytools3-ticker
+sudo apt-get install -t stretch-pgdg libpq-dev
 ```
 In addition you need to compile or install from .deb package Yeti PostgreSQL extension https://github.com/yeti-switch/yeti-pg-ext
 
 Then fork and clone yeti-web repository and run:
 
 ```sh
-$ bundle install
+bundle install
 ```
 
 Then create `config/database.yml`, example is `database.yml.example`. Notice this project uses two databases main "yeti" and second database "cdr"
@@ -29,32 +29,32 @@ Then create `config/database.yml`, example is `database.yml.example`. Notice thi
 And run command to create development database:
 
 ```sh
-$ bundle exec rake db:create db:structure:load db:migrate
-$ bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
-$ bundle exec rake db:seed
+bundle exec rake db:create db:structure:load db:migrate
+bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
+bundle exec rake db:seed
 ```
 
-Then start rails server `$ bundle exec rails s` and login to http://localhost:3000/ with
+Then start rails server `bundle exec rails s` and login to http://localhost:3000/ with
 login `admin` and password `111111`
 
 Then prepare test database(do not use db:test:prepare).
 
 ```sh
-$ RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
-$ RAILS_ENV=test bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
-$ RAILS_ENV=test bundle exec rake db:seed
+RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
+RAILS_ENV=test bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
+RAILS_ENV=test bundle exec rake db:seed
 ```
 
 This project has CDR-database, configured as SecondDatabase
 https://github.com/customink/secondbase
-And all commands should be run explicitryl by calling "db:second_base:*" commands.
+And all commands should be run explicitly by calling "db:second_base:*" commands.
 
 NOTICE: Test DB needs seeds, actually only PGQ seed.
 
 And run tests:
 
 ```sh
-$ bundle exec rspec
+bundle exec rspec
 ```
 
 # Migrations
@@ -79,3 +79,34 @@ If you do not want to migrate with stops, use env-variable IGNORE_STOPS=true
 ```sh
 IGNORE_STOPS=true bundle exec rake db:migrate
 ```
+
+
+## Use Docker Postgres for development
+
+For development purpouse it is convinient to use PostgreSQL from Docker image. Here is the instruction how to set it up-and-running:
+
+* Install Docker(Ubuntu example)
+
+  [Install Docker on Ubuntu 18.10](https://www.thecodecampus.de/blog/install-docker-on-ubuntu-18-10/)
+
+* Run following commands in terminal from `yeti-web` projects directory
+
+  ```
+  sudo docker build -t yeti_postgres -f ci/pgsql.Dockerfile .
+  ```
+
+* Start the Postgres Server using docker image, with remapped port to 3010 and volume "yetiPgData" to persist data after docker container stops:
+
+  ```
+  sudo docker run -p 3010:5432 --volume yetiPgData:/var/lib/postgresql yeti_postgres
+  ```
+
+* Update `config/database.yml` with
+
+  ```yml
+  username: postgres
+  password:
+  port: 3010
+  ```
+
+* Initialize database with instructions described in [Contributing, Development setup](#contributing-development-setup) section(db:create, db:structure:load, etc.)


### PR DESCRIPTION
Background:
"Yeti-web" requires specific version of PostgreSQL with extensions.
It is hard to install it properly on modern Linux distributives.

Solution:
Use Docker "yeti-postgres-image" for local development.

Changes:
Add to README.md step-by-step instruction about how to use Postgres database inside
Docker for development process.