### PR TITLE
depr warns: http status code :success is deprecated

### DIFF
--- a/spec/features/system/cdr_configs/index_cdr_config_spec.rb
+++ b/spec/features/system/cdr_configs/index_cdr_config_spec.rb
@@ -9,7 +9,7 @@ describe 'Index System Cdr Configs', type: :feature do
   it 'n+1 checks' do
     CdrRoundMode = System::CdrRoundMode.find(cdr_config.call_duration_round_mode_id).name
     visit system_cdr_configs_path
-    expect(page).to have_http_status(:success)
+    expect(page).to have_http_status(200)
     expect(page).to have_css('tr.row-call_duration_round_mode td', text: CdrRoundMode.to_s)
   end
 end


### PR DESCRIPTION
cause of DEPRECATION WARNING:

```
DEPRECATION WARNING: The success? predicate is deprecated and
will be removed in Rails 6.0. Please use successful? as provided
by Rack::Response::Helpers.
```
called from:
spec/features/system/cdr_configs/index_cdr_config_spec.rb:9


https://github.com/rspec/rspec-rails/issues/1857