### PR TITLE
load resources accross ajax [new feature]

### DIFF
--- a/app/admin/billing/account.rb
+++ b/app/admin/billing/account.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Account do
   menu parent: 'Billing', priority: 10
-
+  search_support!
   acts_as_safe_destroy
   acts_as_audit
   acts_as_clone
@@ -122,7 +122,13 @@ ActiveAdmin.register Account do
 
   filter :id
   filter :uuid_equals, label: 'UUID'
-  filter :contractor, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :name
   filter :balance
   filter :vat

--- a/app/admin/billing/contact.rb
+++ b/app/admin/billing/contact.rb
@@ -43,7 +43,12 @@ ActiveAdmin.register Billing::Contact do
   end
 
   filter :id
-  filter :contractor, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
   filter :admin_user, input_html: { class: 'chosen' }
   filter :email
   filter :notes

--- a/app/admin/billing/contractors.rb
+++ b/app/admin/billing/contractors.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Contractor do
   menu parent: 'Billing', priority: 2
-
+  search_support!
   acts_as_audit
   acts_as_clone
   acts_as_safe_destroy

--- a/app/admin/billing/invoices.rb
+++ b/app/admin/billing/invoices.rb
@@ -191,8 +191,20 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
   end
 
   filter :id
-  filter :contractor, input_html: { class: 'chosen' }
-  filter :account, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
+  filter :account,
+         input_html: { class: 'chosen-ajax', 'data-path': '/accounts/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:account_id_eq]
+           resource_id ? Account.where(id: resource_id) : []
+         }
+
   filter :state
   filter :start_date, as: :date_time_range
   filter :end_date, as: :date_time_range

--- a/app/admin/cdr/auth_logs.rb
+++ b/app/admin/cdr/auth_logs.rb
@@ -103,7 +103,13 @@ ActiveAdmin.register Cdr::AuthLog, as: 'AuthLog' do
 
   filter :id
   filter :request_time
-  filter :gateway
+  filter :gateway,
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:gateway_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         }
+
   filter :pop
   filter :node
   filter :username

--- a/app/admin/cdr/cdrs.rb
+++ b/app/admin/cdr/cdrs.rb
@@ -54,8 +54,20 @@ ActiveAdmin.register Cdr::Cdr, as: 'CDR' do
   filter :id
   filter :routing_tag_ids_include, as: :select, collection: proc { Routing::RoutingTag.all }, label: 'With routing tag'
   filter :time_start, as: :date_time_range
