### PR TITLE
Improvement. Add documentations for filters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails', '4.8.0'
   gem 'rspec-rails'
-  gem 'rspec_api_documentation', '~> 5.0.0'
+  gem 'rspec_api_documentation', '~> 6.1.0'
   gem 'rubocop', require: false
   gem 'simplecov', require: false, group: :test
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       compass (~> 1.0.0)
       sass-rails (< 5.1)
       sprockets (< 4.0)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -305,7 +305,7 @@ GEM
       actionpack (>= 4.1)
       activesupport (>= 4.1)
     hashdiff (0.3.8)
-    i18n (1.5.2)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.9.0)
       actionpack (>= 4.2, < 5.3)
@@ -364,7 +364,7 @@ GEM
     msgpack (1.2.6)
     multi_json (1.13.1)
     multi_test (0.1.2)
-    mustache (1.0.5)
+    mustache (1.1.0)
     net-ldap (0.16.1)
     net_tcp_client (2.0.1)
     netstring (0.0.3)
@@ -451,7 +451,7 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rspec_api_documentation (5.0.0)
+    rspec_api_documentation (6.1.0)
       activesupport (>= 3.0.0)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0)
@@ -601,7 +601,7 @@ DEPENDENCIES
   ransack
   responders
   rspec-rails
-  rspec_api_documentation (~> 5.0.0)
+  rspec_api_documentation (~> 6.1.0)
   rubocop
   sass-globbing
   sass-rails

--- a/spec/acceptance/rest/admin/api/accounts_spec.rb
+++ b/spec/acceptance/rest/admin/api/accounts_spec.rb
@@ -21,6 +21,8 @@ resource 'Accounts' do
   ]
 
   get '/api/rest/admin/accounts' do
+    jsonapi_filters Api::Rest::Admin::AccountResource
+
     before { create_list(:account, 2) }
 
     example_request 'get listing' do

--- a/spec/acceptance/rest/admin/api/codec_groups_spec.rb
+++ b/spec/acceptance/rest/admin/api/codec_groups_spec.rb
@@ -15,6 +15,8 @@ resource 'Codec groups' do
   get '/api/rest/admin/codec-groups' do
     before { create_list(:codec_group, 2) }
 
+    jsonapi_filters Api::Rest::Admin::CodecGroupResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/contacts_spec.rb
+++ b/spec/acceptance/rest/admin/api/contacts_spec.rb
@@ -22,6 +22,8 @@ resource 'Contacts' do
   get '/api/rest/admin/contacts' do
     before { create_list(:contact, 2) }
 
+    jsonapi_filters Api::Rest::Admin::ContactResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/contractors_spec.rb
+++ b/spec/acceptance/rest/admin/api/contractors_spec.rb
@@ -19,6 +19,8 @@ resource 'Contractors' do
   get '/api/rest/admin/contractors' do
     before { create_list(:contractor, 2, vendor: true) }
 
+    jsonapi_filters Api::Rest::Admin::ContractorResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/destination_next_rates_spec.rb
+++ b/spec/acceptance/rest/admin/api/destination_next_rates_spec.rb
@@ -23,6 +23,8 @@ resource 'Destination next rates' do
   get '/api/rest/admin/destination-next-rates' do
     before { create_list(:destination_next_rate, 2, destination: destination) }
 
+    jsonapi_filters Api::Rest::Admin::DestinationNextRateResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/destination_rate_policies_spec.rb
+++ b/spec/acceptance/rest/admin/api/destination_rate_policies_spec.rb
@@ -13,6 +13,8 @@ resource 'Destination rate policies' do
   let(:type) { 'destination-rate-policies' }
 
   get '/api/rest/admin/destination-rate-policies' do
+    jsonapi_filters Api::Rest::Admin::DestinationRatePolicyResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/destinations_spec.rb
+++ b/spec/acceptance/rest/admin/api/destinations_spec.rb
@@ -27,6 +27,8 @@ resource 'Destinations' do
   get '/api/rest/admin/destinations' do
     before { create_list(:destination, 2) }
 
+    jsonapi_filters Api::Rest::Admin::CodecGroupResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/dialpeer_next_rates_spec.rb
+++ b/spec/acceptance/rest/admin/api/dialpeer_next_rates_spec.rb
@@ -23,6 +23,8 @@ resource 'Dialpeer next rates' do
   get '/api/rest/admin/dialpeer-next-rates' do
     before { create_list(:dialpeer_next_rate, 2, dialpeer: dialpeer) }
 
