### PR TITLE
raise error when we get deprecation warning in specs

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :raise
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
This change will continue to check the code for warnings like DEPRECATION WARNING and generate
`ActiveSupport::DeprecationException` exception.

In the future, when an error of this type occurs, the programmer is required to solve this problem.