-  filter :customer, collection: proc { Contractor.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
-  filter :vendor, collection: proc { Contractor.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true&q[ordered_by]=name' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true&q[ordered_by]=name' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :customer_auth, collection: proc { CustomersAuth.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
   filter :src_prefix_routing
   filter :src_area, collection: proc { Routing::Area.select(%i[id name]) }, input_html: { class: 'chosen' }
@@ -67,8 +79,30 @@ ActiveAdmin.register Cdr::Cdr, as: 'CDR' do
   filter :is_last_cdr, as: :select, collection: proc { [['Yes', true], ['No', false]] }
   filter :dump_level, as: :select, collection: proc { DumpLevel.select(%i[id name]).reorder(:id) }
 
-  filter :orig_gw, collection: proc { Gateway.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
-  filter :term_gw, collection: proc { Gateway.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
+  filter :orig_gw_id_eq,
+         as: :select,
+         label: 'Orig GW',
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:orig_gw_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         },
+         input_html: {
+           class: 'chosen-ajax',
+           'data-path': '/gateways/search?q[allow_origination_eq]=true&q[ordered_by]=name'
+         }
+
+  filter :term_gw_id_eq,
+         as: :select,
+         label: 'Term GW',
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:term_gw_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         },
+         input_html: {
+           class: 'chosen-ajax',
+           'data-path': '/gateways/search?q[allow_termination_eq]=true&q[ordered_by]=name'
+         }
+
   filter :routing_plan, collection: proc { Routing::RoutingPlan.select(%i[id name]) }, input_html: { class: 'chosen' }
   filter :routing_group, collection: proc { RoutingGroup.select(%i[id name]) }, input_html: { class: 'chosen' }
   filter :rateplan, collection: proc { Rateplan.select(%i[id name]) }, input_html: { class: 'chosen' }

--- a/app/admin/cdr/rtp_statistics.rb
+++ b/app/admin/cdr/rtp_statistics.rb
@@ -145,7 +145,13 @@ ActiveAdmin.register Cdr::RtpStatistic, as: 'RtpStatistics' do
   filter :local_tag
   filter :pop
   filter :node
-  filter :gateway
+  filter :gateway,
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:gateway_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         }
+
   filter :gateway_external_id
   filter :remote_host
   filter :remote_port

--- a/app/admin/equipment/gateway_groups.rb
+++ b/app/admin/equipment/gateway_groups.rb
@@ -51,7 +51,13 @@ ActiveAdmin.register GatewayGroup do
 
   filter :id
   filter :name
-  filter :vendor, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :balancing_mode
 
   show do |s|

--- a/app/admin/equipment/gateways.rb
+++ b/app/admin/equipment/gateways.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Gateway do
   menu parent: 'Equipment', priority: 75
-
+  search_support!
   acts_as_audit
   acts_as_clone
   acts_as_safe_destroy
@@ -307,7 +307,13 @@ ActiveAdmin.register Gateway do
   filter :name
   filter :gateway_group, input_html: { class: 'chosen' }
   filter :pop, input_html: { class: 'chosen' }
-  filter :contractor, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :transport_protocol
   filter :host
   filter :enabled, as: :select, collection: [['Yes', true], ['No', false]]

--- a/app/admin/import/import_accounts.rb
+++ b/app/admin/import/import_accounts.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Importing::Account do
-  filter :contractor, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :name
   filter :balance
   boolean_filter :is_changed

--- a/app/admin/import/import_dialpeers.rb
+++ b/app/admin/import/import_dialpeers.rb
@@ -4,9 +4,27 @@ ActiveAdmin.register Importing::Dialpeer, as: 'Dialpeer Imports' do
   filter :o_id
   filter :prefix
   boolean_filter :enabled
-  filter :vendor, input_html: { class: 'chosen' }
-  filter :account, input_html: { class: 'chosen' }
-  filter :gateway, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
+  filter :account,
+         input_html: { class: 'chosen-ajax', 'data-path': '/accounts/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:account_id_eq]
+           resource_id ? Account.where(id: resource_id) : []
+         }
+
+  filter :gateway,
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:gateway_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         }
+
   filter :routing_group, input_html: { class: 'chosen' }
   filter :routeset_discriminator, input_html: { class: 'chosen' }
   boolean_filter :is_changed

--- a/app/admin/import/import_gateway.rb
+++ b/app/admin/import/import_gateway.rb
@@ -2,7 +2,13 @@
 
 ActiveAdmin.register Importing::Gateway do
   filter :name
-  filter :contractor, input_html: { class: 'chosen' }
+  filter :contractor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:contractor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :gateway_group, input_html: { class: 'chosen' }
   boolean_filter :is_changed
 

--- a/app/admin/import/import_gateway_groups.rb
+++ b/app/admin/import/import_gateway_groups.rb
@@ -2,7 +2,13 @@
 
 ActiveAdmin.register Importing::GatewayGroup do
   filter :name
-  filter :vendor, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :balancing_mode, as: :select
   boolean_filter :is_changed
 

--- a/app/admin/realtime_data/active_calls.rb
+++ b/app/admin/realtime_data/active_calls.rb
@@ -37,23 +37,29 @@ ActiveAdmin.register RealtimeData::ActiveCall, as: 'Active Calls' do
 
   filter :vendor_id_eq,
          as: :select,
-         collection: proc { Contractor.vendors },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         },
          label: 'Vendor',
          input_html: {
-           class: 'chosen',
+           class: 'chosen-ajax',
+           'data-path': '/contractors/search?q[vendor_eq]=true',
            onchange: remote_chosen_request(:get, with_contractor_accounts_path, { contractor_id: '$(this).val()' }, :q_vendor_acc_id_eq)
-         },
-         if: proc { !request.xhr? }
+         }
 
   filter :customer_id_eq,
          as: :select,
-         collection: proc { Contractor.customers },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         },
          label: 'Customer',
          input_html: {
-           class: 'chosen',
+           class: 'chosen-ajax',
+           'data-path': '/contractors/search?q[customer_eq]=true',
            onchange: remote_chosen_request(:get, with_contractor_accounts_path, { contractor_id: '$(this).val()' }, :q_customer_acc_id_eq)
-         },
-         if: proc { !request.xhr? }
+         }
 
   filter :vendor_acc_id_eq,
          as: :select,
