### PR TITLE
used scss variable instead inline url

### DIFF
--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -23,6 +23,13 @@
 @import "active_admin/components/active_admin_scoped_collection_actions";
 @import "vendor/highlightjs/default";
 
+// Override style from active_admin_theme gem (app/assets/stylesheets/wigu/active_admin_theme.scss:99)
+#wrapper #header ul.tabs li.has_nested ul {
+  li.current > a::before, li:hover > a::before {
+    background: transparent url($menu-arrow-dark-icon-url) no-repeat 0 0;
+  }
+}
+
 fieldset.inputs {
   input.date-time-picker {
     width: 286px;


### PR DESCRIPTION
Has been overrided background stype for pseudo-element ::before

 

[Origin style link](https://github.com/activeadmin-plugins/active_admin_theme/blob/master/app/assets/stylesheets/wigu/active_admin_theme.scss#L99)

-----------------------------------------------

![Screenshot from 2020-05-12 12-53-39](https://user-images.githubusercontent.com/10907664/81669992-86dd0d00-9436-11ea-8d25-3f32619632b8.png)

