### PR TITLE
Using Coveralls with Docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ script:
     docker-compose run
     -e "PARALLEL_TEST_PROCESSORS=$PARALLEL_TEST_PROCESSORS"
     -e "TEST_GROUP=$TEST_GROUP"
+    -e "TRAVIS_JOB_ID=$TRAVIS_JOB_ID" 
+    -e "TRAVIS_BRANCH=$TRAVIS_BRANCH"
     app-buster make rspec
 
 jobs:


### PR DESCRIPTION
If you’re using Docker in builds, ensure that the necessary environment variables are exposed to the container:

docker exec -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" ...