@@ -69,17 +75,24 @@ ActiveAdmin.register RealtimeData::ActiveCall, as: 'Active Calls' do
 
   filter :orig_gw_id_eq,
          as: :select,
-         collection: proc { Gateway.originations },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:orig_gw_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         },
          label: 'Orig GW',
-         input_html: { class: 'chosen' },
-         if: proc { !request.xhr? }
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search?q[allow_origination_eq]=true' }
 
   filter :term_gw_id_eq,
          as: :select,
-         collection: proc { Gateway.terminations },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:term_gw_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         },
          label: 'Term GW',
-         input_html: { class: 'chosen' },
-         if: proc { !request.xhr? }
+         input_html: {
+           class: 'chosen-ajax',
+           'data-path': '/gateways/search?q[allow_termination_eq]=true'
+         }
 
   filter :duration, as: :numeric
 

--- a/app/admin/reports/custom_cdr.rb
+++ b/app/admin/reports/custom_cdr.rb
@@ -55,5 +55,10 @@ ActiveAdmin.register Report::CustomCdr, as: 'CustomCdr' do
   filter :date_start, as: :date_time_range
   filter :date_end, as: :date_time_range
   filter :created_at, as: :date_time_range
-  filter :customer, as: :select, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 end

--- a/app/admin/reports/custom_cdr_scheduler.rb
+++ b/app/admin/reports/custom_cdr_scheduler.rb
@@ -49,5 +49,10 @@ ActiveAdmin.register Report::CustomCdrScheduler, as: 'CustomCdrScheduler' do
 
   filter :id
   filter :period
-  filter :customer, as: :select, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 end

--- a/app/admin/reports/customer_traffic.rb
+++ b/app/admin/reports/customer_traffic.rb
@@ -44,5 +44,10 @@ ActiveAdmin.register Report::CustomerTraffic, as: 'CustomerTraffic' do
   filter :date_start, as: :date_time_range
   filter :date_end, as: :date_time_range
   filter :created_at, as: :date_time_range
-  filter :customer, as: :select, input_html: { class: 'chosen' }, collection: proc { Contractor.where(customer: true) }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 end

--- a/app/admin/reports/customer_traffic_data_by_vendor.rb
+++ b/app/admin/reports/customer_traffic_data_by_vendor.rb
@@ -9,7 +9,12 @@ ActiveAdmin.register Report::CustomerTrafficDataByVendor, as: 'CustomerTrafficDa
 
   filter :calls_count
   filter :calls_duration
-  filter :vendor, as: :select, input_html: { class: 'chosen' }, collection: proc { Contractor.where(vendor: true) }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   decorate_with ReportCustomerTrafficByVendorDecorator
 

--- a/app/admin/reports/customer_traffic_data_full.rb
+++ b/app/admin/reports/customer_traffic_data_full.rb
@@ -46,7 +46,12 @@ ActiveAdmin.register Report::CustomerTrafficDataFull, as: 'CustomerTrafficDataFu
   filter :destination_prefix
   filter :dst_country_id, label: 'Country', as: :select, input_html: { class: 'chosen' }, collection: proc { System::Country.collection } ## TODO Why dst_country_id????
   filter :dst_network_id, label: 'Network', as: :select, input_html: { class: 'chosen' }, collection: proc { System::Network.collection }
-  filter :vendor, as: :select, input_html: { class: 'chosen' }, collection: proc { Contractor.where(vendor: true) }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   index footer_data: ->(collection) { BillingDecorator.new(collection.totals) } do
     column :destination_prefix

--- a/app/admin/reports/customer_traffic_scheduler.rb
+++ b/app/admin/reports/customer_traffic_scheduler.rb
@@ -40,7 +40,12 @@ ActiveAdmin.register Report::CustomerTrafficScheduler, as: 'CustomerTrafficSched
 
   filter :id
   filter :created_at, as: :date_time_range
-  filter :customer, as: :select, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   show do |_s|
     attributes_table do

--- a/app/admin/reports/realtime/bad_routing.rb
+++ b/app/admin/reports/realtime/bad_routing.rb
@@ -12,10 +12,12 @@ ActiveAdmin.register Report::Realtime::BadRouting do
                             collection: Report::Realtime::Base::INTERVALS,
                             input_html: { class: 'chosen' }, include_blank: false
 
