### PR TITLE
fix invoice generation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --order defined
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,6 @@ jobs:
       name: Rubocop and Bundle Audit
       script:
         - bundle install --jobs=3 --retry=3 --deployment
-        - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
-        - RAILS_ENV=test bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
-        - RAILS_ENV=test bundle exec rake db:seed
         - bundle exec rubocop -P
         - bundle exec rake bundle:audit
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/jobs/jobs/invoice.rb
+++ b/app/jobs/jobs/invoice.rb
@@ -35,11 +35,11 @@ module Jobs
     end
 
     def customers_accounts
-      Account.where('customer_invoice_period_id is not null and next_customer_invoice_at < NOW()').pluck(:id)
+      Account.where('customer_invoice_period_id is not null and next_customer_invoice_at < ?', Time.now.utc).pluck(:id)
     end
 
     def vendors_accounts
-      Account.where('vendor_invoice_period_id is not null and next_vendor_invoice_at < NOW()').pluck(:id)
+      Account.where('vendor_invoice_period_id is not null and next_vendor_invoice_at < ?', Time.now.utc).pluck(:id)
     end
 
     def serialize_time(time)

--- a/app/jobs/jobs/invoice.rb
+++ b/app/jobs/jobs/invoice.rb
@@ -9,7 +9,11 @@ module Jobs
           start_date = account.last_customer_invoice_date
           end_date = account.next_customer_invoice_at
           invoice_type = account.next_customer_invoice_type_id
-          generate_invoice(account.id, start_date, end_date, invoice_type, false)
+          Worker::GenerateInvoiceJob.perform_later account_id: account.id,
+                                                   start_date: serialize_time(start_date),
+                                                   end_date: serialize_time(end_date),
+                                                   invoice_type_id: invoice_type,
+                                                   is_vendor: false
           account.schedule_next_customer_invoice!
         end
       end
@@ -20,7 +24,11 @@ module Jobs
           start_date = account.last_vendor_invoice_date
           end_date = account.next_vendor_invoice_at
           invoice_type = account.next_vendor_invoice_type_id
-          generate_invoice(account.id, start_date, end_date, invoice_type, true)
+          Worker::GenerateInvoiceJob.perform_later account_id: account.id,
+                                                   start_date: serialize_time(start_date),
+                                                   end_date: serialize_time(end_date),
+                                                   invoice_type_id: invoice_type,
+                                                   is_vendor: true
           account.schedule_next_vendor_invoice!
         end
       end
@@ -34,30 +42,8 @@ module Jobs
       Account.where('vendor_invoice_period_id is not null and next_vendor_invoice_at < NOW()').pluck(:id)
     end
 
-    def generate_invoice(acc_id, start_dt, end_dt, invoice_type, is_vendor)
-      account = begin
-                  Account.find(acc_id)
-                rescue StandardError
-                  nil
-                end
-      if account
-
-        inv = Billing::Invoice.new(
-          contractor_id: account.contractor_id,
-          account_id: account.id,
-          start_date: start_dt,
-          vendor_invoice: is_vendor,
-          end_date: end_dt,
-          type_id: invoice_type
-        )
-        account.transaction do
-          InvoiceGenerator.new(inv).save!
-        end
-      else
-        # log
-      end
+    def serialize_time(time)
+      time.utc.to_s
     end
-
-    handle_asynchronously :generate_invoice
   end
 end

--- a/app/jobs/worker/cdr_export_job.rb
+++ b/app/jobs/worker/cdr_export_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Worker
-  class CdrExportJob < ActiveJob::Base
+  class CdrExportJob < ::ApplicationJob
     queue_as 'cdr_export'
 
     def perform(cdr_export_id)

--- a/app/jobs/worker/generate_invoice_job.rb
+++ b/app/jobs/worker/generate_invoice_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Worker
+  class GenerateInvoiceJob < ::ApplicationJob
+    queue_as 'invoice'
+
+    def perform(account_id:, start_date:, end_date:, invoice_type_id:, is_vendor:)
+      account = find_account(account_id)
+      return if account.nil?
+
+      inv = Billing::Invoice.new contractor_id: account.contractor_id,
+                                 account_id: account.id,
+                                 start_date: start_date,
+                                 vendor_invoice: is_vendor,
+                                 end_date: end_date,
+                                 type_id: invoice_type_id
+      account.transaction do
+        InvoiceGenerator.new(inv).save!
+      end
+    end
+
+    def find_account(account_id)
+      Account.find(account_id)
+    rescue ActiveRecord::RecordNotFound => _
+      nil
+    end
+  end
+end

--- a/app/jobs/worker/ping_callback_url_job.rb
+++ b/app/jobs/worker/ping_callback_url_job.rb
@@ -3,7 +3,7 @@
 require 'net/http'
 
 module Worker
-  class PingCallbackUrlJob < ActiveJob::Base
+  class PingCallbackUrlJob < ::ApplicationJob
     class TryAgainError < RuntimeError
     end
 

--- a/app/jobs/worker/remove_cdr_export_file_job.rb
+++ b/app/jobs/worker/remove_cdr_export_file_job.rb
@@ -3,7 +3,7 @@
 require 'net/http'
 
 module Worker
-  class RemoveCdrExportFileJob < ActiveJob::Base
+  class RemoveCdrExportFileJob < ::ApplicationJob
     class FileNotDeletedError < RuntimeError
       def initialize(http_code)
         @http_code = http_code

--- a/app/jobs/worker/send_email_log_job.rb
+++ b/app/jobs/worker/send_email_log_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Worker
+  class SendEmailLogJob < ::ApplicationJob
+    queue_as 'email_log'
+
+    def perform(email_log_id)
+      YetiMail.email_message(email_log_id).deliver!
+      Log::EmailLog.where(id: email_log_id).update_all(sent_at: Time.now)
+    rescue StandardError => e
+      Rails.logger.warn { "<#{e.class}>: #{e.message}" }
+      Rails.logger.warn { e.backtrace.join("\n") }
+
+      Log::EmailLog.where(id: email_log_id).update_all(error: e.message)
+    end
+  end
+end

--- a/app/lib/sql_caller/base.rb
+++ b/app/lib/sql_caller/base.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module SqlCaller
+  class Base
+    include Singleton
+    extend SingleForwardable
+
+    class_attribute :_model_name, instance_writer: false
+
+    CONNECTION_METHODS = %i[
+      select_value
+      select_values
+      execute
+      select_all
+      select_rows
+    ].freeze
+
+    class << self
+      def model_name(value)
+        self._model_name = value
+      end
+
+      def delegate_connection_methods(*names)
+        names.each { |name| delegate_connection_method(name) }
+      end
+
+      def delegate_connection_method(name)
+        define_method(name) { |sql, *args| perform_sp(name, sql, *args) }
+        def_delegators :instance, name
+      end
+
+      def define_custom_method(name, &block)
+        define_method(name) { |*args| instance_exec(*args, &block) }
+        def_delegators :instance, name
+      end
+    end
+
+    delegate_connection_methods(*CONNECTION_METHODS)
+
+    define_custom_method(:select_row) do |sql, *bindings|
+      select_rows(sql, *bindings)[0]
+    end
+
+    define_custom_method(:select_all_serialized) do |sql, *bindings|
+      result = select_all(sql, *bindings)
+      result.map { |row| row.map { |key, value| [key.to_sym, deserialize(result, key, value)] }.to_h }
+    end
+
+    define_custom_method(:set_timezone) do |value|
+      execute("SET TIME ZONE #{quote(value)};")
+    end
+
+    define_custom_method(:current_timezone) do
+      select_value("SELECT current_setting('TIMEZONE');")
+    end
+
+    private
+
+    def quote(value)
+      connection.quote(value)
+    end
+
+    def deserialize(result, key, value)
+      result.column_types[key].deserialize(value)
+    end
+
+    def model_class
+      return @model_class if defined?(@model_class)
+      raise NotImplementedError, 'method #model_name must be defined' if _model_name.nil?
+
+      @model_class = _model_name.constantize
+    end
+
+    def connection
+      model_class.connection
+    end
+
+    def sanitize_sql_array(sql, *bindings)
+      model_class.send :sanitize_sql_array, bindings.unshift(sql)
+    end
+
+    def perform_sp(method, sql, *bindings)
+      sql = sanitize_sql_array(sql, *bindings) if bindings.any?
+      connection.send(method, sql)
+    end
+  end
+end

