### PR TITLE
set variable if not initialized

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'capture_error'
-
 if CaptureError.enabled? && !defined?(::Rake)
   CaptureError.configure!
 end


### PR DESCRIPTION
Summary: resolve warning already initialized constant
CaptureError::EXTRA_VAR_NAME

log:

`lib/capture_error.rb:8: warning: already initialized constant CaptureError::EXTRA_VAR_NAME
lib/capture_error.rb:8: warning: previous definition of EXTRA_VAR_NAME was here
`
screen: 
![name](https://user-images.githubusercontent.com/10907664/82076220-0ab02700-96cd-11ea-96f1-a4f59b9271a0.png)