+    jsonapi_filters Api::Rest::Admin::DialpeerNextRateResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/dialpeers_spec.rb
+++ b/spec/acceptance/rest/admin/api/dialpeers_spec.rb
@@ -29,6 +29,8 @@ resource 'Dialpeers' do
   get '/api/rest/admin/dialpeers' do
     before { create_list(:dialpeer, 2) }
 
+    jsonapi_filters Api::Rest::Admin::DialpeerResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/disconnect_policies_spec.rb
+++ b/spec/acceptance/rest/admin/api/disconnect_policies_spec.rb
@@ -15,6 +15,8 @@ resource 'Disconnect policies' do
   get '/api/rest/admin/disconnect-policies' do
     before { create_list(:disconnect_policy, 2) }
 
+    jsonapi_filters Api::Rest::Admin::DisconnectPolicyResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/diversion_policies_spec.rb
+++ b/spec/acceptance/rest/admin/api/diversion_policies_spec.rb
@@ -13,6 +13,8 @@ resource 'Diversion policies' do
   let(:type) { 'diversion-policies' }
 
   get '/api/rest/admin/diversion-policies' do
+    jsonapi_filters Api::Rest::Admin::DiversionPolicyResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/dump_levels_spec.rb
+++ b/spec/acceptance/rest/admin/api/dump_levels_spec.rb
@@ -13,6 +13,8 @@ resource 'Dump levels' do
   let(:type) { 'dump-levels' }
 
   get '/api/rest/admin/dump-levels' do
+    jsonapi_filters Api::Rest::Admin::DumpLevelResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/filter_types_spec.rb
+++ b/spec/acceptance/rest/admin/api/filter_types_spec.rb
@@ -13,6 +13,8 @@ resource 'Filter types' do
   let(:type) { 'filter-types' }
 
   get '/api/rest/admin/filter-types' do
+    jsonapi_filters Api::Rest::Admin::FilterTypeResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/gateway_groups_spec.rb
+++ b/spec/acceptance/rest/admin/api/gateway_groups_spec.rb
@@ -15,6 +15,8 @@ resource 'Gateway groups' do
   get '/api/rest/admin/gateway-groups' do
     before { create_list(:gateway_group, 2) }
 
+    jsonapi_filters Api::Rest::Admin::GatewayGroupResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/gateways_spec.rb
+++ b/spec/acceptance/rest/admin/api/gateways_spec.rb
@@ -41,6 +41,8 @@ resource 'Gateways' do
   get '/api/rest/admin/gateways' do
     before { create_list(:gateway, 2) }
 
+    jsonapi_filters Api::Rest::Admin::GatewayResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/payments_spec.rb
+++ b/spec/acceptance/rest/admin/api/payments_spec.rb
@@ -15,6 +15,8 @@ resource 'Payments' do
   get '/api/rest/admin/payments' do
     before { create_list(:payment, 2) }
 
+    jsonapi_filters Api::Rest::Admin::PaymentResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/pops_spec.rb
+++ b/spec/acceptance/rest/admin/api/pops_spec.rb
@@ -13,9 +13,10 @@ resource 'Pops' do
   let(:type) { 'pops' }
 
   get '/api/rest/admin/pops' do
-    before do
-      Pop.create(name: 'first')
-    end
+    before { Pop.create(name: 'first') }
+
+    jsonapi_filters Api::Rest::Admin::PopResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/rateplans_spec.rb
+++ b/spec/acceptance/rest/admin/api/rateplans_spec.rb
@@ -17,6 +17,8 @@ resource 'Rateplans' do
   get '/api/rest/admin/rateplans' do
     before { create_list(:rateplan, 2) }
 
+    jsonapi_filters Api::Rest::Admin::RateplanResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/routing/area_prefixes_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/area_prefixes_spec.rb
@@ -15,7 +15,9 @@ resource 'Routing AreaPrefix' do
   required_relationships = %i[area]
   optional_relationships = %i[]
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'area-prefixes'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'area-prefixes',
+                                          resource: Api::Rest::Admin::Routing::AreaPrefixResource
   include_context :acceptance_delete, namespace: 'routing', type: 'area-prefixes'
 
   post '/api/rest/admin/routing/area-prefixes' do