--- a/app/lib/sql_caller/cdr.rb
+++ b/app/lib/sql_caller/cdr.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SqlCaller
+  class Cdr < Base
+    model_name 'Cdr::Base'
+  end
+end

--- a/app/lib/sql_caller/yeti.rb
+++ b/app/lib/sql_caller/yeti.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SqlCaller
+  class Yeti < Base
+    model_name 'ActiveRecord::Base'
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -128,11 +128,13 @@ class Account < Yeti::ActiveRecord
   before_destroy :remove_self_from_related_api_access!
 
   def last_customer_invoice_date
-    invoices.for_customer.order('end_date desc').limit(1).take.try!(:end_date) || customer_invoice_period.initial_date
+    invoices.for_customer.order('end_date desc').limit(1).take
+            .try!(:end_date) || customer_invoice_period.initial_date(next_customer_invoice_at.to_date).to_time
   end
 
   def last_vendor_invoice_date
-    invoices.for_vendor.order('end_date desc').limit(1).take.try!(:end_date) || vendor_invoice_period.initial_date
+    invoices.for_vendor.order('end_date desc').limit(1).take
+            .try!(:end_date) || vendor_invoice_period.initial_date(next_vendor_invoice_at.to_date).to_time
   end
 
   def schedule_next_customer_invoice!

--- a/app/models/billing/invoice_period.rb
+++ b/app/models/billing/invoice_period.rb
@@ -27,73 +27,90 @@ class Billing::InvoicePeriod < Yeti::ActiveRecord
 
   SPLIT_PERIOD_IDS = [BIWEEKLY_SPLIT_ID, WEEKLY_SPLIT_ID].freeze
 
-  DAILY_FROM_NOW = -> { today + 1.day }
-  DAILY_AGO = -> { today - 1.day }
+  DAILY_FROM_NOW = lambda {
+    today + 1.day
+  }
+
+  DAILY_AGO = lambda { |end_date|
+    end_date - 1.day
+  }
 
   WEEKLY_FROM_NOW = lambda {
     Date.commercial(today.year, today.cweek) + 1.week
   }
 
