### PR TITLE
refs #754 fixed rendering index page from /bad_routing

### DIFF
--- a/app/admin/reports/realtime/bad_routings.rb
+++ b/app/admin/reports/realtime/bad_routings.rb
@@ -28,8 +28,7 @@ ActiveAdmin.register Report::Realtime::BadRouting do
 
   controller do
     def scoped_collection
-      length = params[:q][:time_interval_eq].to_i
-      super.detailed_scope(length)
+      super.detailed_scope
     end
   end
 

--- a/app/admin/reports/realtime/not_authenticateds.rb
+++ b/app/admin/reports/realtime/not_authenticateds.rb
@@ -16,8 +16,7 @@ ActiveAdmin.register Report::Realtime::NotAuthenticated do
 
   controller do
     def scoped_collection
-      lenght = params[:q][:time_interval_eq].to_i
-      super.detailed_scope(lenght)
+      super.detailed_scope
     end
   end
 

--- a/app/models/disconnect_initiator.rb
+++ b/app/models/disconnect_initiator.rb
@@ -9,4 +9,8 @@
 #
 
 class DisconnectInitiator < ActiveRecord::Base
+  ID_TRAFFIC_MANAGER = 0
+  ID_TRAFFIC_SWITCH = 1
+  ID_DESTINATION = 2
+  ID_ORIGINATION = 3
 end

--- a/app/models/report/realtime/bad_routing.rb
+++ b/app/models/report/realtime/bad_routing.rb
@@ -149,11 +149,9 @@
 #
 
 class Report::Realtime::BadRouting < Report::Realtime::Base
