### PR TITLE
Create missing partitions

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,6 +120,14 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with :truncation
   end
 
+  config.before(:suite) do
+    # Create partition for current+next monthes if not exists
+    Cdr::Cdr.add_partitions
+    Cdr::AuthLog.add_partitions
+    Cdr::RtpStatistic.add_partitions
+    Log::ApiLog.add_partitions
+  end
+
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
     allow(Raven).to receive(:send_event).with(a_kind_of(Hash))


### PR DESCRIPTION
`@connection.exec_params(sql, type_casted_binds) ActiveRecord::StatementInvalid: PG::CheckViolation: ERROR:  no partition of relation "api_requests" found for row DETAIL:  Partition key of the failing row contains (created_at) = (2020-05-06 08:32:27.462837+00). : INSERT INTO "logs"."api_requests" ("created_at", "path", "method", "status", "controller", "action", "page_duration", "db_duration", "params") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"`