-  WEEKLY_AGO = lambda {
-    WEEKLY_FROM_NOW.call - 1.week
+  WEEKLY_AGO = lambda { |end_date|
+    Date.commercial(end_date.year, end_date.cweek) - 1.week
   }
 
   WEEKLY_SPLIT_FROM_NOW = lambda {
-    last_date = WEEKLY_SPLIT_AGO.call.to_time
-    next_date = last_date.end_of_week + 1.second
-    last_date.month == next_date.month ? next_date : next_date.beginning_of_month
+    today_week_end = Date.commercial(today.year, today.cweek).end_of_week
+    today.month == today_week_end.month ? today_week_end + 1.day : today.end_of_month + 1.day
   }
 
-  WEEKLY_SPLIT_AGO = lambda {
-    last_date = Date.commercial(today.year, today.cweek)
-    last_date.month == today.month ? last_date : today.beginning_of_month
+  WEEKLY_SPLIT_AGO = lambda { |end_date|
+    end_date_week_start = Date.commercial(end_date.year, end_date.cweek)
+    if end_date == end_date_week_start
+      prev_week_start = end_date - 1.week
+      prev_week_end = prev_week_start.end_of_week
+      prev_week_start.month == prev_week_end.month ? prev_week_start : prev_week_start.end_of_month + 1.day
+    else
+      end_date_week_start
+    end
   }
 
   BIWEEKLY_FROM_NOW = lambda {
-    [Date.commercial(today.year, today.cweek) + 2.week,
-     Date.commercial(today.year, today.cweek) + 1.week]
-      .select { |d| d.cweek.even? }.first
+    today_week_start = Date.commercial(today.year, today.cweek)
+    [today_week_start + 2.week, today_week_start + 1.week].detect { |d| d.cweek.even? }
   }
 
-  BIWEEKLY_AGO = lambda {
-    BIWEEKLY_FROM_NOW.call - 2.weeks
+  BIWEEKLY_AGO = lambda { |end_date|
+    end_date - 2.week
   }
 
   BIWEEKLY_SPLIT_FROM_NOW = lambda {
-    last_date = BIWEEKLY_SPLIT_AGO.call.to_time
-    next_date = last_date.end_of_week + 1.second
-    next_date += 1.week unless next_date.to_date.cweek.even?
-    last_date.month == next_date.month ? next_date : next_date.beginning_of_month
+    today_week_start = Date.commercial(today.year, today.cweek)
+    next_biweekly_start = [today_week_start + 2.week, today_week_start + 1.week].detect { |d| d.cweek.even? }
+    today.month == next_biweekly_start.month ? next_biweekly_start : today.end_of_month + 1.day
   }
 
-  BIWEEKLY_SPLIT_AGO = lambda {
-    last_date = [
-      Date.commercial(today.year, today.cweek),
-      Date.commercial(today.year, today.cweek) - 1.week
-
-    ].select { |d| d.cweek.even? }.first
-    last_date.month == today.month ? last_date : today.beginning_of_month
+  BIWEEKLY_SPLIT_AGO = lambda { |end_date|
+    end_date_week_start = Date.commercial(end_date.year, end_date.cweek)
+    if end_date == end_date_week_start
+      prev_biweekly_start = [end_date - 1.week, end_date - 2.week].detect { |d| d.cweek.even? }
+      prev_biweekly_end = prev_biweekly_start.end_of_week + 1.week
+      prev_biweekly_start.month == prev_biweekly_end.month ?
+          prev_biweekly_start :
+          prev_biweekly_start.end_of_month + 1.day
+    else
+      [end_date_week_start, end_date_week_start - 1.week].detect { |d| d.cweek.even? }
+    end
   }
 
   MONTHLY_FROM_NOW = lambda {
-    # Time.now.months_since(1).beginning_of_month
-    today.at_beginning_of_month.next_month
+    today.end_of_month + 1.day
   }
 
-  MONTHLY_AGO = lambda {
-    MONTHLY_FROM_NOW.call.prev_month
+  MONTHLY_AGO = lambda { |end_date|
+    end_date - 1.month
   }
 
-  DAILY_INC = ->(dt) { dt + 1.day }
+  DAILY_INC = lambda { |dt|
+    dt + 1.day
+  }
 
-  WEEKLY_INC = ->(dt) { dt + 1.week }
+  WEEKLY_INC = lambda { |dt|
+    dt + 1.week
+  }
 
   WEEKLY_SPLIT_INC = lambda { |dt|
     next_date = dt.end_of_week + 1.second
     dt.month == next_date.month ? next_date : next_date.beginning_of_month
   }
 
-  BIWEEKLY_INC = ->(dt) { dt + 2.weeks }
+  BIWEEKLY_INC = lambda { |dt|
+    dt + 2.weeks
+  }
 
   BIWEEKLY_SPLIT_INC = lambda { |dt|
     next_date = dt.to_time.end_of_week + 1.second # + 1.week
@@ -109,8 +126,8 @@ class Billing::InvoicePeriod < Yeti::ActiveRecord
     self.class.const_get("#{NAMES[id]}_FROM_NOW").call
   end
 
-  def initial_date
-    self.class.const_get("#{NAMES[id]}_AGO").call
+  def initial_date(end_date)
+    self.class.const_get("#{NAMES[id]}_AGO").call(end_date)
   end
 
   def next_date(dt)
@@ -132,10 +149,14 @@ class Billing::InvoicePeriod < Yeti::ActiveRecord
 
   def days_in_period
     case id
-    when DAILY_ID then 1
-    when WEEKLY_ID, WEEKLY_SPLIT_ID then 7
-    when BIWEEKLY_ID, BIWEEKLY_SPLIT_ID then 14
-    when MONTHLY_ID then 30
+    when DAILY_ID then
+      1
+    when WEEKLY_ID, WEEKLY_SPLIT_ID then
+      7
+    when BIWEEKLY_ID, BIWEEKLY_SPLIT_ID then
+      14
+    when MONTHLY_ID then
+      30
     end
   end
 

--- a/app/models/billing/invoice_type.rb
+++ b/app/models/billing/invoice_type.rb
@@ -14,4 +14,10 @@ class Billing::InvoiceType < Cdr::Base
   MANUAL = 1
   AUTO_FULL = 2
   AUTO_PARTIAL = 3
+
+  NAMES = {
+    MANUAL => 'Manual',
+    AUTO_FULL => 'Auto Full',
+    AUTO_PARTIAL => 'Auto Partial'
+  }.freeze
 end

--- a/app/models/log/email_log.rb
+++ b/app/models/log/email_log.rb
@@ -39,16 +39,6 @@ class Log::EmailLog < Yeti::ActiveRecord
   end
 
   after_create do
-    self.class.delay.send_email(id)
-  end
-
-  def self.send_email(id)
-    YetiMail.email_message(id).deliver!
-    Log::EmailLog.where(id: id).update_all(sent_at: Time.now)
-  rescue StandardError => e
-    Rails.logger.warn { e.message }
-    Rails.logger.warn { e.backtrace.join("\n") }
-
-    Log::EmailLog.where(id: id).update_all(error: e.message)
+    Worker::SendEmailLogJob.perform_later(id)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,9 +50,10 @@ module Yeti
         config.time_zone = 'UTC'
       end
     end
-    p "Timezone #{config.time_zone}"
 
-    config.active_record.default_timezone = :local
+    active_record_tz = ENV.fetch('YETI_PG_TZ', :utc).to_sym
+    config.active_record.default_timezone = active_record_tz
+
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/config/initializers/print_timezone.rb
+++ b/config/initializers/print_timezone.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+begin
+  puts "App Timezone #{Rails.application.config.time_zone}"
+  puts "Yeti DB timezone #{::SqlCaller::Yeti.current_timezone}"
+  puts "CDR DB timezone #{::SqlCaller::Cdr.current_timezone}"
+  puts "ActiveRecord timezone #{Rails.application.config.active_record.default_timezone}"
+rescue StandardError => e
+  puts "suppressed error during timezone print <#{e.class}>: #{e.message}"
+end

--- a/spec/fixtures/invoice_periods.yml
+++ b/spec/fixtures/invoice_periods.yml
@@ -1,0 +1,18 @@
+invoice_period_1:
+  id: 1
+  name: DAILY
+invoice_period_2:
+  id: 2
+  name: WEEKLY
+invoice_period_3:
+  id: 3
+  name: BIWEEKLY
+invoice_period_4:
+  id: 4
+  name: MONTHLY
+invoice_period_5:
+  id: 5
+  name: BIWEEKLY_SPLIT
+invoice_period_6:
+  id: 6
+  name: WEEKLY_SPLIT

--- a/spec/jobs/jobs/invoice_job_spec.rb
+++ b/spec/jobs/jobs/invoice_job_spec.rb
@@ -8,35 +8,716 @@ RSpec.describe Jobs::Invoice do
       end
     end
 
-    let(:monthly_invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::MONTHLY_ID) }
-    let!(:vendor) { FactoryGirl.create(:vendor) }
-    let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+    shared_examples :enqueues_invoice_generation do |options|
+      options.assert_valid_keys(:is_vendor, :start_time, :end_time, :next_invoice_at, :invoice_type)
+      is_vendor = options.fetch(:is_vendor)
+      start_time = options.fetch(:start_time)
+      end_time = options.fetch(:end_time)
+      next_invoice_at = options.fetch(:next_invoice_at)
+      invoice_type = options.fetch(:invoice_type) { Billing::InvoiceType::AUTO_FULL }
 
-    context 'account was created at 2019-04-03' do
-      let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+      next_invoice_at_col = :"next_#{is_vendor ? :vendor : :customer}_invoice_at"
+      invoice_type_name = Billing::InvoiceType::NAMES[invoice_type]
+      description_args = [
+        "start_date '#{start_time}'",
+        "end_date '#{end_time}'",
+        "invoice_type '#{invoice_type_name}'"
+      ]
 
-      let!(:account) do
-        travel_to(account_creation_time) do
-          FactoryGirl.create(:account, contractor: vendor, vendor_invoice_period: monthly_invoice_period)
-        end
-      end
-      # before { expect(account).to have_attributes(next_vendor_invoice_at: Time.parse('2019-05-01 00:00:00')) }
-
-      it 'enqueues Worker::GenerateInvoiceJob' do
+      it "enqueues Worker::GenerateInvoiceJob with #{description_args.join(', ')}" do
         expect { subject }.to have_enqueued_job(Worker::GenerateInvoiceJob).with(
           account_id: account.id,
-          start_date: '2019-04-01 00:00:00 UTC',
-          end_date: '2019-05-01 00:00:00 UTC',
-          invoice_type_id: Billing::InvoiceType::AUTO_FULL,
-          is_vendor: true
+          start_date: start_time.utc.to_s,
+          end_date: end_time.utc.to_s,
+          invoice_type_id: invoice_type,
+          is_vendor: is_vendor
         ).once
       end
 
-      it 'moves account.next_customer_invoice_at to correct datetime' do
-        subject
-        expect(account.reload).to have_attributes(
-          next_vendor_invoice_at: Time.parse('2019-06-01 00:00:00 UTC')
-        )
+      it "changes account #{next_invoice_at_col} from '#{end_time}' to '#{next_invoice_at}'" do
+        expect { subject }.to change {
+          account.reload[next_invoice_at_col].change(usec: 0)
+        }.from(end_time).to(next_invoice_at)
+      end
+    end
+
+    context 'vendor invoice' do
+      let!(:vendor) { FactoryGirl.create(:vendor) }
+      let!(:account) do
+        travel_to(account_creation_time) do
+          FactoryGirl.create(:account, contractor: vendor, vendor_invoice_period: invoice_period)
+        end
+      end
+
+      context 'with invoice period monthly' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::MONTHLY_ID) }
+
+        context 'account was created at 2019-04-03 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-06-01 00:00:00')
+        end
+
+        context 'account was created at 2019-04-28 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-06-01 00:00:00')
+        end
+      end
+
+      context 'with invoice period weekly simple' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::WEEKLY_ID) }
+
+        context 'when account was created at 2019-04-03 and now is 2019-04-08' do
+          let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-08 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-08 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-08 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-22 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-29 and now is 2019-05-06' do
+          let(:account_creation_time) { Time.parse('2019-04-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-06 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-06 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00')
+        end
+      end
+
+      context 'with invoice period daily' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::DAILY_ID) }
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-10' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-10 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-09 00:00:00'),
+                           end_time: Time.parse('2019-04-10 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-11 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-30 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-30 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-02 00:00:00')
+        end
+      end
+
+      context 'with invoice period biweekly simple' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::BIWEEKLY_ID) }
+
+        context 'when account was created at 2019-04-02 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-02 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-17 and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-17 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-15 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00')
+        end
+      end
+
+      context 'with invoice period weekly split' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::WEEKLY_SPLIT_ID) }
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-08 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-22 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-25 and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-25 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-22 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-01 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-30 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-06 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2018-12-31 and now is 2019-01-01' do
+          let(:account_creation_time) { Time.parse('2018-12-31 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-01-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2018-12-31 00:00:00'),
+                           end_time: Time.parse('2019-01-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-01-07 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-28 and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-08-26 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-09-01 and now is 2019-09-02' do
+          let(:account_creation_time) { Time.parse('2019-09-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-02 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-09-01 00:00:00'),
+                           end_time: Time.parse('2019-09-02 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-09 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_FULL
+        end
+
+        context 'when account was created at 2019-03-29 and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-03-25 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-08 00:00:00')
+        end
+      end
+
+      context 'with invoice period biweekly split' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::BIWEEKLY_SPLIT_ID) }
+
+        context 'when account was created at 2019-04-02 (even) and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-08 (odd) and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-08 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-15 (even) and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-15 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-15 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-01 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-29 (even) and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-04-30 (even) and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2018-12-31 (odd) and now is 2019-01-01' do
+          let(:account_creation_time) { Time.parse('2018-12-31 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-01-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2018-12-24 00:00:00'),
+                           end_time: Time.parse('2019-01-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-01-07 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-28 (odd) and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-08-19 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-20 (even) and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-20 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-08-19 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-09-01 (odd) and now is 2019-09-02' do
+          let(:account_creation_time) { Time.parse('2019-09-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-02 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-09-01 00:00:00'),
+                           end_time: Time.parse('2019-09-02 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-16 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_FULL
+        end
+
+        context 'when account was created at 2019-03-29 (odd) and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-03-18 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
+
+        context 'when account was created at 2019-03-21 (even) and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-21 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: true,
+                           start_time: Time.parse('2019-03-18 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
+      end
+    end
+
+    context 'customer invoice' do
+      let!(:customer) { FactoryGirl.create(:customer) }
+      let!(:account) do
+        travel_to(account_creation_time) do
+          FactoryGirl.create(:account, contractor: customer, customer_invoice_period: invoice_period)
+        end
+      end
+
+      context 'with invoice period monthly' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::MONTHLY_ID) }
+
+        context 'account was created at 2019-04-03 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-06-01 00:00:00')
+        end
+
+        context 'account was created at 2019-04-28 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-06-01 00:00:00')
+        end
+      end
+
+      context 'with invoice period weekly simple' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::WEEKLY_ID) }
+
+        context 'when account was created at 2019-04-03 and now is 2019-04-08' do
+          let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-08 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-08 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-08 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-22 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-29 and now is 2019-05-06' do
+          let(:account_creation_time) { Time.parse('2019-04-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-06 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-06 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00')
+        end
+      end
+
+      context 'with invoice period daily' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::DAILY_ID) }
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-10' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-10 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-09 00:00:00'),
+                           end_time: Time.parse('2019-04-10 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-11 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-30 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-30 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-02 00:00:00')
+        end
+      end
+
+      context 'with invoice period biweekly simple' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::BIWEEKLY_ID) }
+
+        context 'when account was created at 2019-04-02 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-02 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-17 and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-17 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-15 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00')
+        end
+      end
+
+      context 'with invoice period weekly split' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::WEEKLY_SPLIT_ID) }
+
+        context 'when account was created at 2019-04-09 and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-09 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-08 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-22 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-25 and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-25 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-22 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-01 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-30 and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-06 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2018-12-31 and now is 2019-01-01' do
+          let(:account_creation_time) { Time.parse('2018-12-31 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-01-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2018-12-31 00:00:00'),
+                           end_time: Time.parse('2019-01-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-01-07 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-28 and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-08-26 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-09-01 and now is 2019-09-02' do
+          let(:account_creation_time) { Time.parse('2019-09-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-02 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-09-01 00:00:00'),
+                           end_time: Time.parse('2019-09-02 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-09 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_FULL
+        end
+
+        context 'when account was created at 2019-03-29 and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-03-25 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-08 00:00:00')
+        end
+      end
+
+      context 'with invoice period biweekly split' do
+        let(:invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::BIWEEKLY_SPLIT_ID) }
+
+        context 'when account was created at 2019-04-02 (even) and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-08 (odd) and now is 2019-04-15' do
+          let(:account_creation_time) { Time.parse('2019-04-08 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-15 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-01 00:00:00'),
+                           end_time: Time.parse('2019-04-15 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-29 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-15 (even) and now is 2019-04-29' do
+          let(:account_creation_time) { Time.parse('2019-04-15 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-29 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-15 00:00:00'),
+                           end_time: Time.parse('2019-04-29 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-01 00:00:00')
+        end
+
+        context 'when account was created at 2019-04-29 (even) and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-04-30 (even) and now is 2019-05-01' do
+          let(:account_creation_time) { Time.parse('2019-04-30 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-04-29 00:00:00'),
+                           end_time: Time.parse('2019-05-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-05-13 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2018-12-31 (odd) and now is 2019-01-01' do
+          let(:account_creation_time) { Time.parse('2018-12-31 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-01-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2018-12-24 00:00:00'),
+                           end_time: Time.parse('2019-01-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-01-07 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-28 (odd) and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-28 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-08-19 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-08-20 (even) and now is 2019-09-01' do
+          let(:account_creation_time) { Time.parse('2019-08-20 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-08-19 00:00:00'),
+                           end_time: Time.parse('2019-09-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-02 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_PARTIAL
+        end
+
+        context 'when account was created at 2019-09-01 (odd) and now is 2019-09-02' do
+          let(:account_creation_time) { Time.parse('2019-09-01 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-09-02 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-09-01 00:00:00'),
+                           end_time: Time.parse('2019-09-02 00:00:00'),
+                           next_invoice_at: Time.parse('2019-09-16 00:00:00'),
+                           invoice_type: Billing::InvoiceType::AUTO_FULL
+        end
+
+        context 'when account was created at 2019-03-29 (odd) and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-29 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-03-18 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
+
+        context 'when account was created at 2019-03-21 (even) and now is 2019-04-01' do
+          let(:account_creation_time) { Time.parse('2019-03-21 02:55:54') }
+          let(:job_execution_time) { Time.parse('2019-04-01 05:30:06') }
+
+          include_examples :enqueues_invoice_generation,
+                           is_vendor: false,
+                           start_time: Time.parse('2019-03-18 00:00:00'),
+                           end_time: Time.parse('2019-04-01 00:00:00'),
+                           next_invoice_at: Time.parse('2019-04-15 00:00:00')
+        end
       end
     end
   end

--- a/spec/jobs/jobs/invoice_job_spec.rb
+++ b/spec/jobs/jobs/invoice_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::Invoice do
+  describe '#execute' do
+    subject do
+      travel_to(job_execution_time) do
+        described_class.first!.execute
+      end
+    end
+
+    let(:monthly_invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::MONTHLY_ID) }
+    let(:job_execution_time) { Time.parse('2019-05-01 05:30:06') }
+
+    context 'account was created at 2019-04-03' do
+      let(:account_creation_time) { Time.parse('2019-04-03 02:55:54') }
+
+      let!(:account) do
+        travel_to(account_creation_time) do
+          vendor = FactoryGirl.create(:vendor)
+          FactoryGirl.create(:account, contractor: vendor, vendor_invoice_period: monthly_invoice_period)
+        end
+      end
+      # before { expect(account).to have_attributes(next_vendor_invoice_at: Time.parse('2019-05-01 00:00:00')) }
+
+      it 'creates invoice with correct attributes', :sync_delayed_jobs do
+        expect { subject }.to change { Billing::Invoice.count }.by(1)
+        invoice = Billing::Invoice.last!
+        expect(invoice).to have_attributes(
+          start_date: Time.parse('2019-04-01 00:00:00'),
+          end_date: Time.parse('2019-05-01 00:00:00'),
+          type_id: Billing::InvoiceType::AUTO_FULL
+        )
+      end
+
+      it 'moves account.next_customer_invoice_at to correct datetime' do
+        subject
+        expect(account.reload).to have_attributes(
+          next_vendor_invoice_at: Time.parse('2019-06-01 00:00:00')
+        )
+      end
+    end
+  end
+end

--- a/spec/jobs/worker/generate_invoice_job_spec.rb
+++ b/spec/jobs/worker/generate_invoice_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Worker::GenerateInvoiceJob do
+  describe '#perform_now' do
+    subject do
+      described_class.new(*job_args).perform_now
+    end
+
+    let(:job_args) do
+      [
+        account_id: account.id,
+        start_date: '2019-04-01 00:00:00 UTC',
+        end_date: '2019-05-01 00:00:00 UTC',
+        invoice_type_id: Billing::InvoiceType::AUTO_FULL,
+        is_vendor: true
+      ]
+    end
+
+    let(:monthly_invoice_period) { Billing::InvoicePeriod.find(Billing::InvoicePeriod::MONTHLY_ID) }
+    let!(:vendor) { FactoryGirl.create(:vendor) }
+    let!(:account) do
+      FactoryGirl.create(:account, contractor: vendor, vendor_invoice_period: monthly_invoice_period)
+    end
+
+    it 'creates invoice with correct attributes' do
+      expect { subject }.to change { Billing::Invoice.count }.by(1)
+      invoice = Billing::Invoice.last!
+      expect(invoice).to have_attributes(
+        account_id: account.id,
+        start_date: Time.parse('2019-04-01 00:00:00 UTC'),
+        end_date: Time.parse('2019-05-01 00:00:00 UTC'),
+        type_id: Billing::InvoiceType::AUTO_FULL
+      )
+    end
+  end
+end

--- a/spec/models/billing/invoice_period_spec.rb
+++ b/spec/models/billing/invoice_period_spec.rb
@@ -37,22 +37,25 @@ describe Billing::InvoicePeriod do
       include_examples :responds_with_correct_times,
                        today_dt: Time.parse('2015-07-06 00:00:00'),
                        next_dt: Time.parse('2015-07-13 00:00:00'),
-                       initial_dt: Time.parse('2015-07-06 00:00:00')
+                       # start of previous week
+                       initial_dt: Time.parse('2015-06-29 00:00:00')
     end
 
     context 'when invoice breaks month' do
       include_examples :responds_with_correct_times,
                        today_dt: Time.parse('2015-07-27 00:00:00'),
                        next_dt: Time.parse('2015-08-03 00:00:00'),
-                       initial_dt: Time.parse('2015-07-27 00:00:00')
+                       # start of previous week
+                       initial_dt: Time.parse('2015-07-20 00:00:00')
     end
 
     context 'when invoice on last week of the year' do
       include_examples :responds_with_correct_times,
                        today_dt: Time.parse('2017-12-27 00:00:00'),
                        next_dt: Time.parse('2018-01-03 00:00:00'),
-                       initial_dt: Time.parse('2017-12-25 00:00:00'),
-                       next_from_now_dt: Time.parse('2018-01-01 00:00:00')
+                       next_from_now_dt: Time.parse('2018-01-01 00:00:00'),
+                       # start of previous week
+                       initial_dt: Time.parse('2017-12-18 00:00:00')
     end
   end # WEEKLY
 
@@ -63,7 +66,8 @@ describe Billing::InvoicePeriod do
       include_examples :responds_with_correct_times,
                        today_dt: Time.parse('2015-07-06 00:00:00'),
                        next_dt: Time.parse('2015-07-13 00:00:00'),
-                       initial_dt: Time.parse('2015-07-06 00:00:00')
+                       # begin of month
+                       initial_dt: Time.parse('2015-07-01 00:00:00')
     end
 
     context 'when invoice breaks month' do
@@ -71,14 +75,16 @@ describe Billing::InvoicePeriod do
         include_examples :responds_with_correct_times,
                          today_dt: Time.parse('2015-07-27 00:00:00'),
                          next_dt: Time.parse('2015-08-01 00:00:00'),
-                         initial_dt: Time.parse('2015-07-27 00:00:00')
+                         # start of previous week
+                         initial_dt: Time.parse('2015-07-20 00:00:00')
       end
 
       context 'second part' do
         include_examples :responds_with_correct_times,
                          today_dt: Time.parse('2015-08-01 00:00:00'),
                          next_dt: Time.parse('2015-08-03 00:00:00'),
-                         initial_dt: Time.parse('2015-08-01 00:00:00')
+                         # start_date of first part period
+                         initial_dt: Time.parse('2015-07-27 00:00:00')
       end
     end
   end # WEEKLY_SPLIT
@@ -91,7 +97,7 @@ describe Billing::InvoicePeriod do
         include_examples :responds_with_correct_times,
                          today_dt: Time.parse('2015-07-06 00:00:00'), # week 28
                          next_dt: Time.parse('2015-07-20 00:00:00'),
-                         initial_dt: Time.parse('2015-07-06 00:00:00')
+                         initial_dt: Time.parse('2015-06-22 00:00:00')
       end
 
       context 'when invoice breaks month' do
@@ -99,14 +105,14 @@ describe Billing::InvoicePeriod do
           include_examples :responds_with_correct_times,
                            today_dt: Time.parse('2015-04-27 00:00:00'), # week 18
                            next_dt: Time.parse('2015-05-11 00:00:00'),
-                           initial_dt: Time.parse('2015-04-27 00:00:00')
+                           initial_dt: Time.parse('2015-04-13 00:00:00')
         end
 
         context 'when breaks second week' do
           include_examples :responds_with_correct_times,
                            today_dt: Time.parse('2015-06-22 00:00:00'), # week 26
                            next_dt: Time.parse('2015-07-06 00:00:00'),
-                           initial_dt: Time.parse('2015-06-22 00:00:00')
+                           initial_dt: Time.parse('2015-06-08 00:00:00')
         end
       end
     end # even week
@@ -116,7 +122,7 @@ describe Billing::InvoicePeriod do
         include_examples :responds_with_correct_times,
                          today_dt: Time.parse('2015-07-13 00:00:00'), # week 29
                          next_dt: Time.parse('2015-07-27 00:00:00'),
-                         initial_dt: Time.parse('2015-07-06 00:00:00'),
+                         initial_dt: Time.parse('2015-06-29 00:00:00'),
                          next_from_now_dt: Time.parse('2015-07-20 00:00:00')
       end
 
@@ -125,7 +131,7 @@ describe Billing::InvoicePeriod do
           include_examples :responds_with_correct_times,
                            today_dt: Time.parse('2015-06-29 00:00:00'), # week 27
                            next_dt: Time.parse('2015-07-13 00:00:00'),
-                           initial_dt: Time.parse('2015-06-22 00:00:00'),
+                           initial_dt: Time.parse('2015-06-15 00:00:00'),
                            next_from_now_dt: Time.parse('2015-07-06 00:00:00')
         end
 
@@ -133,7 +139,7 @@ describe Billing::InvoicePeriod do
           include_examples :responds_with_correct_times,
                            today_dt: Time.parse('2015-04-20 00:00:00'), # week 17
                            next_dt: Time.parse('2015-05-04 00:00:00'),
-                           initial_dt: Time.parse('2015-04-13 00:00:00'),
+                           initial_dt: Time.parse('2015-04-06 00:00:00'),
                            next_from_now_dt: Time.parse('2015-04-27 00:00:00')
         end
       end
@@ -148,7 +154,7 @@ describe Billing::InvoicePeriod do
         include_examples :responds_with_correct_times,
                          today_dt: Time.parse('2015-07-06 00:00:00'), # week 28
                          next_dt: Time.parse('2015-07-20 00:00:00'),
-                         initial_dt: Time.parse('2015-07-06 00:00:00')
+                         initial_dt: Time.parse('2015-07-01 00:00:00')
       end
 
       context 'when invoice breaks month' do
@@ -157,30 +163,30 @@ describe Billing::InvoicePeriod do
             include_examples :responds_with_correct_times,
                              today_dt: Time.parse('2015-04-27 00:00:00'), # week 18
                              next_dt: Time.parse('2015-05-01 00:00:00'), # week 18
-                             initial_dt: Time.parse('2015-04-27 00:00:00')
+                             initial_dt: Time.parse('2015-04-13 00:00:00')
           end
 
           context 'second part' do
             include_examples :responds_with_correct_times,
                              today_dt: Time.parse('2015-05-01 00:00:00'), # week 18
                              next_dt: Time.parse('2015-05-11 00:00:00'), # week 20
-                             initial_dt: Time.parse('2015-05-01 00:00:00')
+                             initial_dt: Time.parse('2015-04-27 00:00:00')
           end
         end
 
         context 'when breaks second week' do
-          context 'second part' do
+          context 'first part' do
             include_examples :responds_with_correct_times,
                              today_dt: Time.parse('2015-06-22 00:00:00'), # week 26
                              next_dt: Time.parse('2015-07-01 00:00:00'), # week 27
-                             initial_dt: Time.parse('2015-06-22 00:00:00')
+                             initial_dt: Time.parse('2015-06-08 00:00:00')
           end
 
           context 'second part' do
             include_examples :responds_with_correct_times,
                              today_dt: Time.parse('2015-07-01 00:00:00'), # week 27
                              next_dt: Time.parse('2015-07-06 00:00:00'), # week 28
-                             initial_dt: Time.parse('2015-07-01 00:00:00')
+                             initial_dt: Time.parse('2015-06-22 00:00:00')
           end
         end
       end
@@ -202,7 +208,7 @@ describe Billing::InvoicePeriod do
                              today_dt: Time.parse('2015-06-29 00:00:00'), # week 27
                              next_dt: Time.parse('2015-07-01 00:00:00'), # week 27
                              # cause it will move to the even week
-                             initial_dt: Time.parse('2015-06-22 00:00:00') # week 26
+                             initial_dt: Time.parse('2015-07-01 00:00:00') # week 26
           end
 
           context 'second part' do
@@ -210,7 +216,7 @@ describe Billing::InvoicePeriod do
                              today_dt: Time.parse('2015-07-01 00:00:00'), # week 27
                              # cause it will move to the even week
                              next_dt: Time.parse('2015-07-06 00:00:00'), # week 28
-                             initial_dt: Time.parse('2015-07-01 00:00:00')
+                             initial_dt: Time.parse('2015-06-22 00:00:00')
           end
         end
 

--- a/spec/models/billing/invoice_period_spec.rb
+++ b/spec/models/billing/invoice_period_spec.rb
@@ -9,21 +9,24 @@ describe Billing::InvoicePeriod do
 
   let(:id) { Billing::InvoicePeriod::NAMES.key(name.upcase) }
 
-  shared_examples :should_set_correct_dates do
-    let(:dt) { nil }
-    let(:expected_next_dt) { nil }
-    let(:expected_initial_dt) { nil }
-    let(:expected_next_from_now_dt) { expected_next_dt }
-    before { allow(Billing::InvoicePeriod).to receive(:today).and_return dt.to_date }
-    it 'should return correct next_date' do
-      expect(subject.next_date(dt).to_time.to_s(:db)).to eq expected_next_dt.to_time.to_s(:db)
-    end
-    it 'should return correct next_date_from_now' do
-      expect(subject.next_date_from_now.to_time.to_s(:db)).to eq expected_next_from_now_dt.to_time.to_s(:db)
-    end
-    it 'should return correct initial_date' do
-      end_date = Time.now.to_date
-      expect(subject.initial_date(end_date).to_time.to_time.to_s(:db)).to eq expected_initial_dt.to_time.to_s(:db)
+  shared_examples :responds_with_correct_times do |today_dt:, next_dt:, initial_dt:, next_from_now_dt: nil|
+    next_from_now_dt ||= next_dt
+
+    context "today is #{today_dt.to_date}" do
+      it "#next_date for today equals '#{next_dt}'" do
+        result = travel_to(today_dt) { subject.next_date(today_dt) }
+        expect(result.to_time.to_s(:db)).to eq next_dt.to_time.to_s(:db)
+      end
+
+      it "#next_date_from_now equals '#{next_from_now_dt}'" do
+        result = travel_to(today_dt) { subject.next_date_from_now }
+        expect(result.to_time.to_s(:db)).to eq next_from_now_dt.to_time.to_s(:db)
+      end
+
+      it "#initial_date equals '#{initial_dt}'" do
+        result = travel_to(today_dt) { subject.initial_date(Time.now.to_date) }
+        expect(result.to_time.to_s(:db)).to eq initial_dt.to_time.to_s(:db)
+      end
     end
   end
 
@@ -31,28 +34,25 @@ describe Billing::InvoicePeriod do
     let(:name) { 'weekly' }
 
     context 'when invoice did not break month' do
-      include_examples :should_set_correct_dates do
-        let(:dt) { Time.parse('2015-07-06 00:00:00') }
-        let(:expected_next_dt) { dt + 1.week }
-        let(:expected_initial_dt) { dt.to_time }
-      end
+      include_examples :responds_with_correct_times,
+                       today_dt: Time.parse('2015-07-06 00:00:00'),
+                       next_dt: Time.parse('2015-07-13 00:00:00'),
+                       initial_dt: Time.parse('2015-07-06 00:00:00')
     end
 
     context 'when invoice breaks month' do
-      include_examples :should_set_correct_dates do
-        let(:dt) { Time.parse('2015-07-27 00:00:00') }
-        let(:expected_next_dt) { dt + 1.week }
-        let(:expected_initial_dt) { dt.to_time }
-      end
+      include_examples :responds_with_correct_times,
+                       today_dt: Time.parse('2015-07-27 00:00:00'),
+                       next_dt: Time.parse('2015-08-03 00:00:00'),
+                       initial_dt: Time.parse('2015-07-27 00:00:00')
     end
 
     context 'when invoice on last week of the year' do
-      include_examples :should_set_correct_dates do
-        let(:dt) { Time.parse('2017-12-27 00:00:00') }
-        let(:expected_next_dt) { dt + 1.week }
-        let(:expected_initial_dt) { dt.beginning_of_week }
-        let(:expected_next_from_now_dt) { expected_next_dt.beginning_of_week }
-      end
+      include_examples :responds_with_correct_times,
+                       today_dt: Time.parse('2017-12-27 00:00:00'),
+                       next_dt: Time.parse('2018-01-03 00:00:00'),
+                       initial_dt: Time.parse('2017-12-25 00:00:00'),
+                       next_from_now_dt: Time.parse('2018-01-01 00:00:00')
     end
   end # WEEKLY
 
@@ -60,27 +60,25 @@ describe Billing::InvoicePeriod do
     let(:name) { 'weekly_split' }
 
     context 'when invoice did not break month' do
-      include_examples :should_set_correct_dates do
-        let(:dt) { Time.parse('2015-07-06 00:00:00') }
-        let(:expected_next_dt) { dt.to_time + 1.week }
-        let(:expected_initial_dt) { dt.to_time }
-      end
+      include_examples :responds_with_correct_times,
+                       today_dt: Time.parse('2015-07-06 00:00:00'),
+                       next_dt: Time.parse('2015-07-13 00:00:00'),
+                       initial_dt: Time.parse('2015-07-06 00:00:00')
     end
 
     context 'when invoice breaks month' do
       context 'first part' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-07-27 00:00:00') }
-          let(:expected_next_dt) { Time.parse('2015-08-01 00:00:00') }
-          let(:expected_initial_dt) { dt.to_time }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-07-27 00:00:00'),
+                         next_dt: Time.parse('2015-08-01 00:00:00'),
+                         initial_dt: Time.parse('2015-07-27 00:00:00')
       end
+
       context 'second part' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-08-01 00:00:00') }
-          let(:expected_next_dt) { Time.parse('2015-08-03 00:00:00') }
-          let(:expected_initial_dt) { dt.to_time }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-08-01 00:00:00'),
+                         next_dt: Time.parse('2015-08-03 00:00:00'),
+                         initial_dt: Time.parse('2015-08-01 00:00:00')
       end
     end
   end # WEEKLY_SPLIT
@@ -90,59 +88,53 @@ describe Billing::InvoicePeriod do
 
     context 'even week' do
       context 'when invoice did not break month' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-07-06 00:00:00') } # week 28
-          let(:expected_next_dt) { dt + 2.week }
-          let(:expected_initial_dt) { dt }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-07-06 00:00:00'), # week 28
+                         next_dt: Time.parse('2015-07-20 00:00:00'),
+                         initial_dt: Time.parse('2015-07-06 00:00:00')
       end
 
       context 'when invoice breaks month' do
         context 'when breaks first week' do
-          include_examples :should_set_correct_dates do
-            let(:dt) { Time.parse('2015-04-27 00:00:00') } # week 18
-            let(:expected_next_dt) { dt + 2.week }
-            let(:expected_initial_dt) { dt }
-          end
+          include_examples :responds_with_correct_times,
+                           today_dt: Time.parse('2015-04-27 00:00:00'), # week 18
+                           next_dt: Time.parse('2015-05-11 00:00:00'),
+                           initial_dt: Time.parse('2015-04-27 00:00:00')
         end
 
         context 'when breaks second week' do
-          include_examples :should_set_correct_dates do
-            let(:dt) { Time.parse('2015-06-22 00:00:00') } # week 26
-            let(:expected_next_dt) { dt + 2.week }
-            let(:expected_initial_dt) { dt }
-          end
+          include_examples :responds_with_correct_times,
+                           today_dt: Time.parse('2015-06-22 00:00:00'), # week 26
+                           next_dt: Time.parse('2015-07-06 00:00:00'),
+                           initial_dt: Time.parse('2015-06-22 00:00:00')
         end
       end
     end # even week
 
     context 'odd week' do
       context 'when invoice did not break month' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-07-13 00:00:00') } # week 29
-          let(:expected_next_dt) { dt + 2.week }
-          let(:expected_next_from_now_dt) { dt + 1.week }
-          let(:expected_initial_dt) { dt - 1.week }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-07-13 00:00:00'), # week 29
+                         next_dt: Time.parse('2015-07-27 00:00:00'),
+                         initial_dt: Time.parse('2015-07-06 00:00:00'),
+                         next_from_now_dt: Time.parse('2015-07-20 00:00:00')
       end
 
       context 'when invoice breaks month' do
         context 'when breaks first week' do
-          include_examples :should_set_correct_dates do
-            let(:dt) { Time.parse('2015-06-29 00:00:00') } # week 27
-            let(:expected_next_dt) { dt + 2.week }
-            let(:expected_next_from_now_dt) { dt + 1.week }
-            let(:expected_initial_dt) { dt - 1.week }
-          end
+          include_examples :responds_with_correct_times,
+                           today_dt: Time.parse('2015-06-29 00:00:00'), # week 27
+                           next_dt: Time.parse('2015-07-13 00:00:00'),
+                           initial_dt: Time.parse('2015-06-22 00:00:00'),
+                           next_from_now_dt: Time.parse('2015-07-06 00:00:00')
         end
 
         context 'whn breaks second week' do
-          include_examples :should_set_correct_dates do
-            let(:dt) { Time.parse('2015-04-20 00:00:00') } # week 17
-            let(:expected_next_dt) { dt + 2.week }
-            let(:expected_next_from_now_dt) { dt + 1.week }
-            let(:expected_initial_dt) { dt - 1.week }
-          end
+          include_examples :responds_with_correct_times,
+                           today_dt: Time.parse('2015-04-20 00:00:00'), # week 17
+                           next_dt: Time.parse('2015-05-04 00:00:00'),
+                           initial_dt: Time.parse('2015-04-13 00:00:00'),
+                           next_from_now_dt: Time.parse('2015-04-27 00:00:00')
         end
       end
     end # odd week
@@ -153,47 +145,42 @@ describe Billing::InvoicePeriod do
 
     context 'even week' do
       context 'when invoice did not break month' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-07-06 00:00:00') } # week 28
-          let(:expected_next_dt) { dt + 2.week }
-          let(:expected_initial_dt) { dt }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-07-06 00:00:00'), # week 28
+                         next_dt: Time.parse('2015-07-20 00:00:00'),
+                         initial_dt: Time.parse('2015-07-06 00:00:00')
       end
 
       context 'when invoice breaks month' do
         context 'when breaks first week' do
           context 'first part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-04-27 00:00:00') } # week 18
-              let(:expected_next_dt) { Time.parse('2015-05-01 00:00:00') } # week 18
-              let(:expected_initial_dt) { dt }
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-04-27 00:00:00'), # week 18
+                             next_dt: Time.parse('2015-05-01 00:00:00'), # week 18
+                             initial_dt: Time.parse('2015-04-27 00:00:00')
           end
 
           context 'second part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-05-01 00:00:00') } # week 18
-              let(:expected_next_dt) { Time.parse('2015-05-11 00:00:00') } # week 20
-              let(:expected_initial_dt) { dt }
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-05-01 00:00:00'), # week 18
+                             next_dt: Time.parse('2015-05-11 00:00:00'), # week 20
+                             initial_dt: Time.parse('2015-05-01 00:00:00')
           end
         end
 
         context 'when breaks second week' do
           context 'second part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-06-22 00:00:00') } # week 26
-              let(:expected_next_dt) { Time.parse('2015-07-01 00:00:00') } # week 27
-              let(:expected_initial_dt) { dt }
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-06-22 00:00:00'), # week 26
+                             next_dt: Time.parse('2015-07-01 00:00:00'), # week 27
+                             initial_dt: Time.parse('2015-06-22 00:00:00')
           end
 
           context 'second part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-07-01 00:00:00') } # week 27
-              let(:expected_next_dt) { Time.parse('2015-07-06 00:00:00') } # week 28
-              let(:expected_initial_dt) { dt }
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-07-01 00:00:00'), # week 27
+                             next_dt: Time.parse('2015-07-06 00:00:00'), # week 28
+                             initial_dt: Time.parse('2015-07-01 00:00:00')
           end
         end
       end
@@ -201,43 +188,39 @@ describe Billing::InvoicePeriod do
 
     context 'odd week' do
       context 'when invoice did not break month' do
-        include_examples :should_set_correct_dates do
-          let(:dt) { Time.parse('2015-07-13 00:00:00') } # week 29
-          # cause it will move to the even week
-          let(:expected_next_dt) { dt + 1.week }
-          let(:expected_initial_dt) { dt - 1.week }
-        end
+        include_examples :responds_with_correct_times,
+                         today_dt: Time.parse('2015-07-13 00:00:00'), # week 29
+                         # cause it will move to the even week
+                         next_dt: Time.parse('2015-07-20 00:00:00'),
+                         initial_dt: Time.parse('2015-07-06 00:00:00')
       end
 
       context 'when invoice breaks month' do
         context 'when breaks first week' do
           context 'first part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-06-29 00:00:00') } # week 27
-              let(:expected_next_dt) { Time.parse('2015-07-01 00:00:00') } # week 27
-              # cause it will move to the even week
-              let(:expected_initial_dt) { Time.parse('2015-06-22 00:00:00') } # week 26
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-06-29 00:00:00'), # week 27
+                             next_dt: Time.parse('2015-07-01 00:00:00'), # week 27
+                             # cause it will move to the even week
+                             initial_dt: Time.parse('2015-06-22 00:00:00') # week 26
           end
 
           context 'second part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-07-01 00:00:00') } # week 27