-  attr_accessor :l
-
-  scope :detailed_scope, lambda { |length|
-    l = length.to_i
+  scope :detailed_scope, lambda {
     select("
+      row_number() over (partition by customer_id, customer_auth_id, rateplan_id, routing_plan_id, internal_disconnect_code, internal_disconnect_reason) AS id,
       customer_id,
       customer_auth_id,
       rateplan_id,

--- a/app/models/report/realtime/not_authenticated.rb
+++ b/app/models/report/realtime/not_authenticated.rb
@@ -149,11 +149,9 @@
 #
 
 class Report::Realtime::NotAuthenticated < Report::Realtime::Base
-  attr_accessor :l
-
-  scope :detailed_scope, lambda { |length|
-    l = length.to_i
+  scope :detailed_scope, lambda {
     select("
+      row_number() over (partition by auth_orig_ip, auth_orig_port, internal_disconnect_code, internal_disconnect_reason) AS id,
       auth_orig_ip,
       auth_orig_port,
       internal_disconnect_code,

--- a/spec/factories/disconnect_initiator.rb
+++ b/spec/factories/disconnect_initiator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :disconnect_initiator, class: DisconnectInitiator do
+    sequence(:id) { |n| n }
+    name { 'Disconnect initiator' }
+
+    trait :traffic_manager do
+      id { DisconnectInitiator::ID_TRAFFIC_MANAGER }
+      name { 'Traffic manager' }
+    end
+
+    trait :traffic_switch do
+      id { DisconnectInitiator::ID_TRAFFIC_SWITCH }
+      name { 'Traffic switch' }
+    end
+
+    trait :destination do
+      id { DisconnectInitiator::ID_DESTINATION }
+      name { 'Destination' }
+    end
+
+    trait :origination do
+      id { DisconnectInitiator::ID_ORIGINATION }
+      name { 'Origination' }
+    end
+  end
+end

--- a/spec/factories/reports/realtime/bad_routing.rb
+++ b/spec/factories/reports/realtime/bad_routing.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bad_routing, class: Report::Realtime::BadRouting, parent: :cdr do
+    time_start { 110.seconds.ago.utc } # this record will be available in page during 10 second
+    disconnect_initiator { DisconnectInitiator.find_by(id: 0) || create(:disconnect_initiator, :traffic_manager) }
+    association :customer_auth, factory: :customers_auth
+  end
+end

--- a/spec/factories/reports/realtime/not_authenticated.rb
+++ b/spec/factories/reports/realtime/not_authenticated.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :not_authenticated, class: Report::Realtime::NotAuthenticated, parent: :cdr do
+    time_start { 110.seconds.ago.utc } # this record will be available in page during 10 second
+    auth_orig_ip { IPAddr.new(rand(2**32), Socket::AF_INET) }
+    customer_auth_id { nil }
+  end
+end

--- a/spec/features/reports/realtime/bad_routing/index_bad_routing_spec.rb
+++ b/spec/features/reports/realtime/bad_routing/index_bad_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Index Report Realtime Bad Routing' do
+  include_context :login_as_admin
+
+  it 'should have records' do
+    bad_routings = FactoryBot.create_list :bad_routing, 2
+    visit report_realtime_bad_routings_path
+    bad_routings.each do |routing|
+      expect(page).to have_css '.col-customer_auth', text: routing.customer_auth.display_name
+    end
+  end
+end

--- a/spec/features/reports/realtime/not_authenticated/index_not_authenticated_spec.rb
+++ b/spec/features/reports/realtime/not_authenticated/index_not_authenticated_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Index Report Realtime Not Authenticated' do
+  include_context :login_as_admin
+
+  it 'should have records' do
+    not_authenticates = FactoryBot.create_list(:not_authenticated, 2)
+    visit report_realtime_not_authenticateds_path
+    not_authenticates.each do |routing|
+      expect(page).to have_css '.col-auth_orig_ip', text: routing.auth_orig_ip
+    end
+  end
+end

--- a/spec/models/report/realtime/bad_routing_spec.rb
+++ b/spec/models/report/realtime/bad_routing_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Report::Realtime::BadRouting do
+  describe '.time_interval_eq' do
+    # DEFAULT_INTERVAL = 60
+    subject { described_class.time_interval_eq(60) }
+
+    context 'record created now' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: Time.now.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 30 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 30.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 60 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 60.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 90 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 90.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 110 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 110.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 115 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 115.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 130 seconds ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 130.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 130 seconds ago with different interval' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 130.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(described_class.time_interval_eq(3600)).to_not include(record)
+      end
+    end
+
+    context 'record created 1 hour ago' do
+      let!(:record) { FactoryBot.create :bad_routing, :with_id, time_start: 3600.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(described_class.time_interval_eq(3600)).to include(record)
+      end
+    end
+  end
+end

--- a/spec/models/report/realtime/not_authenticated_spec.rb
+++ b/spec/models/report/realtime/not_authenticated_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Report::Realtime::NotAuthenticated do
+  describe '.time_interval_eq' do
+    # DEFAULT_INTERVAL = 60
+    subject { described_class.time_interval_eq(Report::Realtime::Base::DEFAULT_INTERVAL) }
+
+    context 'record created now' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: Time.now.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 30 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 30.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 60 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 60.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 90 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 90.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 110 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 110.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 115 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 115.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(subject).to include(record)
+      end
+    end
+
+    context 'record created 130 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 130.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(subject).to_not include(record)
+      end
+    end
+
+    context 'record created 130 seconds ago with different interval' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 130.seconds.ago.utc }
+
+      it 'should not be present in scope' do
+        expect(described_class.time_interval_eq(3600)).to_not include(record)
+      end
+    end
+
+    context 'record created 3600 seconds ago' do
+      let!(:record) { FactoryBot.create :not_authenticated, :with_id, time_start: 3600.seconds.ago.utc }
+
+      it 'should be present in scope' do
+        expect(described_class.time_interval_eq(3600)).to include(record)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #754
Summary: "Bad routing" index page don't rendering, if we have records only
logs: [FATAL]: ActionView::Template::Error (missing attribute: id)

We need 'id' because ActiveAdmin fails to render table for records without id when it's model class has id in schema.