### PR TITLE
fix bug: missing validates for dialpeers model class

### DIFF
--- a/app/models/dialpeer.rb
+++ b/app/models/dialpeer.rb
@@ -67,8 +67,8 @@ class Dialpeer < Yeti::ActiveRecord
   validates :account, :routing_group, :vendor, :valid_from, :valid_till,
                         :initial_rate, :next_rate,
                         :initial_interval, :next_interval, :connect_fee,
-                        :routing_tag_mode, :routeset_discriminator, presence: true
-  validates :initial_rate, :next_rate, :connect_fee, numericality: true
+                        :routing_tag_mode, :routeset_discriminator, :lcr_rate_multiplier, presence: true
+  validates :initial_rate, :next_rate, :connect_fee, :lcr_rate_multiplier, numericality: true
   validates :initial_interval, :next_interval, numericality: { greater_than: 0 } # we have DB constraints for this
   validates :acd_limit, numericality: { greater_than_or_equal_to: 0.00 }
   validates :asr_limit, numericality: { greater_than_or_equal_to: 0.00, less_than_or_equal_to: 1.00 }
@@ -85,10 +85,10 @@ class Dialpeer < Yeti::ActiveRecord
   validates :batch_prefix, format: { without: /\s/ }
 
   validate :contractor_is_vendor
-  validate :vendor_owners_the_account
+  validate :vendor_owners_the_account, if: :account
   validate :gateway_presence
-  validate :vendor_owners_the_gateway
-  validate :vendor_owners_the_gateway_group
+  validate :vendor_owners_the_gateway, if: :gateway
+  validate :vendor_owners_the_gateway_group, if: :gateway_group
 
   validates_with RoutingTagIdsValidator
 

--- a/spec/models/dialpeer_spec.rb
+++ b/spec/models/dialpeer_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe Dialpeer, type: :model do
         include_examples :validation_no_error_on_field, :gateway
       end
 
+      context 'with Gateway_id 0' do
+        let(:attributes) { { gateway_id: 0 } }
+
+        include_examples :validation_error_on_field, :base, 'Specify a gateway_group or a gateway'
+      end
+
+      context 'with Gateway_group_id 0' do
+        let(:attributes) { { gateway_group_id: 0 } }
+
+        include_examples :validation_error_on_field, :base, 'Specify a gateway_group or a gateway'
+      end
+
       context 'with Gateway' do
         let(:attributes) { { gateway: g, vendor_id: vendor.id, gateway_id: g.id } }
         let(:vendor) { g.contractor }

--- a/spec/requests/api/rest/admin/dialpeer_spec.rb
+++ b/spec/requests/api/rest/admin/dialpeer_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::Admin::DialpeersController do
+  include_context :json_api_admin_helpers, type: :dialpeers
+  describe 'POST api/rest/admin/dialpeers' do
+    include_context :init_routing_tag_collection
+    subject do
+      post json_api_request_path, params: json_api_request_body.to_json, headers: json_api_request_headers
+    end
+
+    let(:routing_group) { FactoryBot.create(:routing_group) }
+    let(:vendor) { FactoryBot.create(:vendor) }
+    let(:account) { FactoryBot.create(:account, contractor: vendor) }
+    let(:routing_tag_mode) { Routing::RoutingTagMode.take! }
+    let(:routeset_discriminator) { Routing::RoutesetDiscriminator.take || FactoryBot.create(:routeset_discriminator) }
+
+    context 'without gateway_id and gateway_group_id' do
+      let(:json_api_request_body) do
+        {
+          data: {
+            type: json_api_resource_type,
+            attributes: json_api_request_attributes,
+            relationships: json_api_request_relationships
+          }
+        }
+      end
+      let(:json_api_request_attributes) do
+        {
+          'acd-limit': '0.01',
+          'enabled': 'true',
+          'prefix': '_test_',
+          'asr-limit': '0.02',
+          'next-rate': '0.01',
+          'initial-rate': '0.01',
+          'connect-fee': '0.01',
+          'valid-from': '2020-02-02',
+          'valid-till': '2020-02-02'
+
+        }
+      end
+      let(:json_api_request_relationships) do
+        {
+          'routing-group': { data: { id: routing_group.id.to_s, type: 'routing_groups' } },
+          'account': { data: { id: account.id.to_s, type: 'accounts' } },
+          'routing-tag-mode': { data: { id: routing_tag_mode.id.to_s, type: 'routing_tag_modes' } },
+          'routeset-discriminator': { data: { id: routeset_discriminator.id.to_s, type: 'routeset_discriminators' } },
+          'vendor': { data: { id: vendor.id.to_s, type: 'contractors' } },
+          'routing-tag-ids': { data: { id: [@tag_ua], type: 'routing_tags' } },
+          'gateway': { data: { id: 0, type: 'gateways' } },
+          'gateway-group': { data: { id: 0, type: 'gateway_groups' } }
+        }
+      end
+
+      include_examples :returns_json_api_errors, errors: [
+        { detail: 'base - Specify a gateway_group or a gateway' }
+      ], status: 422
+    end
+
+    context 'without lcr-rate-multiplier' do
+      let!(:gateway) { create :gateway, contractor: vendor }
+      let(:json_api_request_body) do
+        {
+          data: {
+            type: json_api_resource_type,
+            attributes: json_api_request_attributes,
+            relationships: json_api_request_relationships
+          }
+        }
+      end
+      let(:json_api_request_attributes) do
+        {
+          'acd-limit': '0.01',
+          'enabled': 'true',
+          'prefix': '_test_',
+          'asr-limit': '0.02',
+          'next-rate': '0.01',
+          'initial-rate': '0.01',
+          'connect-fee': '0.01',
+          'valid-from': '2020-02-02',
+          'valid-till': '2020-02-02',
+
+          'lcr-rate-multiplier': ''
+
+        }
+      end
+      let(:json_api_request_relationships) do
+        {
+          'routing-group': { data: { id: routing_group.id.to_s, type: 'routing_groups' } },
+          'account': { data: { id: account.id.to_s, type: 'accounts' } },
+          'routing-tag-mode': { data: { id: routing_tag_mode.id.to_s, type: 'routing_tag_modes' } },
+          'routeset-discriminator': { data: { id: routeset_discriminator.id.to_s, type: 'routeset_discriminators' } },
+          'vendor': { data: { id: vendor.id.to_s, type: 'contractors' } },
+          'routing-tag-ids': { data: { id: [@tag_ua], type: 'routing_tags' } },
+          'gateway': { data: { id: gateway.id, type: 'gateways' } }
+        }
+      end
+
+      include_examples :returns_json_api_errors, errors: [
+        { detail: "lcr-rate-multiplier - can't be blank" },
+        { detail: 'lcr-rate-multiplier - is not a number' }
+      ], status: 422
+    end
+  end
+end


### PR DESCRIPTION
 refs #336 

Added missing presence validations for field: **lcr_rate_multiplier** and **gateway_id** with zero. 

we have error when pass gateway_id with 0 because in throws out error `undefined method vendor_id for nil class` in [200](https://github.com/yeti-switch/yeti-web/blob/4d0aad6a414d2b8b8520f66faccce590f7b06cdb/app/models/dialpeer.rb#L200) line

