### PR TITLE
parallel tests on travis

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,4 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out log/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::SummaryLogger --out log/spec_summary.log
+--format ParallelTests::RSpec::FailuresLogger --out log/failing_specs.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ services:
 git:
   depth: false
 
+cache:
+  directories:
+    - vendor/bundle
+
 env:
   secure: "V6Fww6hQLaoajQmJnS8cyUAv7AEEwtrJDXkZC08/CRs10PoozP0idzgYCk3aHM0l2BiN/dvZCb9rNL9ZLv9LYmnZCvQ/OVOC6vFZHWebcd0wf3RWAPZzRsAXrFtRxDu9JbzJcQsW95c+9rKrtiiFSIQHUni1CYEbmFx4J7hB3Fl5Hb60wMbP5aanS9LP2X0f5Rl7idkXXxxY/3eFg4ZZWIODlCnuiYNuyuU26iR5I9VsL6+bu77aFZJ85z1ywvVvqV3ZIY0rr2EWQPtg4gilAnnkFjPDGz6vYIATuMPHflK/M+gcvLJqt0B/s8wMPX2mtNWJ191um2JoYBgZh6dykg89YUIsR4DFcLGTLRyK5X/6iLiBbkl7UwKU4/UDdiKt6mnh9KG8kM5c6U9QXUglvfoA7x4KlLNRPohqbxZskw5OTnf30zMKiDSL0buCA8Y1m5PBAdqR53/ruyxDZLgGd2Qv0lTktBxYYD04PBUbrW7SSxbTkzOudvXrXbGc0B2YhJnMTl3qkUSiXcxKyrROKdhMKL+Wg96YRnkJ01eMfqK9w56iAMfe3TIl+jFnvLLUFZlKC6jClW1tb9eRs+gxW6OLuDl44ReZ6q9qJhOXAIXXsJ3uon7ZT86hyQ8C8t4rteUUEXfCT/+lPtqmlD3WmkZ3abpHhlBIY9/GfqoNoyM="
   global:
@@ -63,6 +67,7 @@ script:
 jobs:
   include:
     - stage: test
+      env: CACHE_NAME=test
       name: Rubocop and Bundle Audit
       script:
         - bundle install --jobs=3 --retry=3 --deployment
@@ -73,7 +78,7 @@ jobs:
         - bundle exec rake bundle:audit
 
     - stage: test
-      env: JOB_NAME=cucumber
+      env: CACHE_NAME=test
       name: Cucumber
       script:
         - bundle install --jobs=3 --retry=3 --deployment
@@ -83,6 +88,7 @@ jobs:
         - bundle exec cucumber
 
     - stage: test
+      env: CACHE_NAME=pgq_test
       name: PGQ Processors rspec
       script:
         - bundle install --jobs=3 --retry=3 --deployment
@@ -94,7 +100,7 @@ jobs:
 
     - stage: stable package
       if: branch != master OR tag =~ ^.*$
-      env: JOB_NAME=jessie_package
+      env: CACHE_NAME=jessie_package
       name: Stable Jessie Package
       script: &build_jessie
         - rm -vf config/database.yml
@@ -111,6 +117,7 @@ jobs:
 
     - stage: stable package
       if: branch != master OR tag =~ ^.*$
+      env: CACHE_NAME=stretch_package
       name: Stable Stretch Package
       script: &build_stretch
         - rm -vf config/database.yml
@@ -127,6 +134,7 @@ jobs:
 
     - stage: nightly package
       if: branch = master
+      env: CACHE_NAME=jessie_package
       name: Nightly Jessie Package
       script: *build_jessie
       deploy:
@@ -139,6 +147,7 @@ jobs:
 
     - stage: nightly package
       if: branch = master
