### PR TITLE
depr warns: Yeti::Application to Rails.application

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@
 
 require File.expand_path('config/application', __dir__)
 
-Yeti::Application.load_tasks
+Rails.application.load_tasks
 
 unless SecondBase.config
   raise ActiveRecord::AdapterNotFound, 'database.yml#secondbase is not specified'

--- a/app/admin/system/info.rb
+++ b/app/admin/system/info.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register_page 'Info' do
         end
         panel 'Build info' do
           data = {
-            ui_version: Yeti::Application.config.app_build_info.fetch('version', 'unknown'),
+            ui_version: Rails.application.config.app_build_info.fetch('version', 'unknown'),
             routing_version: Yeti::ActiveRecord::DB_VER,
             cdr_version: Cdr::Base::DB_VER,
             ruby: "#{RUBY_VERSION}/#{RUBY_PLATFORM}/#{RUBY_RELEASE_DATE}",

--- a/app/views/active_admin/_footer.html.arb
+++ b/app/views/active_admin/_footer.html.arb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 div 'data-servertime' => Time.current.strftime('%Y %m %d %H %M %S %Z'), 'id' => 'servertime' do
-  "Copyright #{Date.today.year} Yeti Admin ver: #{Yeti::Application.config.app_build_info.fetch('version', 'unknown')}. Routing ver #{Yeti::ActiveRecord::DB_VER}. CDR ver #{Cdr::Base::DB_VER}."
+  "Copyright #{Date.today.year} Yeti Admin ver: #{Rails.application.config.app_build_info.fetch('version', 'unknown')}. Routing ver #{Yeti::ActiveRecord::DB_VER}. CDR ver #{Cdr::Base::DB_VER}."
 end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require ::File.expand_path('../config/environment', __FILE__)
-run Yeti::Application
+run Rails.application

--- a/config/initializers/app_build_info.rb
+++ b/config/initializers/app_build_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Yeti::Application.config.app_build_info = begin
+Rails.application.config.app_build_info = begin
                                              YAML.load_file(File.join(Rails.root, 'version.yml'))
                                           rescue StandardError
                                             {}

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -7,4 +7,4 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 
-Yeti::Application.config.secret_key_base = '2f2303065d1396322ff6cb6568ad2f42ac1963129db7b668f338f42d1c45a17163753da01469420bb0deb3e63f32a73334ce52432932f77b38f1be35446ab089'
+Rails.application.config.secret_key_base = '2f2303065d1396322ff6cb6568ad2f42ac1963129db7b668f338f42d1c45a17163753da01469420bb0deb3e63f32a73334ce52432932f77b38f1be35446ab089'


### PR DESCRIPTION
**Summary**
Resolved DEPRECATION WARNING when run server in test enviroment

details:
Deprecate using subclass of Rails::Application to start the Rails server.

log:
`wrapped_app : DEPRECATION WARNING: Using Rails::Application subclass to start the server is deprecated and will be removed in Rails 6.0. Please change run Yeti::Application to run Rails.application in config.ru.
`
Pull Request [link](https://github.com/rails/rails/pull/30127)

