### PR TITLE
Fix admin system/countries get_networks

### DIFF
--- a/app/models/system/country.rb
+++ b/app/models/system/country.rb
@@ -12,7 +12,7 @@
 class System::Country < Yeti::ActiveRecord
   self.table_name = 'sys.countries'
   has_many :prefixes, class_name: 'System::NetworkPrefix'
-  has_many :networks, -> { uniq }, through: :prefixes
+  has_many :networks, -> { distinct }, through: :prefixes
 
   def display_name
     "#{id} | #{name}"

--- a/spec/features/routing/destinations/index_destination_spec.rb
+++ b/spec/features/routing/destinations/index_destination_spec.rb
@@ -2,13 +2,40 @@
 
 require 'spec_helper'
 
-describe 'Index Destinations', type: :feature do
-  include_context :login_as_admin
+describe 'Index Destinations', type: :feature, js: true do
+  subject do
+    visit destinations_path
+  end
 
-  include_examples :test_index_table_exist do
+  include_context :login_as_admin
+  let!(:records) { create_list(:destination, 2) }
+
+  it 'has record' do
+    subject
+    expect(page).to have_css('.resource_id_link', text: records.first.id)
+  end
+
+  context 'when filter by country and network' do
+    let!(:country) { create(:country, name: 'United Stated', iso2: 'US') }
+    let!(:network) { create(:network, name: 'some network') }
+    let!(:network_prefix) { create(:network_prefix, country: country, network: network, prefix: '123') }
+    let!(:matched_record) { create(:destination, prefix: network_prefix.prefix) }
     before do
-      @item = create(:destination)
-      visit destinations_path
+      canada = create(:country, name: 'Canada', iso2: 'CA')
+      other_network = create(:network, name: 'other network')
+      create(:network_prefix, country: canada, network: other_network, prefix: '23435678')
+    end
+
+    it 'selects correct network' do
+      subject
+
+      scroll_to_element('.filter_form input[type="submit"]')
+      chosen_select('#q_network_prefix_country_id_eq_chosen', search: country.display_name)
+      chosen_select('#q_network_prefix_network_id_eq_chosen', search: network.name)
+      page.find('.filter_form input[type="submit"]').click
+
+      expect(page).to have_css('.resource_id_link', text: matched_record.id)
+      expect(page).to have_css('table.index_table tbody tr', count: 1)
     end
   end
 end


### PR DESCRIPTION
Fixes #547

Relation method `#uniq` returns an array which breaks associations loading in AR.
Chain method `#distinct` will do the trick.