+      env: CACHE_NAME=stretch_package
       name: Nightly Stretch Package
       script: *build_stretch
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,17 @@ git:
 
 env:
   secure: "V6Fww6hQLaoajQmJnS8cyUAv7AEEwtrJDXkZC08/CRs10PoozP0idzgYCk3aHM0l2BiN/dvZCb9rNL9ZLv9LYmnZCvQ/OVOC6vFZHWebcd0wf3RWAPZzRsAXrFtRxDu9JbzJcQsW95c+9rKrtiiFSIQHUni1CYEbmFx4J7hB3Fl5Hb60wMbP5aanS9LP2X0f5Rl7idkXXxxY/3eFg4ZZWIODlCnuiYNuyuU26iR5I9VsL6+bu77aFZJ85z1ywvVvqV3ZIY0rr2EWQPtg4gilAnnkFjPDGz6vYIATuMPHflK/M+gcvLJqt0B/s8wMPX2mtNWJ191um2JoYBgZh6dykg89YUIsR4DFcLGTLRyK5X/6iLiBbkl7UwKU4/UDdiKt6mnh9KG8kM5c6U9QXUglvfoA7x4KlLNRPohqbxZskw5OTnf30zMKiDSL0buCA8Y1m5PBAdqR53/ruyxDZLgGd2Qv0lTktBxYYD04PBUbrW7SSxbTkzOudvXrXbGc0B2YhJnMTl3qkUSiXcxKyrROKdhMKL+Wg96YRnkJ01eMfqK9w56iAMfe3TIl+jFnvLLUFZlKC6jClW1tb9eRs+gxW6OLuDl44ReZ6q9qJhOXAIXXsJ3uon7ZT86hyQ8C8t4rteUUEXfCT/+lPtqmlD3WmkZ3abpHhlBIY9/GfqoNoyM="
+  global:
+    TEST_GROUPS_QTY=8
+  matrix:
+    - TEST_GROUP=1
+    - TEST_GROUP=2
+    - TEST_GROUP=3
+    - TEST_GROUP=4
+    - TEST_GROUP=5
+    - TEST_GROUP=6
+    - TEST_GROUP=7
+    - TEST_GROUP=8
 
 before_install:
   - gem update --system
@@ -38,9 +49,21 @@ stages:
   - stable package
   - nightly package
 
+# by default stage=test
+# matrix only works for top level script
+script:
+  - echo "Running parallel spec $TEST_GROUP/$TEST_GROUPS_QTY"
+  - bundle install --jobs=3 --retry=3 --deployment
+  - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
+  - RAILS_ENV=test bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
+  - RAILS_ENV=test bundle exec rake db:seed
+  - bundle exec parallel_test spec/ -n $TEST_GROUPS_QTY --only-group $TEST_GROUP --group-by filesize --type rspec
+  - script/format_runtime_log log/parallel_runtime_rspec.log
+
 jobs:
   include:
     - stage: test
+      name: Rubocop and Bundle Audit
       script:
         - bundle install --jobs=3 --retry=3 --deployment
         - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
@@ -48,9 +71,10 @@ jobs:
         - RAILS_ENV=test bundle exec rake db:seed
         - bundle exec rubocop -P
         - bundle exec rake bundle:audit
-        - bundle exec rspec
 
     - stage: test
+      env: JOB_NAME=cucumber
+      name: Cucumber
       script:
         - bundle install --jobs=3 --retry=3 --deployment
         - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
@@ -59,6 +83,7 @@ jobs:
         - bundle exec cucumber
 
     - stage: test
+      name: PGQ Processors rspec
       script:
         - bundle install --jobs=3 --retry=3 --deployment
         - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
@@ -69,6 +94,8 @@ jobs:
 
     - stage: stable package
       if: branch != master OR tag =~ ^.*$
+      env: JOB_NAME=jessie_package
+      name: Stable Jessie Package
       script: &build_jessie
         - rm -vf config/database.yml
         - docker build -t yeti-web -f ./ci/build_jessie.Dockerfile .
@@ -84,6 +111,7 @@ jobs:
 
     - stage: stable package
       if: branch != master OR tag =~ ^.*$
+      name: Stable Stretch Package
       script: &build_stretch
         - rm -vf config/database.yml
         - docker build -t yeti-web -f ./ci/build_stretch.Dockerfile .
@@ -99,6 +127,7 @@ jobs:
 
     - stage: nightly package
       if: branch = master
+      name: Nightly Jessie Package
       script: *build_jessie
       deploy:
         skip_cleanup: true
@@ -110,6 +139,7 @@ jobs:
 
     - stage: nightly package
       if: branch = master
+      name: Nightly Stretch Package
       script: *build_stretch
       deploy:
         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ stages:
 # by default stage=test
 # matrix only works for top level script
 script:
-  - echo "Running parallel spec $TEST_GROUP/$TEST_GROUPS_QTY"
   - bundle install --jobs=3 --retry=3 --deployment
   - RAILS_ENV=test bundle exec rake db:create db:structure:load db:migrate
   - RAILS_ENV=test bundle exec rake db:second_base:create db:second_base:structure:load db:second_base:migrate
   - RAILS_ENV=test bundle exec rake db:seed
   - bundle exec parallel_test spec/ -n $TEST_GROUPS_QTY --only-group $TEST_GROUP --group-by filesize --type rspec
+  - echo "Slowest spec files for TEST_GROUP $TEST_GROUP from $TEST_GROUPS_QTY"
   - script/format_runtime_log log/parallel_runtime_rspec.log
 
 jobs:

--- a/Gemfile
+++ b/Gemfile
@@ -90,10 +90,10 @@ group :development, :test do
   gem 'bundler-audit', require: false
   gem 'database_cleaner'
   gem 'factory_girl_rails', '4.8.0'
+  gem 'parallel_tests'
   gem 'rspec-rails'
   gem 'rspec_api_documentation', '~> 5.0.0'
   gem 'rubocop', require: false
-  gem 'simplecov', require: false, group: :test
 end
 
 gem 'apitome', '~> 0.1.0'
@@ -105,6 +105,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
+  gem 'simplecov', require: false
   gem 'webmock'
 end
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,6 +376,8 @@ GEM
       activerecord (>= 4.2, < 5.3)
       request_store (~> 1.1)
     parallel (1.12.1)
+    parallel_tests (2.29.0)
+      parallel
     parser (2.5.3.0)
       ast (~> 2.4.0)
     pg (1.0.0)
@@ -590,6 +592,7 @@ DEPENDENCIES
   odf-report!
   paper_trail
   parallel
+  parallel_tests
   pg
   postgres_ext!
   puma

--- a/script/format_runtime_log
+++ b/script/format_runtime_log
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+log_path = ARGV[0]
+filter_qty = (ARGV[1] || 10).to_i
+
+unless File.exist?(log_path)
+  puts "File #{log_path.inspect} does not exist. skipping"
+  exit
+end
+
+content = File.read(log_path).split("\n").select { |line| line.start_with?('spec/') }
+data = content.map { |line| line.split(':') }.sort_by { |parts| parts[1].to_f }.reverse[0..filter_qty]
+output_content = data.map { |parts| "  #{parts[1].to_f.round(2)}\tseconds for #{parts[0]}" }
+
+puts "Top #{filter_qty} slowest spec files:"
+puts output_content.join("\n")
+puts "\nTotal #{content.size} spec files."

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,12 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.profile_examples = 10
+  config.order = :random
+  Kernel.srand config.seed
+
   config.include FactoryGirl::Syntax::Methods
   config.include RspecRequestHelper, type: :request
   config.extend Helpers::ActiveAdminForms::ExampleGroups, type: :feature


### PR DESCRIPTION
slowest test group executes 16 minutes (5 minutes preparing and 11 minutes tests)
but this can be improved by splitting huge test files into smaller ones

`TEST_GROUP=1`

```
Top 10 slowest example groups:
  Create new Radius Auth Profile
    9.11 seconds average (27.32 seconds / 3 examples) ./spec/features/equipment/radius_auth_profile/new_radius_auth_profile_spec.rb:5
  Create new Interval Cdr
    2.7 seconds average (8.09 seconds / 3 examples) ./spec/features/reports/interval_cdrs/new_interval_cdr_spec.rb:5
  Create new Interval Cdr Scheduler
    2.45 seconds average (7.34 seconds / 3 examples) ./spec/features/reports/interval_cdr_schedulers/new_interval_cdr_scheduler_spec.rb:5
  Create new Sensor
    1.8 seconds average (5.39 seconds / 3 examples) ./spec/features/system/sensors/new_sensor_spec.rb:5
  Create new Lnp Resolver
    1.5 seconds average (4.49 seconds / 3 examples) ./spec/features/system/lnp_resolvers/new_lnp_resolver_spec.rb:5
  Create new Lua Script
    1.41 seconds average (4.23 seconds / 3 examples) ./spec/features/system/lua_scripts/new_lua_script_spec.rb:5
  Create new Numberlist
    1.17 seconds average (3.51 seconds / 3 examples) ./spec/features/routing/numberlists/new_numberlist_spec.rb:5
  Index Gateways
    0.92451 seconds average (0.92451 seconds / 1 example) ./spec/features/equipment/gateways/index_gateways_spec.rb:5
  Copy Dialpeer
    0.89498 seconds average (0.89498 seconds / 1 example) ./spec/features/routing/dialpeers/copy_dialpeer_spec.rb:5
  Create new Destinations
    0.72246 seconds average (0.72246 seconds / 1 example) ./spec/features/routing/destinations/create_destination_spec.rb:5
Finished in 11 minutes 37 seconds (files took 9.72 seconds to load)
1985 examples, 0 failures
```