-  filter :customer_id, label: 'Customer',
-                       as: :select,
-                       collection: proc { Contractor.select(:id, :name).reorder(:name) },
-                       input_html: { class: 'chosen' }
+  filter :customer,
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         },
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true&q[ordered_by]=name' }
 
   filter :rateplan, input_html: { class: 'chosen' }
   filter :routing_plan, input_html: { class: 'chosen' }

--- a/app/admin/reports/realtime/origination_performance.rb
+++ b/app/admin/reports/realtime/origination_performance.rb
@@ -14,10 +14,12 @@ ActiveAdmin.register Report::Realtime::OriginationPerformance do
                             collection: Report::Realtime::Base::INTERVALS,
                             input_html: { class: 'chosen' }, include_blank: false
 
-  filter :customer_id, label: 'Customer',
-                       as: :select,
-                       collection: proc { Contractor.select(:id, :name).reorder(:name) },
-                       input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true&q[ordered_by]=name' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   with_default_realtime_interval
 

--- a/app/admin/reports/realtime/termination_distribution.rb
+++ b/app/admin/reports/realtime/termination_distribution.rb
@@ -14,9 +14,12 @@ ActiveAdmin.register Report::Realtime::TerminationDistribution do
                             collection: Report::Realtime::Base::INTERVALS,
                             input_html: { class: 'chosen' }, include_blank: false
 
-  filter :customer_id, label: 'Customer',
-                       as: :select, collection: proc { Contractor.select(:id, :name).reorder(:name) },
-                       input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true&q[ordered_by]=name' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   with_default_realtime_interval
 

--- a/app/admin/reports/vendor_traffic.rb
+++ b/app/admin/reports/vendor_traffic.rb
@@ -42,5 +42,10 @@ ActiveAdmin.register Report::VendorTraffic, as: 'VendorTraffic' do
   filter :date_start, as: :date_time_range
   filter :date_end, as: :date_time_range
   filter :created_at, as: :date_time_range
-  filter :vendor, as: :select, input_html: { class: 'chosen' }, collection: proc { Contractor.where(vendor: true) }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 end

--- a/app/admin/reports/vendor_traffic_data.rb
+++ b/app/admin/reports/vendor_traffic_data.rb
@@ -11,7 +11,12 @@ ActiveAdmin.register Report::VendorTrafficData, as: 'VendorTrafficData' do
 
   filter :calls_count
   filter :calls_duration
-  filter :customer, as: :select, input_html: { class: 'chosen' }, collection: proc { Contractor.where(customer: true) }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   controller do
     def scoped_collection

--- a/app/admin/reports/vendor_traffic_scheduler.rb
+++ b/app/admin/reports/vendor_traffic_scheduler.rb
@@ -40,7 +40,12 @@ ActiveAdmin.register Report::VendorTrafficScheduler, as: 'VendorTrafficScheduler
 
   filter :id
   filter :created_at, as: :date_time_range
-  filter :vendor, as: :select, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   show do |_s|
     attributes_table do

--- a/app/admin/routing/customers_auths.rb
+++ b/app/admin/routing/customers_auths.rb
@@ -210,9 +210,27 @@ ActiveAdmin.register CustomersAuth do
   filter :name
   filter :enabled, as: :select, collection: [['Yes', true], ['No', false]]
   filter :reject_calls, as: :select, collection: [['Yes', true], ['No', false]]
-  filter :customer, input_html: { class: 'chosen' }
-  filter :account, input_html: { class: 'chosen' }
-  filter :gateway, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
+  filter :account,
+         input_html: { class: 'chosen-ajax', 'data-path': '/accounts/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:account_id_eq]
+           resource_id ? Account.where(id: resource_id) : []
+         }
+
+  filter :gateway,
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:gateway_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         }
+
   filter :rateplan, input_html: { class: 'chosen' }
   filter :routing_plan, input_html: { class: 'chosen' }
   filter :dump_level, as: :select, collection: proc { DumpLevel.select(%i[id name]).reorder(:id) }

--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -182,10 +182,26 @@ ActiveAdmin.register Dialpeer do
   filter :prefix
   filter :routing_for_contains, as: :string, input_html: { class: 'search_filter_string' }
   filter :enabled, as: :select, collection: [['Yes', true], ['No', false]]
-  filter :vendor, input_html: { class: 'chosen' }
-  filter :account, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+  filter :account,
+         input_html: { class: 'chosen-ajax', 'data-path': '/accounts/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:account_id_eq]
+           resource_id ? Account.where(id: resource_id) : []
+         }
   filter :routeset_discriminator, input_html: { class: 'chosen' }