--- a/spec/acceptance/rest/admin/api/routing/area_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/area_spec.rb
@@ -9,5 +9,7 @@ resource 'Routing Area' do
   let(:collection) { create_list(:area, 2) }
   let(:record) { collection.first }
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'areas'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'areas',
+                                          resource: Api::Rest::Admin::Routing::AreaResource
 end

--- a/spec/acceptance/rest/admin/api/routing/numberlist_actions_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/numberlist_actions_spec.rb
@@ -3,11 +3,13 @@
 require 'spec_helper'
 require 'rspec_api_documentation/dsl'
 
-resource 'Routin NumberlistActions' do
+resource 'Routing NumberlistActions' do
   include_context :acceptance_admin_user
 
   let(:collection) { Routing::NumberlistAction.all }
   let(:record) { Routing::NumberlistAction.take }
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'numberlist-actions'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'numberlist-actions',
+                                          resource: Api::Rest::Admin::Routing::NumberlistActionResource
 end

--- a/spec/acceptance/rest/admin/api/routing/numberlist_items_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/numberlist_items_spec.rb
@@ -24,7 +24,9 @@ resource 'Routing NumberlistItems' do
     tag-action
   ]
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'numberlist-items'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'numberlist-items',
+                                          resource: Api::Rest::Admin::Routing::NumberlistItemResource
   include_context :acceptance_delete, namespace: 'routing', type: 'numberlist-items'
 
   post '/api/rest/admin/routing/numberlist-items' do

--- a/spec/acceptance/rest/admin/api/routing/numberlists_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/numberlists_spec.rb
@@ -23,7 +23,9 @@ resource 'Numberlist' do
     tag-action
   ]
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'numberlists'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'numberlists',
+                                          resource: Api::Rest::Admin::Routing::NumberlistResource
   include_context :acceptance_delete, namespace: 'routing', type: 'numberlists'
 
   post '/api/rest/admin/routing/numberlists' do

--- a/spec/acceptance/rest/admin/api/routing/rate_profit_control_modes_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/rate_profit_control_modes_spec.rb
@@ -13,6 +13,7 @@ resource 'Rate profit control modes' do
   let(:type) { 'rate-profit-control-modes' }
 
   get '/api/rest/admin/routing/rate-profit-control-modes' do
+    jsonapi_filters Api::Rest::Admin::Routing::RateProfitControlModeResource
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/routing/routeset_discriminators_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/routeset_discriminators_spec.rb
@@ -15,6 +15,8 @@ resource 'Routeset discriminators' do
   get '/api/rest/admin/routing/routeset-discriminators' do
     before { create_list(:routeset_discriminator, 2) }
 
+    jsonapi_filters Api::Rest::Admin::Routing::RoutesetDiscriminatorResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/routing/routing_tag_detection_rules_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/routing_tag_detection_rules_spec.rb
@@ -23,7 +23,9 @@ resource 'Routing RoutingTagDetectionRules' do
   required_relationships = %i[]
   optional_relationships = %i[src-area dst-area tag-action routing-tag-modes]
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'routing-tag-detection-rules'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'routing-tag-detection-rules',
+                                          resource: Api::Rest::Admin::Routing::RoutingTagDetectionRuleResource
   include_context :acceptance_delete, namespace: 'routing', type: 'routing-tag-detection-rules'
 
   post '/api/rest/admin/routing/routing-tag-detection-rules' do

--- a/spec/acceptance/rest/admin/api/routing/routing_tag_modes_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/routing_tag_modes_spec.rb
@@ -9,5 +9,7 @@ resource 'Routing RoutingTagMode' do
   let(:collection) { Routing::RoutingTagMode.all }
   let(:record) { Routing::RoutingTagMode.take }
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'routing-tag-modes'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'routing-tag-modes',
+                                          resource: Api::Rest::Admin::Routing::RoutingTagModeResource
 end

--- a/spec/acceptance/rest/admin/api/routing/routing_tags_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/routing_tags_spec.rb
@@ -19,7 +19,9 @@ resource 'Routing RoutingTag' do
 
   optional_relationships = %i[]
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'routing-tags'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'routing-tags',
+                                          resource: Api::Rest::Admin::Routing::RoutingTagResource
   include_context :acceptance_delete, namespace: 'routing', type: 'routing-tags'
 
   post '/api/rest/admin/routing/routing-tags' do

