### PR TITLE
Additional clickhouse dictionaries

### DIFF
--- a/app/controllers/api/rest/clickhouse_dictionaries/nodes_controller.rb
+++ b/app/controllers/api/rest/clickhouse_dictionaries/nodes_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::Rest::ClickhouseDictionaries::NodesController < ::Api::RestController
+  def index
+    render plain: ClickhouseDictionary::Node.call
+  end
+end

--- a/app/controllers/api/rest/clickhouse_dictionaries/pops_controller.rb
+++ b/app/controllers/api/rest/clickhouse_dictionaries/pops_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::Rest::ClickhouseDictionaries::PopsController < ::Api::RestController
+  def index
+    render plain: ClickhouseDictionary::Pop.call
+  end
+end

--- a/app/models/clickhouse_dictionary/node.rb
+++ b/app/models/clickhouse_dictionary/node.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ClickhouseDictionary
+  class Node < Base
+    model_class ::Node
+
+    attributes :id,
+               :name,
+               :pop_id
+  end
+end

--- a/app/models/clickhouse_dictionary/pop.rb
+++ b/app/models/clickhouse_dictionary/pop.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ClickhouseDictionary
+  class Pop < Base
+    model_class ::Pop
+
+    attributes :id,
+               :name
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,8 @@ Rails.application.routes.draw do
             dasherized_resources :gateways
             dasherized_resources :network_prefixes
             dasherized_resources :networks
+            dasherized_resources :nodes
+            dasherized_resources :pops
             dasherized_resources :rateplans
             dasherized_resources :routing_plans
           end

--- a/spec/requests/api/rest/clickhouse_dictionaries/accounts_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/accounts_spec.rb
@@ -1,40 +1,40 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/accounts' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::AccountsController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :accounts
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'accounts' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/accounts' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:accounts) { create_list(:account, 3) + [create(:account, external_id: 123)] }
+    let!(:accounts) { create_list(:account, 3) + [create(:account, external_id: 123)] }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      accounts.map do |record|
-        record.reload
-        {
-          id: record.id,
-          name: record.name,
-          external_id: record.external_id,
-          origination_capacity: record.origination_capacity,
-          termination_capacity: record.termination_capacity,
-          total_capacity: record.total_capacity,
-          uuid: record.uuid
-        }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        accounts.map do |record|
+          record.reload
+          {
+            id: record.id,
+            name: record.name,
+            external_id: record.external_id,
+            origination_capacity: record.origination_capacity,
+            termination_capacity: record.termination_capacity,
+            total_capacity: record.total_capacity,
+            uuid: record.uuid
+          }
+        end
       end
     end
-  end
 
-  context 'when raises exception' do
-    before do
-      expect(ClickhouseDictionary::Account).to receive(:call).once
-                                                             .and_raise(StandardError, 'test error')
+    context 'when raises exception' do
+      before do
+        expect(ClickhouseDictionary::Account).to receive(:call).once
+                                                               .and_raise(StandardError, 'test error')
+      end
+
+      include_examples :raises_exception, StandardError, 'test error'
+      include_examples :captures_error, safe: true
     end
-
-    include_examples :raises_exception, StandardError, 'test error'
-    include_examples :captures_error, safe: true
   end
 end

--- a/spec/requests/api/rest/clickhouse_dictionaries/areas_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/areas_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/areas' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::AreasController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :areas
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'areas' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/areas' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:areas) { create_list(:area, 3) }
+    let!(:areas) { create_list(:area, 3) }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      areas.map { |record| { id: record.id, name: record.name } }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        areas.map { |record| { id: record.id, name: record.name } }
+      end
     end
   end
 end