-  filter :gateway, input_html: { class: 'chosen' }
+  filter :gateway,
+         input_html: { class: 'chosen-ajax', 'data-path': '/gateways/search' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:gateway_id_eq]
+           resource_id ? Gateway.where(id: resource_id) : []
+         }
+
   filter :gateway_group, input_html: { class: 'chosen' }
   filter :routing_group, input_html: { class: 'chosen' }
   filter :routing_group_routing_plans_id_eq, as: :select, input_html: { class: 'chosen' }, label: 'Routing Plan', collection: -> { Routing::RoutingPlan.all }

--- a/app/admin/routing/routing_plan_static_route.rb
+++ b/app/admin/routing/routing_plan_static_route.rb
@@ -30,7 +30,12 @@ ActiveAdmin.register Routing::RoutingPlanStaticRoute, as: 'Static Route' do
   filter :prefix
   filter :country, input_html: { class: 'chosen' }
   filter :network, input_html: { class: 'chosen' }
-  filter :vendor, collection: -> { Contractor.vendors }, input_html: { class: 'chosen' }
+  filter :vendor,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[vendor_eq]=true' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:vendor_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
 
   # after_build do |resource|
   #   from = begin

--- a/app/admin/system/api_access.rb
+++ b/app/admin/system/api_access.rb
@@ -14,7 +14,13 @@ ActiveAdmin.register System::ApiAccess, as: 'Api Access' do
                 account_ids: []
 
   filter :id
-  filter :customer, collection: proc { Contractor.select(%i[id name]).reorder(:name) }, input_html: { class: 'chosen' }
+  filter :customer,
+         input_html: { class: 'chosen-ajax', 'data-path': '/contractors/search?q[customer_eq]=true&q[ordered_by]=name' },
+         collection: proc {
+           resource_id = params.fetch(:q, {})[:customer_id_eq]
+           resource_id ? Contractor.where(id: resource_id) : []
+         }
+
   filter :login
 
   index do

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -38,6 +38,7 @@
 //= require highlightjs
 //= require modal_link
 //= require import_apply_unique_fields