-              # cause it will move to the even week
-              let(:expected_next_dt) { Time.parse('2015-07-06 00:00:00') } # week 28
-              let(:expected_initial_dt) { dt }
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-07-01 00:00:00'), # week 27
+                             # cause it will move to the even week
+                             next_dt: Time.parse('2015-07-06 00:00:00'), # week 28
+                             initial_dt: Time.parse('2015-07-01 00:00:00')
           end
         end
 
         context 'when breaks second week' do
           context 'first part' do
-            include_examples :should_set_correct_dates do
-              let(:dt) { Time.parse('2015-04-20 00:00:00') } # week 17
-              # cause it will move to the even week
-              let(:expected_next_dt) { Time.parse('2015-04-27 00:00:00') } # week 18
-              let(:expected_initial_dt) { Time.parse('2015-04-13 00:00:00') } # week 18
-            end
+            include_examples :responds_with_correct_times,
+                             today_dt: Time.parse('2015-04-20 00:00:00'), # week 17
+                             # cause it will move to the even week
+                             next_dt: Time.parse('2015-04-27 00:00:00'), # week 18
+                             initial_dt: Time.parse('2015-04-13 00:00:00') # week 18
           end
         end
       end

--- a/spec/models/billing/invoice_period_spec.rb
+++ b/spec/models/billing/invoice_period_spec.rb
@@ -3,9 +3,11 @@
 require 'spec_helper'
 
 describe Billing::InvoicePeriod do