```
600.86	seconds for spec/controllers/api/rest/admin/cdr/cdrs_controller_spec.rb
27.32	seconds for spec/features/equipment/radius_auth_profile/new_radius_auth_profile_spec.rb
8.09	seconds for spec/features/reports/interval_cdrs/new_interval_cdr_spec.rb
7.34	seconds for spec/features/reports/interval_cdr_schedulers/new_interval_cdr_scheduler_spec.rb
6.57	seconds for spec/models/cdr/auth_log_table_spec.rb
5.39	seconds for spec/features/system/sensors/new_sensor_spec.rb
4.5	seconds for spec/models/routing/routing_tag_spec.rb
4.49	seconds for spec/features/system/lnp_resolvers/new_lnp_resolver_spec.rb
4.23	seconds for spec/features/system/lua_scripts/new_lua_script_spec.rb
3.51	seconds for spec/features/routing/numberlists/new_numberlist_spec.rb
```


`TEST_GROUP=2`
```
Top 10 slowest example groups:
  Index Invoices
    13.43 seconds average (13.43 seconds / 1 example) ./spec/features/billing/invoices/index_invoices_feature_spec.rb:5
  Create new Gateway group
    3.58 seconds average (3.58 seconds / 1 example) ./spec/features/equipment/gateway_groups/new_gateway_group_spec.rb:5
  Create new Account
    2.66 seconds average (2.66 seconds / 1 example) ./spec/features/billing/accounts/new_account_spec.rb:5
  Create new Dialpeer Next Rate
    2.19 seconds average (6.58 seconds / 3 examples) ./spec/features/routing/dialpeer_next_rates/new_dialpeer_next_rate_spec.rb:5
  Create new Vendor Traffic
    2.03 seconds average (6.1 seconds / 3 examples) ./spec/features/reports/vendor_traffics/new_vendor_traffic_spec.rb:5
  Create new Codec Group
    1.75 seconds average (7.01 seconds / 4 examples) ./spec/features/equipment/codec_groups/new_codec_group_spec.rb:5
  Create new Vendor Traffic Scheduler
    1.48 seconds average (4.45 seconds / 3 examples) ./spec/features/reports/vendor_traffic_schedulers/new_vendor_traffic_scheduler_spec.rb:5
  Create new Area
    1.01 seconds average (3.03 seconds / 3 examples) ./spec/features/routing/areas/new_area_spec.rb:5
  System IP access
    0.6578 seconds average (0.6578 seconds / 1 example) ./spec/acceptance/rest/system/api/ip_access_spec.rb:6
  Copy Rateplan action
    0.56081 seconds average (1.12 seconds / 2 examples) ./spec/features/routing/rateplans/copy_rateplan_spec.rb:5
Finished in 1 minute 57.16 seconds (files took 8.36 seconds to load)
291 examples, 0 failures, 3 pending
```

```
39.06	seconds for spec/controllers/api/rest/admin/destination_next_rates_spec.rb
13.43	seconds for spec/features/billing/invoices/index_invoices_feature_spec.rb
8.86	seconds for spec/models/customers_auth_spec.rb
7.01	seconds for spec/features/equipment/codec_groups/new_codec_group_spec.rb
6.58	seconds for spec/features/routing/dialpeer_next_rates/new_dialpeer_next_rate_spec.rb
6.1	seconds for spec/features/reports/vendor_traffics/new_vendor_traffic_spec.rb
5.74	seconds for spec/requests/api/rest/customer/v1/accounts_spec.rb
4.45	seconds for spec/features/reports/vendor_traffic_schedulers/new_vendor_traffic_scheduler_spec.rb
3.58	seconds for spec/features/equipment/gateway_groups/new_gateway_group_spec.rb
3.03	seconds for spec/features/routing/areas/new_area_spec.rb
```

`TEST_GROUP=3`

