### PR TITLE
[1.10] improve cdr indexes, change originated cps charts sql, update customer api cdrs

### DIFF
--- a/app/models/jsonapi_model/originated_cps.rb
+++ b/app/models/jsonapi_model/originated_cps.rb
@@ -23,7 +23,7 @@ module JsonapiModel
 
     def _save
       scope = Cdr::Cdr
-              .where(customer_acc_id: account.id, routing_attempt: 1)
+              .where(customer_acc_id: account.id, is_last_cdr: true)
               .where('time_start BETWEEN ? AND ?', from_time, to_time)
               .group(TIME_START_SQL)
               .order(TIME_START_SQL)

--- a/app/resources/api/rest/customer/v1/cdr_resource.rb
+++ b/app/resources/api/rest/customer/v1/cdr_resource.rb
@@ -95,7 +95,6 @@ class Api::Rest::Customer::V1::CdrResource < Api::Rest::Customer::V1::BaseResour
   ransack_filter :dialpeer_initial_interval, type: :number
   ransack_filter :dialpeer_next_interval, type: :number
   ransack_filter :routing_attempt, type: :number
-  ransack_filter :is_last_cdr, type: :boolean
   ransack_filter :lega_disconnect_code, type: :number
   ransack_filter :lega_disconnect_reason, type: :string
   ransack_filter :node_id, type: :number

--- a/db/secondbase/migrate/20200221080918_improve_cdr_indexes.rb
+++ b/db/secondbase/migrate/20200221080918_improve_cdr_indexes.rb
@@ -1,0 +1,23 @@
+class ImproveCdrIndexes < ActiveRecord::Migration[5.2]
+  def up
+    execute %Q{
+      DROP INDEX IF EXISTS cdr.cdr_customer_acc_external_id_eq_time_start_idx;
+    }
+    execute %Q{
+      DROP INDEX IF EXISTS cdr.cdr_customer_acc_id_time_start_idx;
+    }
+
+    execute %Q{
+      CREATE INDEX IF NOT EXISTS cdr_customer_acc_external_id_time_start_idx
+      ON cdr.cdr
+      USING btree (customer_acc_external_id, time_start)
+      WHERE is_last_cdr;
+    }
+    execute %Q{
+      CREATE INDEX IF NOT EXISTS cdr_customer_acc_id_time_start_idx
+      ON cdr.cdr
+      USING btree (customer_acc_id, time_start)
+      WHERE is_last_cdr;
+    }
+  end
+end

--- a/db/secondbase/structure.sql
+++ b/db/secondbase/structure.sql
@@ -6493,17 +6493,17 @@ CREATE UNIQUE INDEX invoice_documents_invoice_id_idx ON billing.invoice_document
 
 
 --
--- Name: cdr_customer_acc_external_id_eq_time_start_idx; Type: INDEX; Schema: cdr; Owner: -
+-- Name: cdr_customer_acc_external_id_time_start_idx; Type: INDEX; Schema: cdr; Owner: -
 --
 
-CREATE INDEX cdr_customer_acc_external_id_eq_time_start_idx ON ONLY cdr.cdr USING btree (customer_acc_external_id, time_start) WHERE (routing_attempt = 1);
+CREATE INDEX cdr_customer_acc_external_id_time_start_idx ON ONLY cdr.cdr USING btree (customer_acc_external_id, time_start) WHERE is_last_cdr;
 
 
 --
 -- Name: cdr_customer_acc_id_time_start_idx; Type: INDEX; Schema: cdr; Owner: -
 --
 
-CREATE INDEX cdr_customer_acc_id_time_start_idx ON ONLY cdr.cdr USING btree (customer_acc_id, time_start) WHERE (routing_attempt = 1);
+CREATE INDEX cdr_customer_acc_id_time_start_idx ON ONLY cdr.cdr USING btree (customer_acc_id, time_start) WHERE is_last_cdr;
 
 
 --
@@ -6779,6 +6779,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20200106104136'),
 ('20200120195529'),
 ('20200120200605'),
-('20200220113109');
+('20200220113109'),
+('20200221080918');
 
 

--- a/spec/acceptance/rest/customer/api/v1/chart_originated_cps_spec.rb
+++ b/spec/acceptance/rest/customer/api/v1/chart_originated_cps_spec.rb
@@ -18,7 +18,7 @@ resource 'OriginatedCPS', document: :customer_v1 do
   before do
     create_list :cdr, 12,
                 customer_acc_id: customer_acc.id,
-                routing_attempt: 1,
+                is_last_cdr: true,
                 time_start: '2019-01-01 23:59:59'
   end
 

--- a/spec/requests/api/rest/customer/v1/cdrs_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/cdrs_controller_spec.rb
@@ -200,6 +200,20 @@ describe Api::Rest::Customer::V1::CdrsController, type: :request do
           let(:attr_name) { :local_tag }
         end
       end
+
+      context 'is_last_cdr false' do
+        let(:request_filters) { { is_last_cdr: false } }
+        let!(:expected_record) { create(:cdr, customer_acc: account, is_last_cdr: false) }
+
+        it 'response contains only one filtered record' do
+          subject
+          expect(response_json[:data]).to match_array(
+            Cdr::Cdr.where(is_last_cdr: false).map do |r|
+              hash_including(id: r.uuid)
+            end
+          )
+        end
+      end
     end
   end
 

--- a/spec/requests/api/rest/customer/v1/chart_originated_cps_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/chart_originated_cps_controller_spec.rb
@@ -13,35 +13,42 @@ describe Api::Rest::Customer::V1::ChartOriginatedCpsController, type: :request d
     create_list :cdr, 4,
                 customer_acc_id: account.id,
                 routing_attempt: 1,
+                is_last_cdr: true,
                 time_start: '2019-01-01 00:00:00'
 
     create_list :cdr, 2,
                 customer_acc_id: account.id,
-                routing_attempt: 1,
+                routing_attempt: 2,
+                is_last_cdr: true,
                 time_start: '2019-01-01 00:00:59'
 
     create_list :cdr, 12,
                 customer_acc_id: account.id,
-                routing_attempt: 1,
+                routing_attempt: 3,
+                is_last_cdr: true,
                 time_start: '2019-01-01 23:59:59'
 
-    # not first routing attempt
+    # not last cdr
     create :cdr,
            customer_acc_id: account.id,
-           routing_attempt: 2,
+           routing_attempt: 1,
+           is_last_cdr: false,
            time_start: '2019-01-01 15:34:00'
 
     # created_at out of scope
     create :cdr,
+           is_last_cdr: true,
            customer_acc_id: account.id,
-           time_start: '2019-01-02 00:00:00'
+           time_start: '2019-01-02 02:15:00'
 
     create :cdr,
+           is_last_cdr: true,
            customer_acc_id: account.id,
            time_start: '2018-12-31 23:59:59'
 
     # different account
     create :cdr,
+           is_last_cdr: true,
            customer_acc_id: another_account.id,
            time_start: '2019-01-01 12:00:01'
   end


### PR DESCRIPTION
cherry-pick of #633 to `1.10`

* cdr remove indexes conditioned by routing_attempt=1 and add indexes conditioned by is_last_cdr=true
* chart originated cps count cdrs with is_last_cdr=true
* customer api cdrs remove filter is_last_cdr_eq/not_eq (filter is_last_cdr still present)

fixes #632, refs #607