### PR TITLE
added task named db:second_base:drop to drop second database

### DIFF
--- a/lib/tasks/second_base.rake
+++ b/lib/tasks/second_base.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :second_base do
+    desc 'Alias for db:second_base:drop:_unsafe'
+    task drop: :environment do
+      SecondBase.on_base { Rake::Task['db:drop:_unsafe'].execute }
+    end
+  end
+end


### PR DESCRIPTION
Solved #417 

added new tesk 
rake db:second_base:drop that remore both database if not set env variable (test and dev)

**it just alias for db:second_base:drop:_unsafe**
-------------------------------------------------------------------------------------
![drop](https://user-images.githubusercontent.com/10907664/82072164-c15cd900-96c6-11ea-92f9-8d11e30f0c72.png)