```
Top 10 slowest example groups:
  Create new Gateway
    6.71 seconds average (40.28 seconds / 6 examples) ./spec/features/equipment/gateways/new_gateway_spec.rb:5
  Create new Customer Traffic
    2.08 seconds average (6.23 seconds / 3 examples) ./spec/features/reports/customer_traffics/new_customer_traffic_spec.rb:5
  Create new Destination Next Rate
    2.01 seconds average (6.04 seconds / 3 examples) ./spec/features/routing/destination_next_rates/new_destination_next_rate_spec.rb:5
  Create new Billing Contact
    1.98 seconds average (5.95 seconds / 3 examples) ./spec/features/billing/contacts/new_contact_spec.rb:5
  Export Customers Auth
    1.3 seconds average (1.3 seconds / 1 example) ./spec/features/routing/customers_auths/export_customers_auth_spec.rb:5
  CDR show
    1.22 seconds average (1.22 seconds / 1 example) ./spec/features/cdr/cdr_history/cdr_show_spec.rb:5
  Create new Network
    1.12 seconds average (3.36 seconds / 3 examples) ./spec/features/system/networks/new_network_spec.rb:5
  Importing::CustomersAuth => CustomersAuth delayed_job
    0.99589 seconds average (11.95 seconds / 12 examples) ./spec/models/jobs/importing_customers_auth_job_spec.rb:6
  Create new Dialpeer
    0.83885 seconds average (0.83885 seconds / 1 example) ./spec/features/routing/dialpeers/edit_dialpeer_spec.rb:5
  CDRs index
    0.74111 seconds average (2.22 seconds / 3 examples) ./spec/features/cdr/cdr_history/cdrs_index_spec.rb:5
Finished in 4 minutes 58.5 seconds (files took 8.14 seconds to load)
516 examples, 0 failures
```

```
174.37	seconds for spec/controllers/api/rest/admin/customers_auths_controller_spec.rb
40.28	seconds for spec/features/equipment/gateways/new_gateway_spec.rb
14.88	seconds for spec/models/customers_auth_normalized_spec.rb
12.52	seconds for spec/controllers/api/rest/admin/payments_controller_spec.rb
11.95	seconds for spec/models/jobs/importing_customers_auth_job_spec.rb
6.23	seconds for spec/features/reports/customer_traffics/new_customer_traffic_spec.rb
6.04	seconds for spec/features/routing/destination_next_rates/new_destination_next_rate_spec.rb
5.95	seconds for spec/features/billing/contacts/new_contact_spec.rb
3.36	seconds for spec/features/system/networks/new_network_spec.rb
2.22	seconds for spec/features/cdr/cdr_history/cdrs_index_spec.rb
```

`TEST_GROUP=4`

```
Top 10 slowest example groups:
  Create new Custom Cdr
    10.98 seconds average (32.93 seconds / 3 examples) ./spec/features/reports/custom_cdrs/new_custom_cdr_spec.rb:5
  Create new Disconnect Policy Code
    1.58 seconds average (4.75 seconds / 3 examples) ./spec/features/equipment/disconnect_policy_codes/new_disconnect_policy_code_spec.rb:5
  Create new Smtp Connection
    1.46 seconds average (4.38 seconds / 3 examples) ./spec/features/system/smtp_connections/new_smtp_connection_spec.rb:5
  Create new Routing Plan Lnp Rule
    1.4 seconds average (4.19 seconds / 3 examples) ./spec/features/routing/routing_plan_lnp_rules/new_routing_plan_lnp_rule_spec.rb:5
  Create new Routing Plan
    1.33 seconds average (1.33 seconds / 1 example) ./spec/features/routing/routing_plans/new_routing_plan_spec.rb:5
  Create new Numberlist Item
    1.17 seconds average (3.51 seconds / 3 examples) ./spec/features/routing/numberlist_items/new_numberlist_item_spec.rb:5
  Edit Customers Auth
    0.80589 seconds average (0.80589 seconds / 1 example) ./spec/features/routing/customers_auths/edit_customers_auth_spec.rb:5
  Index Customer Auths
    0.73326 seconds average (0.73326 seconds / 1 example) ./spec/features/routing/customers_auths/index_customer_auth_spec.rb:5
  Importing::Dialpeer => Dialpeer delayed_job
    0.62275 seconds average (6.85 seconds / 11 examples) ./spec/models/jobs/importing_dialpeer_job_spec.rb:6
  Index Dialpeer
    0.59539 seconds average (0.59539 seconds / 1 example) ./spec/features/routing/dialpeers/index_dialpeer_spec.rb:5
Finished in 1 minute 48.73 seconds (files took 7.37 seconds to load)
205 examples, 0 failures
```

