### PR TITLE
fix invoices generation at beginning of year, fix rateplan association for report

### DIFF
--- a/app/lib/billing_period/biweekly.rb
+++ b/app/lib/billing_period/biweekly.rb
@@ -6,7 +6,7 @@ module BillingPeriod
 
     def period_end_for(time)
       date = time.to_date
-      today_week_start = Date.commercial(date.year, date.cweek)
+      today_week_start = Date.commercial(date.cwyear, date.cweek)
 
       period_end_date = [
         today_week_start + 2.weeks,
@@ -18,7 +18,7 @@ module BillingPeriod
 
     def period_start_for(period_end)
       period_end_date = period_end.to_date
-      period_start_date = Date.commercial(period_end_date.year, period_end_date.cweek) - 2.weeks
+      period_start_date = Date.commercial(period_end_date.cwyear, period_end_date.cweek) - 2.weeks
 
       date_to_time_in_time_zone(period_start_date)
     end

--- a/app/lib/billing_period/biweekly_split.rb
+++ b/app/lib/billing_period/biweekly_split.rb
@@ -7,7 +7,7 @@ module BillingPeriod
 
     def period_end_for(time)
       date = time.to_date
-      today_week_start = Date.commercial(date.year, date.cweek)
+      today_week_start = Date.commercial(date.cwyear, date.cweek)
       next_biweekly_start = [
         today_week_start + 2.weeks, today_week_start + 1.week
       ].detect { |d| d.cweek.even? }
@@ -23,7 +23,7 @@ module BillingPeriod
 
     def period_start_for(period_end)
       period_end_date = period_end.to_date
-      period_end_week_start = Date.commercial(period_end_date.year, period_end_date.cweek)
+      period_end_week_start = Date.commercial(period_end_date.cwyear, period_end_date.cweek)
 
       if period_end_date == period_end_week_start
         prev_biweekly_start = [

--- a/app/lib/billing_period/weekly.rb
+++ b/app/lib/billing_period/weekly.rb
@@ -6,14 +6,14 @@ module BillingPeriod
 
     def period_end_for(time)
       date = time.to_date
-      period_end_date = Date.commercial(date.year, date.cweek) + 1.week
+      period_end_date = Date.commercial(date.cwyear, date.cweek) + 1.week
 
       date_to_time_in_time_zone(period_end_date)
     end
 
     def period_start_for(period_end)
       period_end_date = period_end.to_date
-      period_start_date = Date.commercial(period_end_date.year, period_end_date.cweek) - 1.week
+      period_start_date = Date.commercial(period_end_date.cwyear, period_end_date.cweek) - 1.week
 
       date_to_time_in_time_zone(period_start_date)
     end

--- a/app/lib/billing_period/weekly_split.rb
+++ b/app/lib/billing_period/weekly_split.rb
@@ -7,7 +7,7 @@ module BillingPeriod
 
     def period_end_for(time)
       date = time.to_date
-      today_week_end = Date.commercial(date.year, date.cweek).end_of_week
+      today_week_end = Date.commercial(date.cwyear, date.cweek).end_of_week
       if date.month == today_week_end.month
         period_end_date = today_week_end + 1.day
       else
@@ -19,7 +19,7 @@ module BillingPeriod
 
     def period_start_for(period_end)
       period_end_date = period_end.to_date
-      week_start = Date.commercial(period_end_date.year, period_end_date.cweek)
+      week_start = Date.commercial(period_end_date.cwyear, period_end_date.cweek)
 
       if period_end_date == week_start
         prev_week_start = period_end_date - 1.week

--- a/app/models/report/custom_data.rb
+++ b/app/models/report/custom_data.rb
@@ -98,7 +98,7 @@ class Report::CustomData < Cdr::Base
 
   belongs_to :report, class_name: 'Report::CustomCdr', foreign_key: :report_id
 
-  belongs_to :rateplan, class_name: 'Rateplan', foreign_key: :rateplan_id
+  belongs_to :rateplan, class_name: 'Routing::Rateplan', foreign_key: :rateplan_id
   belongs_to :routing_group, class_name: 'RoutingGroup', foreign_key: :routing_group_id
 
   belongs_to :orig_gw, class_name: 'Gateway', foreign_key: :orig_gw_id


### PR DESCRIPTION
* fix rateplan association for report
 
* fix invoices generation at beginning of year


https://travis-ci.org/github/yeti-switch/yeti-web/jobs/752262071
```
     Failure/Error: period_start_date = Date.commercial(period_end_date.year, period_end_date.cweek) - 1.week
     
     ArgumentError:
       invalid date
```

https://travis-ci.org/github/yeti-switch/yeti-web/jobs/751787008
```
          NameError:
            uninitialized constant Report::CustomData::Rateplan
```