+//= require ajax-chosen
 
 
 $(document).ready(function () {
@@ -45,6 +46,7 @@ $(document).ready(function () {
     $("select.chosen-wide").chosen({no_results_text: "No results matched", width: '80%', search_contains: true});
     $("select.chosen-sortable").chosen({no_results_text: "No results matched", width: '80%', search_contains: true}).chosenSortable();
 
+    $("select.chosen-ajax").chosen_ajax({ajax_method: "GET", ajax_min_chars: 3, no_results_text: "No results matched"})
 
     $('.index_as_table .index_table').stickyTableHeaders();
     $(document).on('has_many_add:after', function (e, fieldset) {

--- a/app/assets/javascripts/ajax-chosen.js
+++ b/app/assets/javascripts/ajax-chosen.js
@@ -1,0 +1,85 @@
+(function ($) {
+
+    // Ajax objects holder
+    var ajax_xml_http_request = {};
+
+    $.fn.chosen_ajax = function (options) {
+        // Call chosen
+        $(this).chosen(options);
+
+        // Loo selectors
+        $.each(this, function (i, obj) {
+            // Create unique key for each element
+            var key = "k-" + Math.floor((Math.random() * 9999999999) + 1000000000);
+            $(this).attr("data-key", key);
+            ajax_xml_http_request[key] = new window.XMLHttpRequest();
+            //
+            var select = $(this);   // Original select element
+            var chosen = $(this).next('div');   // Chosen div, chosen-container
+
+            // Set listener on search field
+            chosen.find('.search-field input, .chosen-search input').on('input', function () {
+                var old_search_term = $(this).attr("data-search");
+                var search_term = $(this).val();
+                var search_input = $(this)
+                if (!search_term || old_search_term == search_term
+                    || (options.hasOwnProperty('ajax_min_chars') && search_term.length < options.ajax_min_chars))
+                    return true;
+                $(this).attr("data-search", search_term);
+                var val = select.val();
+
+                // Set Method
+                if (!options.hasOwnProperty('ajax_method'))
+                    options.ajax_method = "GET";
+
+                // Set data
+                if (options.hasOwnProperty('ajax_data'))
+                    options.ajax_data.search_for = search_term;
+                else
+                    options.ajax_data = {search_for: search_term};
+
+                // Set term parameter
+                var path = select.data('path');
+                if (path.indexOf('?') > 1) {
+                    path += '&' + 'q[search_for]=' + search_term;
+                } else if (path.indexOf('?') === -1) {
+                    path += '?' + 'q[search_for]=' + search_term;
+                }
+                // Abort previous ajax request
+                ajax_xml_http_request[key].abort();
+                var xhr = $.ajax({
+                    url: path,
+                    method: options.ajax_method,
+                    type: options.ajax_method,
+                    dataType: "json",
+                    success: function (data) {
+                        if (data.length == 0) {
+                            return true;
+                        }
+                        // Clear options
+                        select.find('option:not(:selected)').remove();
+                        chosen.find('ul.chosen-results').html('');
+                        // Set new options
+                        $.each(data, function (i, item) {
+                            select.append('<option value="' + item.id + '">' + item.value + '</option>');
+                        });
+                        select.val(val);
+                        select.trigger('chosen:updated');
+                        //
+                        chosen.find('.search-field input').click();
+                        chosen.find('.chosen-search input').val(search_term);
+                        chosen.find('.search-field input').val(search_term);
+                        //
+                        select.trigger('chosen:open');
+                        //
+                        chosen.find('.search-field input, .chosen-search input').attr("style", "width:  100%");
+                    },
+                    error: function(jqXHR, exception) {
+                        chosen.trigger('chosen:no_results')
+                    }
+                });
+                ajax_xml_http_request[key] = xhr; // Save current ajax request object
+            });
+        });
+    };
+}(jQuery));

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -58,6 +58,8 @@ class Account < Yeti::ActiveRecord
   scope :vendors_accounts, -> { joins(:contractor).where('contractors.vendor' => true) }
   scope :customers_accounts, -> { joins(:contractor).where('contractors.customer' => true) }
   scope :collection, -> { order(:name) }
+  scope :search_for, ->(term) { where("name || ' | ' || id::varchar ILIKE ?", "%#{term}%") }
+  scope :ordered_by, ->(term) { order(term) }
 
   validates_numericality_of :min_balance, :balance
   validates_uniqueness_of :uuid, :name
@@ -199,5 +201,11 @@ class Account < Yeti::ActiveRecord
       record.account_ids.delete(id)
       record.save!
     end
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[
+      search_for ordered_by
+    ]
   end
 end

--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -30,6 +30,8 @@ class Contractor < ActiveRecord::Base
 
   scope :customers, -> { where customer: true }
   scope :vendors, -> { where vendor: true }
+  scope :search_for, ->(term) { where("name || ' | ' || id::varchar ILIKE ?", "%#{term}%") }
+  scope :ordered_by, ->(term) { order(term) }
 
   include Yeti::ResourceStatus
 
@@ -68,5 +70,11 @@ class Contractor < ActiveRecord::Base
     if customer_changed?(from: true, to: false) && customers_auths.any?
       errors.add(:customer, I18n.t('activerecord.errors.models.contractor.attributes.customer'))
     end
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[
+      search_for ordered_by
+    ]
   end
 end

--- a/app/models/gateway.rb
+++ b/app/models/gateway.rb
@@ -203,7 +203,8 @@ class Gateway < Yeti::ActiveRecord
   scope :with_radius_accounting, -> { where 'radius_accounting_profile_id is not null' }
   scope :shared, -> { where is_shared: true }
   scope :for_origination, ->(contractor_id) { where('allow_origination and ( is_shared or contractor_id=?)', contractor_id).order(:name) }
-
+  scope :search_for, ->(term) { where("name || ' | ' || id::varchar ILIKE ?", "%#{term}%") }
+  scope :ordered_by, ->(term) { order(term) }
   scope :for_termination, lambda { |contractor_id|
     where("#{table_name}.allow_termination AND (#{table_name}.contractor_id=? OR #{table_name}.is_shared)", contractor_id)
       .joins(:vendor)
@@ -328,5 +329,11 @@ class Gateway < Yeti::ActiveRecord
 
   def incoming_auth_changed?
     incoming_auth_username_changed? || incoming_auth_password_changed?
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[
+      search_for ordered_by
+    ]
   end
 end

--- a/config/initializers/yeti.rb
+++ b/config/initializers/yeti.rb
@@ -29,6 +29,7 @@ ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActsAsBelongsTo
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::WithDefaultParams
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::WithGlobalDSL
 ActiveAdmin::ResourceDSL.send :include, ResourceDSL::BooleanFilter
+ActiveAdmin::ResourceDSL.send :include, ResourceDSL::ActiveSearch
 
 # ActiveAdmin::CSVBuilder.send(:include, Yeti::CSVBuilder)
 

--- a/lib/resource_dsl/active_search.rb
+++ b/lib/resource_dsl/active_search.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ResourceDSL
+  module ActiveSearch
+    def search_support!
+      collection_action :search, method: :get do
+        data = resource_class.ransack(params[:q]).result
+        result = data.map do |item|
+          { id: item.id, value: item.display_name }
+        end
+        render json: result
+      end
+    end
+  end
+end

--- a/spec/features/ajax_filters_spec.rb
+++ b/spec/features/ajax_filters_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Load filter options', type: :feature, js: true do
+  include_context :login_as_admin
+  before { visit cdrs_path }
+  context 'customer filter' do
+    let!(:goal_customer_list) {
+      [
+        FactoryBot.create(:customer, name: 'customer_1'),
+        FactoryBot.create(:customer, name: 'customer_2')
+      ]
+    }
+    let!(:other_customer) { FactoryBot.create(:customer, name: 'other') }
+
+    subject do
+      # open chosen popup to get input
+      find('#q_customer_id_chosen').click
+      find('#q_customer_id_chosen input').fill_in with: 'cus'
+    end
+
+    it 'should have one option in select' do
+      within '#sidebar #new_q #q_customer_input select', visible: false do
+        expect(page).to have_css('option', count: 1, visible: false)
+        expect(page).to have_css('option:first-child', text: 'Any', visible: false)
+      end
+    end
+
+    it 'when type letters load options (2 results and "Any" existed)' do
+      subject
+      goal_customer_list.each do |item|
+        expect(page).to have_css('#q_customer_input select option', text: item.name, visible: false)
+      end
+      # 2 results from database and "Any" option by default = total 3
+      expect(page).to have_css('#q_customer_input select option', count: 3, visible: false)
+    end
+
+    it 'should select option and execute filter ' do
+      customer = goal_customer_list.first
+      subject
+      # make first element selected
+      find('#q_customer_id_chosen li', text: customer.name).click
+
+      # execute filter and reload page
+      page.find('input[type=submit]').click
+
+      expect(CGI.unescape(page.current_url)).to include("q[customer_id_eq]=#{customer.id}")
+      # check selected element
+      expect(find('#q_customer_input select option', visible: false, text: customer.name)).to be_selected
+    end
+  end
+end


### PR DESCRIPTION
load resources accross ajax
solved: #711 

- contractor/customer/vendor
- account
- gateway/orig gw/term gw

![ajax](https://user-images.githubusercontent.com/10907664/82563840-49c7f780-9b67-11ea-81fa-f80c5149cf9a.gif)
---------------------------------------------------------------------------

 **has gateway filter**:
- [x] import_dialpeers
- [x] auth_logs (Cdr::AuthLog)
- [x] rtp_statistics (Cdr::RtpStatistic)
- [x] dialpeers (Dialpeer)
- [x] customers_auths (CustomersAuth)
**has account filter**:
- [x] import_dialpeers
- [x] invoices (Billing::Invoice)
- [x] customers_auths (CustomersAuth)
- [x] dialpeers (Dialpeer)
 **has contractor filter**
**vendor**
- [x] import_dialpeers
- [x] import_gateway_groups
- [x] gateway_groups ()
- [x] active_calls (RealtimeData::ActiveCall)
- [x] cdrs (Cdr::Cdr)
- [x] vendor_traffics (Report::VendorTraffic)
- [x] vendor_traffic_schedulers (Report::VendorTrafficScheduler)
- [x] dialpeers (Dialpeer)
- [x] static_routes (Routing::RoutingPlanStaticRoute)
**customer**
- [x] cdrs
- [x] active_calls
- [x] custom_cdrs
- [x] custom_cdr_schedulers
- [x] customer_traffics
- [x] customer_traffic_schedulers
- [x] report_realtime_bad_routings
- [x] report_realtime_origination_performances
- [x] report_realtime_termination_distributions
- [x] customers_auths
- [x] api_accesses
**contractor**
- [x] accounts
- [x] import_gateways
- [x] import_accounts
- [x] billing_contacts 
- [x] invoices 
- [x] gateways