```
32.93	seconds for spec/features/reports/custom_cdrs/new_custom_cdr_spec.rb
12.14	seconds for spec/models/jobs/jobs/calls_monitoring_spec.rb
7.39	seconds for spec/controllers/api/rest/admin/contacts_controller_spec.rb
6.85	seconds for spec/models/jobs/importing_dialpeer_job_spec.rb
4.75	seconds for spec/features/equipment/disconnect_policy_codes/new_disconnect_policy_code_spec.rb
4.38	seconds for spec/features/system/smtp_connections/new_smtp_connection_spec.rb
4.34	seconds for spec/models/cdr/table_spec.rb
4.19	seconds for spec/features/routing/routing_plan_lnp_rules/new_routing_plan_lnp_rule_spec.rb
3.51	seconds for spec/features/routing/numberlist_items/new_numberlist_item_spec.rb
2.63	seconds for spec/requests/api/rest/admin/destination_next_rates_spec.rb
```

`TEST_GROUP=5`

```
Top 10 slowest example groups:
  Edit Nunberlist Item
    12.79 seconds average (12.79 seconds / 1 example) ./spec/features/routing/numberlist_items/edit_numberlist_item_spec.rb:5
  Create new Routing Plan Static Route Batch Creator
    3.09 seconds average (9.27 seconds / 3 examples) ./spec/features/routing/routing_plan_static_route_batch_creators/new_routing_plan_static_route_batch_creator_spec.rb:5
  Create new Routing Plan Static Route
    1.72 seconds average (5.16 seconds / 3 examples) ./spec/features/routing/routing_plan_static_routes/new_routing_plan_static_route_spec.rb:5
  Create new Rateplan Duplicator
    1.19 seconds average (3.58 seconds / 3 examples) ./spec/features/routing/rateplan_duplicators/new_rateplan_duplicator_spec.rb:5
  Create new Rateplan
    1.18 seconds average (1.18 seconds / 1 example) ./spec/features/routing/rateplans/new_rateplan_spec.rb:5
  Copy Customers Auth
    1.04 seconds average (1.04 seconds / 1 example) ./spec/features/routing/customers_auths/copy_customers_auth_spec.rb:12
  Copy Routing group with dialpeers action
    0.71751 seconds average (0.71751 seconds / 1 example) ./spec/features/routing/routing_groups/copy_routing_group_with_dialpeers_spec.rb:5
  Copy Rateplan action
    0.70646 seconds average (0.70646 seconds / 1 example) ./spec/features/routing/rateplans/copy_rateplan_with_destinations_spec.rb:5
  Importing::Dialpeer
    0.5354 seconds average (3.21 seconds / 6 examples) ./spec/models/importing/importing_dialpeer_spec.rb:7
  Gateway inband dtmf filtering mode
    0.42931 seconds average (0.85863 seconds / 2 examples) ./spec/acceptance/rest/admin/api/equipment/gateway_inband_dtmf_filtering_modes_spec.rb:6
Finished in 3 minutes 20.9 seconds (files took 8.07 seconds to load)
737 examples, 0 failures, 11 pending
```

```
73.09	seconds for spec/controllers/api/rest/admin/destinations_controller_spec.rb
53.12	seconds for spec/controllers/api/rest/admin/accounts_controller_spec.rb
12.79	seconds for spec/features/routing/numberlist_items/edit_numberlist_item_spec.rb
9.89	seconds for spec/models/billing/invoice_period_spec.rb
9.27	seconds for spec/features/routing/routing_plan_static_route_batch_creators/new_routing_plan_static_route_batch_creator_spec.rb
6.47	seconds for spec/controllers/api/rest/admin/rateplans_controller_spec.rb
5.16	seconds for spec/features/routing/routing_plan_static_routes/new_routing_plan_static_route_spec.rb
3.58	seconds for spec/features/routing/rateplan_duplicators/new_rateplan_duplicator_spec.rb
3.21	seconds for spec/models/importing/importing_dialpeer_spec.rb
2.83	seconds for spec/models/jobs/importing_numberlist_item_job_spec.rb
```