+  subject do
+    Billing::InvoicePeriod.find(id)
+  end
+
   let(:id) { Billing::InvoicePeriod::NAMES.key(name.upcase) }
-  before { @invoice_period = Billing::InvoicePeriod.create(id: id, name: name) }
-  subject { @invoice_period }
 
   shared_examples :should_set_correct_dates do
     let(:dt) { nil }
@@ -20,7 +22,8 @@ describe Billing::InvoicePeriod do
       expect(subject.next_date_from_now.to_time.to_s(:db)).to eq expected_next_from_now_dt.to_time.to_s(:db)
     end
     it 'should return correct initial_date' do
-      expect(subject.initial_date.to_time.to_time.to_s(:db)).to eq expected_initial_dt.to_time.to_s(:db)
+      end_date = Time.now.to_date
+      expect(subject.initial_date(end_date).to_time.to_time.to_s(:db)).to eq expected_initial_dt.to_time.to_s(:db)
     end
   end
 


### PR DESCRIPTION
```sh
$ rspec --format doc spec/jobs/jobs/invoice_job_spec.rb
```

```
App Timezone Europe/Kiev
Yeti DB timezone UTC
CDR DB timezone UTC
ActiveRecord timezone utc

Jobs::Invoice
  #execute
    vendor invoice
      with invoice period monthly
        account was created at 2019-04-03 and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-06-01 00:00:00 +0300'
        account was created at 2019-04-28 and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-06-01 00:00:00 +0300'
      with invoice period weekly simple
        when account was created at 2019-04-03 and now is 2019-04-08
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-04-08 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-08 00:00:00 +0300' to '2019-04-15 00:00:00 +0300'
        when account was created at 2019-04-09 and now is 2019-04-15
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-08 00:00:00 +0300', end_date '2019-04-15 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-15 00:00:00 +0300' to '2019-04-22 00:00:00 +0300'
        when account was created at 2019-04-29 and now is 2019-05-06
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-29 00:00:00 +0300', end_date '2019-05-06 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-05-06 00:00:00 +0300' to '2019-05-13 00:00:00 +0300'
      with invoice period daily
        when account was created at 2019-04-09 and now is 2019-04-10
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-09 00:00:00 +0300', end_date '2019-04-10 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-10 00:00:00 +0300' to '2019-04-11 00:00:00 +0300'
        when account was created at 2019-04-30 and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-30 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-05-02 00:00:00 +0300'
      with invoice period biweekly simple
        when account was created at 2019-04-02 and now is 2019-04-15
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-04-15 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-15 00:00:00 +0300' to '2019-04-29 00:00:00 +0300'
        when account was created at 2019-04-17 and now is 2019-04-29
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-15 00:00:00 +0300', end_date '2019-04-29 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-29 00:00:00 +0300' to '2019-05-13 00:00:00 +0300'
      with invoice period weekly split
        when account was created at 2019-04-09 and now is 2019-04-15
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-08 00:00:00 +0300', end_date '2019-04-15 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-15 00:00:00 +0300' to '2019-04-22 00:00:00 +0300'
        when account was created at 2019-04-25 and now is 2019-04-29
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-22 00:00:00 +0300', end_date '2019-04-29 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-29 00:00:00 +0300' to '2019-05-01 00:00:00 +0300'
        when account was created at 2019-04-30 and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-29 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-05-06 00:00:00 +0300'
        when account was created at 2018-12-31 and now is 2019-01-01
          enqueues Worker::GenerateInvoiceJob with start_date '2018-12-31 00:00:00 +0200', end_date '2019-01-01 00:00:00 +0200', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-01-01 00:00:00 +0200' to '2019-01-07 00:00:00 +0200'
        when account was created at 2019-08-28 and now is 2019-09-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-08-26 00:00:00 +0300', end_date '2019-09-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-09-01 00:00:00 +0300' to '2019-09-02 00:00:00 +0300'
        when account was created at 2019-09-01 and now is 2019-09-02
          enqueues Worker::GenerateInvoiceJob with start_date '2019-09-01 00:00:00 +0300', end_date '2019-09-02 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-09-02 00:00:00 +0300' to '2019-09-09 00:00:00 +0300'
        when account was created at 2019-03-29 and now is 2019-04-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-03-25 00:00:00 +0200', end_date '2019-04-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-01 00:00:00 +0300' to '2019-04-08 00:00:00 +0300'
      with invoice period biweekly split
        when account was created at 2019-04-02 (even) and now is 2019-04-15
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-04-15 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-15 00:00:00 +0300' to '2019-04-29 00:00:00 +0300'
        when account was created at 2019-04-08 (odd) and now is 2019-04-15
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-01 00:00:00 +0300', end_date '2019-04-15 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-15 00:00:00 +0300' to '2019-04-29 00:00:00 +0300'
        when account was created at 2019-04-15 (even) and now is 2019-04-29
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-15 00:00:00 +0300', end_date '2019-04-29 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-29 00:00:00 +0300' to '2019-05-01 00:00:00 +0300'
        when account was created at 2019-04-29 (even) and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-29 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-05-13 00:00:00 +0300'
        when account was created at 2019-04-30 (even) and now is 2019-05-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-04-29 00:00:00 +0300', end_date '2019-05-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-05-01 00:00:00 +0300' to '2019-05-13 00:00:00 +0300'
        when account was created at 2018-12-31 (odd) and now is 2019-01-01
          enqueues Worker::GenerateInvoiceJob with start_date '2018-12-24 00:00:00 +0200', end_date '2019-01-01 00:00:00 +0200', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-01-01 00:00:00 +0200' to '2019-01-07 00:00:00 +0200'
        when account was created at 2019-08-28 (odd) and now is 2019-09-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-08-19 00:00:00 +0300', end_date '2019-09-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-09-01 00:00:00 +0300' to '2019-09-02 00:00:00 +0300'
        when account was created at 2019-08-20 (even) and now is 2019-09-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-08-19 00:00:00 +0300', end_date '2019-09-01 00:00:00 +0300', invoice_type 'Auto Partial'
          changes account next_vendor_invoice_at from '2019-09-01 00:00:00 +0300' to '2019-09-02 00:00:00 +0300'
        when account was created at 2019-09-01 (odd) and now is 2019-09-02
          enqueues Worker::GenerateInvoiceJob with start_date '2019-09-01 00:00:00 +0300', end_date '2019-09-02 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-09-02 00:00:00 +0300' to '2019-09-16 00:00:00 +0300'
        when account was created at 2019-03-29 (odd) and now is 2019-04-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-03-18 00:00:00 +0200', end_date '2019-04-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-01 00:00:00 +0300' to '2019-04-15 00:00:00 +0300'
        when account was created at 2019-03-21 (even) and now is 2019-04-01
          enqueues Worker::GenerateInvoiceJob with start_date '2019-03-18 00:00:00 +0200', end_date '2019-04-01 00:00:00 +0300', invoice_type 'Auto Full'
          changes account next_vendor_invoice_at from '2019-04-01 00:00:00 +0300' to '2019-04-15 00:00:00 +0300'

Finished in 10.04 seconds (files took 5.04 seconds to load)
54 examples, 0 failures
```