### PR TITLE
depr warns: wraps unsafe pluck to Arel.sql

### DIFF
--- a/app/models/clickhouse_dictionary/account.rb
+++ b/app/models/clickhouse_dictionary/account.rb
@@ -4,12 +4,12 @@ module ClickhouseDictionary
   class Account < Base
     model_class ::Account
 
-    attributes :id,
-               :name,
-               :external_id,
-               :origination_capacity,
-               :termination_capacity,
-               :total_capacity,
-               :uuid
+    attribute :id, sql: 'billing.accounts.id'
+    attribute :name, sql: 'billing.accounts.name'
+    attribute :external_id, sql: 'billing.accounts.external_id'
+    attribute :origination_capacity, sql: 'billing.accounts.origination_capacity'
+    attribute :termination_capacity, sql: 'billing.accounts.termination_capacity'
+    attribute :total_capacity, sql: 'billing.accounts.total_capacity'
+    attribute :uuid, sql: 'billing.accounts.uuid'
   end
 end

--- a/app/models/clickhouse_dictionary/base.rb
+++ b/app/models/clickhouse_dictionary/base.rb
@@ -26,7 +26,7 @@ module ClickhouseDictionary
 
     def call
       fields = attribute_names
-      rows = scoped_collection.pluck(*pluck_fields).map { |values| fields.zip(values).to_h }
+      rows = scoped_collection.pluck(Arel.sql(pluck_fields.join(', '))).map { |values| fields.zip(values).to_h }
       rows.map(&:to_json).join("\n")
     end
 

--- a/app/models/clickhouse_dictionary/network_prefix.rb
+++ b/app/models/clickhouse_dictionary/network_prefix.rb
@@ -4,11 +4,11 @@ module ClickhouseDictionary
   class NetworkPrefix < Base
     model_class ::System::NetworkPrefix
 
-    attributes :id,
-               :prefix,
+    attributes :prefix,
                :country_id,
                :network_id
 
+    attribute :id, sql: 'sys.network_prefixes.id'
     attribute :country_name, sql: 'sys.countries.name'
     attribute :network_name, sql: 'sys.networks.name'
 

--- a/app/models/concerns/acts_as_totals_relation.rb
+++ b/app/models/concerns/acts_as_totals_relation.rb
@@ -2,9 +2,9 @@
 
 module ActsAsTotalsRelation
   def totals_row_by(*select_sql)
-    safe_select_sql = select_sql.map { |sql| Arel.sql(sql) }
+    safe_select_sql = Array(select_sql).join(', ')
     except(:preload, :includes, :eager_load, :limit, :offset, :select, :order)
-      .pluck(safe_select_sql)
+      .pluck(Arel.sql(safe_select_sql))
       .first
   end
 end


### PR DESCRIPTION
cause of: outputting the following warning
```
DEPRECATION WARNING: Dangerous query method
 (method whose arguments are used as raw SQL) called with non-attribute argument(s):
```

spec for reproduce warning: 
spec/requests/api/rest/clickhouse_dictionaries/network_prefixes_spec.rb:3
spec/features/billing/accounts/index_accounts_spec.rb:8
spec/features/billing/invoices/index_invoices_feature_spec.rb:8

-------------------------------------------------------------------------------------------------------------------------------
![arel](https://user-images.githubusercontent.com/10907664/81393363-c4c4f300-910f-11ea-87ff-f8910d4062c1.png)