### PR TITLE
moved configs for bundler tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,14 +105,19 @@ bundler:
 .PHONY: gems
 gems: bundler
 	$(info:msg=Install/Update gems)
-	$(bundle_bin) install --jobs=4 --deployment --without development test
+	$(bundle_bin) config --delete with
+	$(bundle_bin) config set without 'development test'
+	$(bundle_bin) config set deployment 'true'
+	$(bundle_bin) install --jobs=4
 	$(bundle_bin) clean
 
 
 .PHONY: gems-test
 gems-test: bundler
 	$(info:msg=Install/Update gems for tests)
-	$(bundle_bin) install --jobs=4 --deployment --with development test
+	$(bundle_bin) config set with 'development test'
+	$(bundle_bin) config set deployment 'true'
+	$(bundle_bin) install --jobs=4
 	$(bundle_bin) clean
 	$(bundle_bin) binstubs rspec-core
 

--- a/pgq-processors/Makefile
+++ b/pgq-processors/Makefile
@@ -23,7 +23,8 @@ bundler:
 .PHONY: gems
 gems: bundler
 	$(info:msg=Install/Update gems)
-	$(bundle_bin) install --jobs=4 --deployment --binstubs
+	$(bundle_bin) config set deployment 'true'
+	$(bundle_bin) install --jobs=4 --binstubs
 
 .PHONY: test
 test: gems


### PR DESCRIPTION
**moved bundler's configs** named "with", "without" and "deployment" from inline call as key for command bundle to config globally, 
**cause of: outputing warning** 
`" [DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions."`