### PR TITLE
refs #685 new sub menu 'components' in system menu

### DIFF
--- a/app/admin/system/lnp_resolver.rb
+++ b/app/admin/system/lnp_resolver.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register System::LnpResolver do
   actions :all
-  menu parent: 'System', label: 'LNP resolvers', priority: 130
+  menu parent: %w[System Components], label: 'LNP resolvers', priority: 40
   config.batch_actions = false
   permit_params :name, :address, :port
 

--- a/app/admin/system/load_balancer.rb
+++ b/app/admin/system/load_balancer.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register System::LoadBalancer do
   actions :all
-  menu parent: 'System', label: 'Load balancers', priority: 124
+  menu parent: %w[System Components], label: 'Load balancers', priority: 20
   config.batch_actions = false
 
   permit_params :name, :signalling_ip

--- a/app/admin/system/nodes.rb
+++ b/app/admin/system/nodes.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Node do
   includes :pop
-  menu parent: 'System', priority: 125
+  menu parent: %w[System Components], priotity: 30
   config.batch_actions = false
 
   acts_as_clone

--- a/app/admin/system/pops.rb
+++ b/app/admin/system/pops.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Pop do
-  menu parent: 'System', priority: 119
+  menu parent: %w[System Components], priority: 10
   config.batch_actions = false
 
   permit_params :name

--- a/app/admin/system/sensor.rb
+++ b/app/admin/system/sensor.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register System::Sensor do
   # actions :index, :show
-  menu parent: 'System', label: 'Sensors', priority: 140
+  menu parent: %w[System Components], label: 'Sensors', priority: 50
   config.batch_actions = false
 
   permit_params :name, :mode_id, :source_interface, :target_mac, :source_ip,

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -12,7 +12,9 @@ ActiveAdmin.setup do |config|
       #      menu.add label: "Rate Tools", priority: 65
       menu.add label: 'Realtime Data', priority: 70
       menu.add label: 'Logs', priority: 80
-      menu.add label: 'System', priority: 90
+      menu.add label: 'System', priority: 90 do |sub_menu|
+        sub_menu.add label: 'Components'
+      end
 
       # http://127.0.0.1:3000/admin/admin_users/1
       menu.add label: proc { display_name current_active_admin_user },


### PR DESCRIPTION

![menu](https://user-images.githubusercontent.com/10907664/80954735-7d77f300-8ded-11ea-8e56-934ae8bc7a4c.png)
Added menu "components" and placed in it 5 items:
/nodes
/pops
/system_sensors
/system_load_balancers
/system_lnp_resolvers
Adding through initializers/active_admin.rb file

-----------------------------------------------------------------
Menu structure #685