--- a/spec/requests/api/rest/clickhouse_dictionaries/contractors_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/contractors_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/contractors' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::ContractorsController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :contractors
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'contractors' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/contractors' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:contractors) { create_list(:vendor, 2) + [create(:customer, external_id: 123)] }
+    let!(:contractors) { create_list(:vendor, 2) + [create(:customer, external_id: 123)] }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      contractors.map do |record|
-        {
-          id: record.id,
-          name: record.name,
-          external_id: record.external_id,
-          enabled: record.enabled,
-          vendor: record.vendor,
-          customer: record.customer
-        }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        contractors.map do |record|
+          {
+            id: record.id,
+            name: record.name,
+            external_id: record.external_id,
+            enabled: record.enabled,
+            vendor: record.vendor,
+            customer: record.customer
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/rest/clickhouse_dictionaries/countries_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/countries_spec.rb
@@ -1,24 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/countries' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::CountriesController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :countries
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'countries' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/countries' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:countries) do
-    [
-      create(:country, name: 'Canada', iso2: 'CA'),
-      create(:country, name: 'United Stated', iso2: 'US')
-    ]
-  end
+    let!(:countries) do
+      FactoryBot.create_list(:country, 2, :uniq_name)
+    end
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      countries.map { |record| { id: record.id, name: record.name, iso2: record.iso2 } }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        countries.map { |record| { id: record.id, name: record.name, iso2: record.iso2 } }
+      end
     end
   end
 end

--- a/spec/requests/api/rest/clickhouse_dictionaries/customer_auths_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/customer_auths_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/customer-auths' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::CustomerAuthsController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :'customer-auths'
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'customer-auths' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/customer-auths' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:customer_auths) { create_list(:customers_auth, 2) + [create(:customers_auth, external_id: 123)] }
+    let!(:customer_auths) { create_list(:customers_auth, 2) + [create(:customers_auth, external_id: 123)] }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      customer_auths.map do |record|
-        {
-          id: record.id,
-          name: record.name,
-          external_id: record.external_id,
-          customer_id: record.customer_id,
-          account_id: record.account_id,
-          enabled: record.enabled
-        }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        customer_auths.map do |record|
+          {
+            id: record.id,
+            name: record.name,
+            external_id: record.external_id,
+            customer_id: record.customer_id,
+            account_id: record.account_id,
+            enabled: record.enabled
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/rest/clickhouse_dictionaries/gateways_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/gateways_spec.rb
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/gateways' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::GatewaysController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :gateways
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'gateways' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/gateways' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:gateways) { create_list(:gateway, 3) + [create(:gateway, external_id: 123)] }
+    let!(:gateways) { create_list(:gateway, 3) + [create(:gateway, external_id: 123)] }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      gateways.map do |record|
-        {
-          id: record.id,
-          name: record.name,
-          external_id: record.external_id,
-          origination_capacity: record.origination_capacity,
-          termination_capacity: record.termination_capacity,
-          enabled: record.enabled,
-          gateway_group_id: record.gateway_group_id,
-          allow_origination: record.allow_origination,
-          allow_termination: record.allow_termination
-        }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        gateways.map do |record|
+          {
+            id: record.id,
+            name: record.name,
+            external_id: record.external_id,
+            origination_capacity: record.origination_capacity,
+            termination_capacity: record.termination_capacity,
+            enabled: record.enabled,
+            gateway_group_id: record.gateway_group_id,
+            allow_origination: record.allow_origination,
+            allow_termination: record.allow_termination
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/rest/clickhouse_dictionaries/network_prefixes_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/network_prefixes_spec.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/network-prefixes' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::NetworkPrefixesController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :'network-prefixes'
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'network-prefixes' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/network-prefixes' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:network_prefixes) { create_list(:network_prefix, 3) }
+    let!(:network_prefixes) { create_list(:network_prefix, 3) }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      network_prefixes.map do |record|
-        {
-          id: record.id,
-          prefix: record.prefix,
-          country_name: record.country.name,
-          network_name: record.network.name,
-          country_id: record.country_id,
-          network_id: record.network_id
-        }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        network_prefixes.map do |record|
+          {
+            id: record.id,
+            prefix: record.prefix,
+            country_name: record.country.name,
+            network_name: record.network.name,
+            country_id: record.country_id,
+            network_id: record.network_id
+          }
+        end
       end
     end
   end

--- a/spec/requests/api/rest/clickhouse_dictionaries/networks_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/networks_spec.rb
@@ -1,24 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/networks' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::NetworksController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :networks
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'networks' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/networks' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:networks) do
-    [
-      create(:network),
-      create(:network, name: 'Other')
-    ]
-  end
+    let!(:networks) do
+      FactoryBot.create_list(:network, 2, :uniq_name)
+    end
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      networks.map { |record| { id: record.id, name: record.name } }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        networks.map { |record| { id: record.id, name: record.name } }
+      end
     end
   end
 end

--- a/spec/requests/api/rest/clickhouse_dictionaries/nodes_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/nodes_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::ClickhouseDictionaries::NodesController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :nodes
+
+  describe 'GET /api/rest/clickhouse-dictionaries/nodes' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
+
+    let!(:nodes) do
+      FactoryBot.create_list(:node, 2)
+    end
+
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        nodes.map { |record| { id: record.id, name: record.name, pop_id: record.pop_id } }
+      end
+    end
+  end
+end

--- a/spec/requests/api/rest/clickhouse_dictionaries/pops_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/pops_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::ClickhouseDictionaries::PopsController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :pops
+
+  describe 'GET /api/rest/clickhouse-dictionaries/pops' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
+
+    let!(:pops) do
+      FactoryBot.create_list(:pop, 2)
+    end
+
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        pops.map { |record| { id: record.id, name: record.name } }
+      end
+    end
+  end
+end

--- a/spec/requests/api/rest/clickhouse_dictionaries/rateplans_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/rateplans_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/rateplans' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::RateplansController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :rateplans
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'rateplans' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/rateplans' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:rateplan) { create_list(:rateplan, 3) }
+    let!(:rateplan) { create_list(:rateplan, 3) }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      rateplan.map do |record|
-        record.reload
-        { id: record.id, name: record.name, uuid: record.uuid, external_id: record.external_id }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        rateplan.map do |record|
+          record.reload
+          { id: record.id, name: record.name, uuid: record.uuid, external_id: record.external_id }
+        end
       end
     end
   end

--- a/spec/requests/api/rest/clickhouse_dictionaries/routing_plans_spec.rb
+++ b/spec/requests/api/rest/clickhouse_dictionaries/routing_plans_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe '/api/rest/clickhouse-dictionaries/routing-plans' do
-  subject do
-    get clickhouse_dictionary_path
-  end
+RSpec.describe Api::Rest::ClickhouseDictionaries::RoutingPlansController do
+  include_context :clickhouse_dictionaries_api_helpers, type: :'routing-plans'
 
-  include_context :clickhouse_dictionaries_api_helpers do
-    let(:clickhouse_dictionary_type) { 'routing-plans' }
-  end
+  describe 'GET /api/rest/clickhouse-dictionaries/routing-plans' do
+    subject do
+      get clickhouse_dictionary_request_path
+    end
 
-  let!(:routing_plans) { create_list(:routing_plan, 3) }
+    let!(:routing_plans) { create_list(:routing_plan, 3) }
 
-  include_examples :responds_with_correct_json_each_row do
-    let(:expected_rows) do
-      routing_plans.map { |record| { id: record.id, name: record.name, external_id: record.external_id } }
+    include_examples :responds_with_correct_json_each_row do
+      let(:expected_rows) do
+        routing_plans.map { |record| { id: record.id, name: record.name, external_id: record.external_id } }
+      end
     end
   end
 end

--- a/spec/support/contexts/clickhouse_dictionaries_api_helpers.rb
+++ b/spec/support/contexts/clickhouse_dictionaries_api_helpers.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.shared_context :clickhouse_dictionaries_api_helpers do
-  let(:clickhouse_dictionary_path) do
-    "/api/rest/clickhouse-dictionaries/#{clickhouse_dictionary_type}"
-  end
-  let(:clickhouse_dictionary_type) do
-    raise "override let(:clickhouse_dictionary_type) in #{full_description.inspect} test"
-  end
+RSpec.shared_context :clickhouse_dictionaries_api_helpers do |type: nil|
+  let(:clickhouse_dictionary_resource_type) { type.to_s }
+  let(:clickhouse_dictionary_request_path_prefix) { '/api/rest/clickhouse-dictionaries' }
+  let(:clickhouse_dictionary_request_path) { "#{clickhouse_dictionary_request_path_prefix}/#{clickhouse_dictionary_resource_type}" }
 
   def response_json_each_row
     response.body.split("\n").map { |row| JSON.parse(row).deep_symbolize_keys }


### PR DESCRIPTION
fixes #802
* [x] Rewrite RSpec.shared_context :clickhouse_dictionaries_api_helpers to receive type as parameter
* [x] Rewrite existing tests with type as parameter
* [x] Create tests for Node and Pop dictionaries
* [x] Create Node and Pop dictionaries and controllers