`TEST_GROUP=6`

```
Top 10 slowest example groups:
  Index Admin Users
    12.95 seconds average (12.95 seconds / 1 example) ./spec/features/system/admin_users/index_admin_user_spec.rb:5
  Create new Dialpeer
    4.56 seconds average (13.67 seconds / 3 examples) ./spec/features/routing/dialpeers/new_dialpeer_spec.rb:5
  Create new Radius Accounting Profile
    1.75 seconds average (5.26 seconds / 3 examples) ./spec/features/equipment/radius_accounting_profiles/new_radius_accounting_profile_spec.rb:5
  Create new Registration
    1.62 seconds average (4.85 seconds / 3 examples) ./spec/features/equipment/registrations/new_registration_spec.rb:5
  Create new Admin User
    1.49 seconds average (4.46 seconds / 3 examples) ./spec/features/system/admin_users/new_admin_user_spec.rb:5
  Create new Network Prefix
    1.28 seconds average (3.85 seconds / 3 examples) ./spec/features/system/network_prefixes/new_network_prefix_spec.rb:5
  Create new Routing Group Duplicator
    1.08 seconds average (3.23 seconds / 3 examples) ./spec/features/routing/routing_group_duplicators/new_routing_group_duplicator_spec.rb:5
  Create new Disconnect Policy
    1.02 seconds average (3.05 seconds / 3 examples) ./spec/features/equipment/disconnect_policies/new_disconnect_policy_spec.rb:5
  Create new Routing Tag
    0.9977 seconds average (2.99 seconds / 3 examples) ./spec/features/routing/routing_tags/new_routing_tag_spec.rb:5
  Export Gateways
    0.51339 seconds average (0.51339 seconds / 1 example) ./spec/features/equipment/gateways/export_gateways_spec.rb:5
Finished in 5 minutes 17 seconds (files took 8.2 seconds to load)
1037 examples, 0 failures
```

```
106.43	seconds for spec/controllers/api/rest/admin/dialpeers_controller_spec.rb
37.48	seconds for spec/controllers/api/rest/admin/routing/numberlist_items_controller_spec.rb
34.66	seconds for spec/controllers/api/rest/admin/dialpeer_next_rates_controller_spec.rb
24.6	seconds for spec/controllers/api/rest/admin/routing/numberlists_controller_spec.rb
22.6	seconds for spec/controllers/api/rest/admin/contractors_controller_spec.rb
13.84	seconds for spec/controllers/api/rest/admin/routing_plans_controller_spec.rb
13.67	seconds for spec/features/routing/dialpeers/new_dialpeer_spec.rb
12.95	seconds for spec/features/system/admin_users/index_admin_user_spec.rb
5.26	seconds for spec/features/equipment/radius_accounting_profiles/new_radius_accounting_profile_spec.rb
4.94	seconds for spec/controllers/api/rest/admin/routing/areas_controller_spec.rb
```

`TEST_GROUP=7`

```
Top 10 slowest example groups:
  Create new Load Balancer
    7.57 seconds average (22.72 seconds / 3 examples) ./spec/features/system/load_balancers/new_load_balancer_spec.rb:5
  Create new Custom Cdr Scheduler
    4.25 seconds average (12.76 seconds / 3 examples) ./spec/features/reports/custom_cdr_schedulers/new_custom_cdr_scheduler_spec.rb:5
  Create new CDR export
    3.16 seconds average (3.16 seconds / 1 example) ./spec/features/cdr/cdr_exports/new_cdr_export_spec.rb:5
  Create new Api Access
    1.59 seconds average (1.59 seconds / 1 example) ./spec/features/system/api_accesses/new_api_access_spec.rb:5
  Create new Customer Traffic Scheduler
    1.4 seconds average (4.19 seconds / 3 examples) ./spec/features/reports/customer_traffic_schedulers/new_customer_traffic_scheduler_spec.rb:5
  Create new Payment
    1.39 seconds average (1.39 seconds / 1 example) ./spec/features/billing/payments/new_payment_spec.rb:5
  Create new Area Prefix
    1.13 seconds average (3.38 seconds / 3 examples) ./spec/features/routing/area_prefixes/new_area_prefix_spec.rb:5
  Create new Contractor
    0.44817 seconds average (0.44817 seconds / 1 example) ./spec/features/billing/contractors/new_contractor_spec.rb:5
  Export Auth Logs
    0.43604 seconds average (0.43604 seconds / 1 example) ./spec/features/cdr/auth_logs/export_auth_logs_spec.rb:5
  YetiMail
    0.419740m seconds average (0.41974 seconds / 1 example) ./spec/mailers/yeti_mail_spec.rb:5
Finished in 7 minutes 12 seconds (files took 8.11 seconds to load)
1135 examples, 0 failures
```

