### PR TITLE
fix rescue_from order in active_admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,11 +20,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from StandardError, with: :capture_error!
+
   include CaptureError::ControllerMethods
   include Concerns::Rescuers
   include Concerns::IndexMaxRecords
-
-  rescue_from StandardError, with: :capture_error!
 
   def redirect_to_back(default = root_url)
     if !request.env['HTTP_REFERER'].blank? && (request.env['HTTP_REFERER'] != request.env['REQUEST_URI'])


### PR DESCRIPTION
regression added when sentry capture errors implemented

all custom rescue from defined in `app/controllers/concerns/rescuers.rb` was broken