--- a/spec/acceptance/rest/admin/api/routing/tag_actions_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing/tag_actions_spec.rb
@@ -9,5 +9,7 @@ resource 'Routing TagAction' do
   let(:collection) { Routing::TagAction.all }
   let(:record) { Routing::TagAction.take  }
 
-  include_context :acceptance_index_show, namespace: 'routing', type: 'tag-actions'
+  include_context :acceptance_index_show, namespace: 'routing',
+                                          type: 'tag-actions',
+                                          resource: Api::Rest::Admin::Routing::TagActionResource
 end

--- a/spec/acceptance/rest/admin/api/routing_groups_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing_groups_spec.rb
@@ -15,6 +15,8 @@ resource 'Routing groups' do
   get '/api/rest/admin/routing-groups' do
     before { create_list(:routing_group, 2) }
 
+    jsonapi_filters Api::Rest::Admin::RoutingGroupResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/routing_plans_spec.rb
+++ b/spec/acceptance/rest/admin/api/routing_plans_spec.rb
@@ -15,6 +15,8 @@ resource 'Routing plans' do
   get '/api/rest/admin/routing-plans' do
     before { create_list(:routing_plan, 2) }
 
+    jsonapi_filters Api::Rest::Admin::RoutingPlanResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/sdp_c_locations_spec.rb
+++ b/spec/acceptance/rest/admin/api/sdp_c_locations_spec.rb
@@ -13,6 +13,8 @@ resource 'Sdp c locations' do
   let(:type) { 'sdp-c-locations' }
 
   get '/api/rest/admin/sdp-c-locations' do
+    jsonapi_filters Api::Rest::Admin::SdpCLocationResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/session_refresh_methods_spec.rb
+++ b/spec/acceptance/rest/admin/api/session_refresh_methods_spec.rb
@@ -13,6 +13,8 @@ resource 'Session refresh methods' do
   let(:type) { 'session-refresh-methods' }
 
   get '/api/rest/admin/session-refresh-methods' do
+    jsonapi_filters Api::Rest::Admin::SessionRefreshMethodResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/acceptance/rest/admin/api/sortings_spec.rb
+++ b/spec/acceptance/rest/admin/api/sortings_spec.rb
@@ -13,9 +13,10 @@ resource 'Sortings' do
   let(:type) { 'sortings' }
 
   get '/api/rest/admin/sortings' do
-    before do
-      Sorting.create(name: 'name')
-    end
+    before { Sorting.create(name: 'name') }
+
+    jsonapi_filters Api::Rest::Admin::SortingResource
+
     example_request 'get listing' do
       expect(status).to eq(200)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,8 @@ RspecApiDocumentation.configure do |config|
   config.docs_dir = Rails.root.join('doc', 'api', 'admin')
   config.api_name = 'Admin API'
 
+  config.format = %i[slate open_api]
+
   config.define_group :customer_v1 do |c|
     c.exclusion_filter = :admin # must be overriden to anything
     c.filter = :customer_v1

--- a/spec/support/contexts/acceptance/acceptance_index_show.rb
+++ b/spec/support/contexts/acceptance/acceptance_index_show.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_context :acceptance_index_show do |namespace: nil, type:|
+RSpec.shared_context :acceptance_index_show do |namespace: nil, type:, resource: nil|
   # let(:collection) { ModelClass.all }
   # let(:record) { ModelClass.take  }
 
@@ -14,6 +14,10 @@ RSpec.shared_context :acceptance_index_show do |namespace: nil, type:|
 
   get resource_path do
     before { collection }
+
+    if resource.present?
+      jsonapi_filters resource
+    end
 
     example_request 'get listing' do
       expect(status).to eq(200)

--- a/spec/support/helpers/jsonapi_parameters.rb
+++ b/spec/support/helpers/jsonapi_parameters.rb
@@ -15,7 +15,7 @@ module Helpers
       'start' => 'start',
       'end' => 'end',
       'cont any' => 'contain any'
-    }
+    }.freeze
     def jsonapi_attributes(required, optional)
       required.each { |e| jsonapi_attribute(e, required: true) }
       optional.each { |e| jsonapi_attribute(e) }


### PR DESCRIPTION
1. Filters (like `filter[name]`) were added to parameters in acceptance specs. 
2. Change output format for `rspec-api-documentation` to slate and open-api

**How to test it**
1. Run `rake docs:generate`
2. Download and install `slate`. https://github.com/lord/slate#getting-started-with-slate
3. Move generated `.md` files to `/path/to/slate/source`
4. Run slate