```
332.85	seconds for spec/controllers/api/rest/admin/gateways_controller_spec.rb
22.72	seconds for spec/features/system/load_balancers/new_load_balancer_spec.rb
12.76	seconds for spec/features/reports/custom_cdr_schedulers/new_custom_cdr_scheduler_spec.rb
12.21	seconds for spec/controllers/api/rest/admin/routing/routing_tag_detection_rules_controller_spec.rb
4.25	seconds for spec/controllers/api/rest/admin/codec_groups_controller_spec.rb
4.19	seconds for spec/features/reports/customer_traffic_schedulers/new_customer_traffic_scheduler_spec.rb
3.57	seconds for spec/routing/route_spec.rb
3.4	seconds for spec/controllers/api/rest/admin/routing_groups_controller_spec.rb
3.38	seconds for spec/features/routing/area_prefixes/new_area_prefix_spec.rb
3.16	seconds for spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
```

`TEST_GROUP=8`

```
Top 10 slowest example groups:
  Index Rateplans
    12.76 seconds average (12.76 seconds / 1 example) ./spec/features/routing/rateplans/index_rateplan_spec.rb:5
  Create new Invoice
    2.19 seconds average (2.19 seconds / 1 example) ./spec/features/billing/invoices/new_invoice_feature_spec.rb:5
  Create new LNP Database
    1.98 seconds average (5.94 seconds / 3 examples) ./spec/features/equipment/lnp_databases/new_lnp_database_spec.rb:5
  Api::Rest::Customer::V1::RateplansController
    1.8 seconds average (25.16 seconds / 14 examples) ./spec/requests/api/rest/customer/v1/rateplans_controller_spec.rb:5
  Create new Routing Tag Detection Rule
    0.99563 seconds average (5.97 seconds / 6 examples) ./spec/features/routing/routing_tag_detection_rules/new_routing_tag_detection_rule_spec.rb:5
  Api::Rest::Customer::V1::RatesController
    0.83291 seconds average (11.66 seconds / 14 examples) ./spec/requests/api/rest/customer/v1/rates_controller_spec.rb:5
  Edit Destination
    0.67574 seconds average (0.67574 seconds / 1 example) ./spec/features/routing/destinations/edit_destination_spec.rb:5
  Codec groups
    0.66192 seconds average (3.31 seconds / 5 examples) ./spec/acceptance/rest/admin/api/codec_groups_spec.rb:6
  Api::Rest::Customer::V1::CdrsController
    0.469 seconds average (11.26 seconds / 24 examples) ./spec/requests/api/rest/customer/v1/cdrs_controller_spec.rb:5
  Api::Rest::Admin::Cdr::AuthLogsController
    0.44241 seconds average (226.07 seconds / 511 examples) ./spec/controllers/api/rest/admin/cdr/auth_logs_controller_spec.rb:5

Finished in 5 minutes 30 seconds (files took 8.25 seconds to load)
688 examples, 0 failure
```

```
226.07	seconds for spec/controllers/api/rest/admin/cdr/auth_logs_controller_spec.rb
25.16	seconds for spec/requests/api/rest/customer/v1/rateplans_controller_spec.rb
12.76	seconds for spec/features/routing/rateplans/index_rateplan_spec.rb
11.66	seconds for spec/requests/api/rest/customer/v1/rates_controller_spec.rb
11.26	seconds for spec/requests/api/rest/customer/v1/cdrs_controller_spec.rb
7.74	seconds for spec/controllers/api/rest/admin/gateway_groups_controller_spec.rb
5.97	seconds for spec/features/routing/routing_tag_detection_rules/new_routing_tag_detection_rule_spec.rb
5.94	seconds for spec/features/equipment/lnp_databases/new_lnp_database_spec.rb
3.31	seconds for spec/acceptance/rest/admin/api/codec_groups_spec.rb
2.35	seconds for spec/models/jobs/importing_gateway_group_job_spec.rb
```