### PR TITLE
resolve #743, fixed filters named routing_tag_ids_array_contains and tagged 

### DIFF
--- a/app/models/concerns/routing_tag_ids_scopeable.rb
+++ b/app/models/concerns/routing_tag_ids_scopeable.rb
@@ -8,7 +8,7 @@ module RoutingTagIdsScopeable
       where("yeti_ext.tag_compare(routing_tag_ids, ARRAY[#{id.join(',')}], routing_tag_mode_id)>0")
     }
 
-    scope :tagged, lambda { |*value|
+    scope :tagged, lambda { |value|
       if ActiveModel::Type::Boolean.new.cast(value)
         where("routing_tag_ids <> '{}'") # has tags
       else

--- a/app/models/customers_auth.rb
+++ b/app/models/customers_auth.rb
@@ -142,6 +142,12 @@ class CustomersAuth < Yeti::ActiveRecord
       )"
     )
   }
+  scope :src_prefix_array_contains, ->(src) { where.contains src_prefix: Array(src) }
+  scope :dst_prefix_array_contains, ->(dst) { where.contains dst_prefix: Array(dst) }
+  scope :uri_domain_array_contains, ->(uri) { where.contains uri_domain: Array(uri) }
+  scope :from_domain_array_contains, ->(f_dom) { where.contains from_domain: Array(f_dom) }
+  scope :to_domain_array_contains, ->(to_dom) { where.contains to_domain: Array(to_dom) }
+  scope :x_yeti_auth_array_contains, ->(auth) { where.contains x_yeti_auth: Array(auth) }
 
   include Yeti::ResourceStatus
 
@@ -201,7 +207,15 @@ class CustomersAuth < Yeti::ActiveRecord
   private
 
   def self.ransackable_scopes(_auth_object = nil)
-    [:ip_covers]
+    %i[
+      src_prefix_array_contains
+      dst_prefix_array_contains
+      uri_domain_array_contains
+      from_domain_array_contains
+      to_domain_array_contains
+      x_yeti_auth_array_contains
+      ip_covers
+    ]
   end
 
   protected

--- a/app/models/dialpeer.rb
+++ b/app/models/dialpeer.rb
@@ -200,10 +200,13 @@ class Dialpeer < Yeti::ActiveRecord
     errors.add(:gateway_group, 'must be owned by selected vendor') unless gateway_group_id.nil? || (vendor_id && gateway_group_id && vendor_id == gateway_group.vendor_id)
   end
 
+  scope :routing_tag_ids_array_contains, ->(*tag_id) { where.contains routing_tag_ids: Array(tag_id) }
+
   private
 
   def self.ransackable_scopes(_auth_object = nil)
     %i[
+      routing_tag_ids_array_contains
       routing_for_contains
       routing_tag_ids_covers
       tagged

--- a/app/models/routing/destination.rb
+++ b/app/models/routing/destination.rb
@@ -152,10 +152,13 @@ class Routing::Destination < Yeti::ActiveRecord
     )', prx, prx, prx)
   }
 
