### PR TITLE
WARNING :added error name for method "raise_error"

### DIFF
--- a/spec/models/system/sensor_spec.rb
+++ b/spec/models/system/sensor_spec.rb
@@ -111,7 +111,7 @@ describe System::Sensor do
         end
 
         it 'rise error' do
-          expect { subject }.to raise_error
+          expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
     end


### PR DESCRIPTION


casue of: outputting following warning
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<**ActiveRecord::RecordInvalid**: Validation failed: Name has already been taken>.

before: expect { subject }.to raise_error
after: expect { subject }.to raise_error **ActiveRecord::RecordInvalid**
![raise_error](https://user-images.githubusercontent.com/10907664/81305329-bd4d0d80-906d-11ea-9e44-0cfb2e93737c.png)