+  scope :routing_tag_ids_array_contains, ->(*tag_id) { where.contains routing_tag_ids: Array(tag_id) }
+
   private
 
   def self.ransackable_scopes(_auth_object = nil)
     %i[
+      routing_tag_ids_array_contains
       routing_for_contains
       routing_tag_ids_covers
       tagged

--- a/app/models/routing/routing_tag_detection_rule.rb
+++ b/app/models/routing/routing_tag_detection_rule.rb
@@ -38,10 +38,13 @@ class Routing::RoutingTagDetectionRule < Yeti::ActiveRecord
     id.to_s
   end
 
+  scope :routing_tag_ids_array_contains, ->(*tag_id) { where.contains routing_tag_ids: Array(tag_id) }
+
   private
 
   def self.ransackable_scopes(_auth_object = nil)
     %i[
+      routing_tag_ids_array_contains
       routing_tag_ids_covers
       tagged
     ]

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-# https://github.com/activerecord-hackery/ransack/issues/321
 Ransack.configure do |config|
-  { array_contains: :contains }.each do |rp, ap|
-    config.add_predicate rp, arel_predicate: ap, wants_array: true
-  end
   config.ignore_unknown_conditions = false
   config.sanitize_custom_scope_booleans = false
 end

--- a/spec/features/routing/customers_auths/filters_spec.rb
+++ b/spec/features/routing/customers_auths/filters_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Filter Customers Auths records', :js do
+  include_context :login_as_admin
+  let!(:_customers_auths_list) { create_list :customers_auth, 2 }
+  before { visit customers_auths_path }
+
+  context 'by' do
+    context '"SRC PREFIX"' do
+      prefix = '_src_'
+      let!(:customers_auth_src) { create(:customers_auth, src_prefix: [prefix]) }
+      it 'should have filtered record only' do
+        fill_in 'SRC Prefix', with: prefix
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_src.id
+        expect(page).to have_field 'SRC Prefix', with: prefix
+      end
+    end
+
+    context '"DST PREFIX"' do
+      prefix = '_dst_'
+      let!(:customers_auth_dst) { create(:customers_auth, dst_prefix: [prefix]) }
+      it 'should have filtered record only' do
+        fill_in 'DST Prefix', with: prefix
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_dst.id
+        expect(page).to have_field 'DST Prefix', with: prefix
+      end
+    end
+
+    context '"URI DOMAIN"' do
+      domain = 'main.com'
+      let!(:customers_auth_domain) { create(:customers_auth, uri_domain: [domain]) }
+      it 'should have filtered record only' do
+        fill_in 'URI Domain', with: domain
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_domain.id
+        expect(page).to have_field 'URI Domain', with: domain
+      end
+    end
+
+    context '"FROM DOMAIN"' do
+      domain = 'main.com'
+      let!(:customers_auth_f_domain) { create(:customers_auth, from_domain: [domain]) }
+      it 'should have filtered record only' do
+        fill_in 'From Domain', with: domain
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_f_domain.id
+        expect(page).to have_field 'From Domain', with: domain
+      end
+    end
+
+    context '"TO DOMAIN"' do
+      domain = 'main.com'
+      let!(:customers_auth_t_domain) { create(:customers_auth, to_domain: [domain]) }
+      it 'should have filtered record only' do
+        fill_in 'To Domain', with: domain
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_t_domain.id
+        expect(page).to have_field 'To Domain', with: domain
+      end
+    end
+
+    context '"X-YETI-AUTH"' do
+      domain = 'string'
+      let!(:customers_auth_x_domain) { create(:customers_auth, x_yeti_auth: [domain]) }
+      it 'should have filtered record only' do
+        fill_in 'X-Yeti-Auth', with: domain
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_x_domain.id
+        expect(page).to have_field 'X-Yeti-Auth', with: domain
+      end
+    end
+  end
+end

--- a/spec/features/routing/destinations/filters_spec.rb
+++ b/spec/features/routing/destinations/filters_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Filter Destination records', :js do
+  include_context :login_as_admin
+  let!(:other_destinations_list) { create_list :destination, 2 }
+
+  context 'by' do
+    context '"TAGGED"' do
+      let!(:tag) { create :routing_tag, :ua }
+      let!(:customers_auth_tagged) { create :destination, routing_tag_ids: [tag.id] }
+
+      it 'should have records with any tag' do
+        visit destinations_path
+        select :Yes, from: :Tagged
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: customers_auth_tagged.id
+        expect(page).to have_select :Tagged, selected: 'Yes'
+      end
+
+      it 'should have record without any tag' do
+        visit destinations_path
+        select :No, from: :Tagged
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: other_destinations_list.count
+        expect(page).to have_select :Tagged, selected: 'No'
+        other_destinations_list.each { |d| expect(page).to have_css('.resource_id_link', text: d.id) }
+      end
+    end
+
+    context '"ROUTING TAG IDS CONTAINS"' do
+      let!(:tag_us) { create :routing_tag }
+      let!(:tag_ua) { create :routing_tag }
+      let!(:destinations_tag_contains) { create :destination, routing_tag_ids: [tag_us.id, tag_ua.id] }
+
+      it 'should have one record with routing_tag only' do
+        visit destinations_path
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_us.name
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_ua.name
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: destinations_tag_contains.id
+      end
+    end
+  end
+end

--- a/spec/features/routing/dialpeers/filters_spec.rb
+++ b/spec/features/routing/dialpeers/filters_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Filter Destination records', :js do
+  include_context :login_as_admin
+  let!(:other_dialpeers) { create_list :dialpeer, 2 }
+  before { visit dialpeers_path }
+
+  context 'by' do
+    context '"TAGGED"' do
+      let!(:tag) { create :routing_tag }
+      let!(:dialpeer_tagged) { create :dialpeer, routing_tag_ids: [tag.id] }
+
+      it 'should have record with any tag' do
+        select :Yes, from: :Tagged
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: dialpeer_tagged.id
+        expect(page).to have_select :Tagged, selected: 'Yes'
+      end
+
+      it 'should have record without any tag' do
+        select :No, from: :Tagged
+        click_button :Filter
+        expect(page).to have_css('table.index_table tbody tr', count: other_dialpeers.count)
+        expect(page).to have_select :Tagged, selected: 'No'
+        other_dialpeers.each { |p| expect(page).to have_css '.resource_id_link', text: p.id }
+      end
+    end
+
+    context '"ROUTING TAG IDS CONTAINS"' do
+      let!(:tag_us) { create :routing_tag, :us }
+      let!(:tag_ua) { create :routing_tag, :ua }
+      let!(:dialpeer_tag_countains) { create :dialpeer, routing_tag_ids: [tag_us.id, tag_ua.id] }
+
+      it 'should have one record with routing_tag only' do
+        visit dialpeers_path
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_us.name
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_ua.name
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: dialpeer_tag_countains.id
+      end
+    end
+  end
+end

--- a/spec/features/routing/routing_tag_detection_rules/filters_spec.rb
+++ b/spec/features/routing/routing_tag_detection_rules/filters_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Filter Routing Tag detection rule records', :js do
+  include_context :login_as_admin
+  let!(:routing_tag_detection_rule_list) { create_list :routing_tag_detection_rule, 2 }
+  context 'by' do
+    context '"ROUTING TAG IDS CONTAINS"' do
+      let!(:tag_us) { create :routing_tag, :us }
+      let!(:tag_ua) { create :routing_tag, :ua }
+      let!(:routing_tag_contains) { create :routing_tag_detection_rule, routing_tag_ids: [tag_us.id, tag_ua.id] }
+      it 'should have one record with routing_tags only' do
+        visit routing_routing_tag_detection_rules_path
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_us.name
+        chosen_pick '#q_routing_tag_ids_array_contains_chosen', text: tag_ua.name
+        click_button :Filter
+        expect(page).to have_css 'table.index_table tbody tr', count: 1
+        expect(page).to have_css '.resource_id_link', text: routing_tag_contains.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
Summary: filters called routing tag ids contains, tagger do not work

1. To correct the error's filter routing_tag_ids_array_contains was implemented differently, with the scope and method `contains` from `active_record_extended` gem
1. To fix tagged filter was removed Array arguments (from *value to vaue) because:
`ActiveModel::Type::Boolean.new.cast(['true'])` => true
`ActiveModel::Type::Boolean.new.cast(['false'])` => true too

**tests**

**app/models/customers_auth.rb**
    src_prefix
    dst_prefix
    uri_domain
    from_domain
    to_domain
    x_yeti_auth
**app/models/dialpeer.rb**
routing_tag_ids_array_contains
tegged
**app/models/routing/destination.rb**
    routing_tag_ids_array_contains
    tagged
**app/models/routing/routing_tag_detection_rule.rb**
    routing_tag_ids_array_contains