### PR TITLE
Added additional UI filters

### DIFF
--- a/app/admin/billing/contractors.rb
+++ b/app/admin/billing/contractors.rb
@@ -102,10 +102,14 @@ ActiveAdmin.register Contractor do
 
   filter :id
   filter :name
-  filter :enabled, as: :select, collection: [['Yes', true], ['No', false]]
-  filter :vendor, as: :select, collection: [['Yes', true], ['No', false]]
-  filter :customer, as: :select, collection: [['Yes', true], ['No', false]]
+  filter :address
+  filter :description
+  filter :phones
   filter :external_id
+  filter :smtp_connection, input_html: { class: 'chosen' }, collection: proc { System::SmtpConnection.pluck(:name, :id) }
+  boolean_filter :enabled
+  boolean_filter :vendor
+  boolean_filter :customer
 
   sidebar :links, only: %i[show edit] do
     ul do

--- a/app/admin/billing/invoices.rb
+++ b/app/admin/billing/invoices.rb
@@ -183,6 +183,10 @@ ActiveAdmin.register Billing::Invoice, as: 'Invoice' do
   filter :end_date, as: :date_time_range
   filter :vendor_invoice, label: 'Direction', as: :select, collection: [['Vendor', true], ['Customer', false]]
   filter :type
+  filter :amount
+  filter :billing_duration
+  filter :calls_count
+  filter :calls_duration
 
   show do |s|
     tabs do

--- a/app/admin/cdr/auth_logs.rb
+++ b/app/admin/cdr/auth_logs.rb
@@ -120,4 +120,16 @@ ActiveAdmin.register Cdr::AuthLog, as: 'AuthLog' do
   filter :from_uri
   filter :to_uri
   filter :call_id
+  filter :code
+  filter :reason
+  filter :internal_reason
+  filter :realm
+  filter :request_method
+  filter :x_yeti_auth
+  filter :diversion
+  filter :pai
+  filter :ppi
+  filter :privacy
+  filter :rpid
+  filter :rpid_privacy
 end

--- a/app/admin/cdr/cdr_exports.rb
+++ b/app/admin/cdr/cdr_exports.rb
@@ -4,7 +4,9 @@ ActiveAdmin.register CdrExport, as: 'CDR Export' do
   menu parent: 'CDR', priority: 97
   actions :index, :show, :create, :new
 
+  filter :id
   filter :status, as: :select, collection: CdrExport::STATUSES
+  filter :rows_count
   filter :callback_url
   filter :created_at
 

--- a/app/admin/cdr/cdrs.rb
+++ b/app/admin/cdr/cdrs.rb
@@ -139,6 +139,12 @@ ActiveAdmin.register Cdr::Cdr, as: 'CDR' do
   filter :pdd
   filter :rtt
   filter :p_charge_info_in, as: :string_eq
+  filter :uuid_equals, label: 'UUID'
+  filter :auth_orig_ip, as: :string
+  filter :sign_orig_ip
+  filter :sign_orig_local_ip
+  filter :sign_term_local_ip
+  filter :sign_term_ip
 
   # X-Accel-Redirect: /protected/iso.img;
   #  location /protected/ {

--- a/app/admin/equipment/gateways.rb
+++ b/app/admin/equipment/gateways.rb
@@ -317,6 +317,12 @@ ActiveAdmin.register Gateway do
   filter :external_id
   filter :radius_accounting_profile, input_html: { class: 'chosen' }
   filter :lua_script, input_html: { class: 'chosen' }
+  boolean_filter :auth_enabled
+  filter :auth_user
+  filter :auth_password
+  filter :incoming_auth_username
+  filter :incoming_auth_password
+  filter :codec_group, input_html: { class: 'chosen' }, collection: proc { CodecGroup.pluck(:name, :id) }
 
   form do |f|
     f.semantic_errors *f.object.errors.keys

--- a/app/admin/equipment/registrations.rb
+++ b/app/admin/equipment/registrations.rb
@@ -65,6 +65,12 @@ ActiveAdmin.register Equipment::Registration do
   filter :pop, input_html: { class: 'chosen' }
   filter :node, input_html: { class: 'chosen' }
   filter :sip_schema
+  filter :transport_protocol, input_html: { class: 'chosen' }, collection: proc { Equipment::TransportProtocol.pluck(:name, :id) }
+  filter :domain
+  filter :username
+  filter :auth_user
+  filter :auth_password
+  filter :contact
 
   form do |f|
     f.semantic_errors *f.object.errors.keys

--- a/app/admin/routing/area_prefixes.rb
+++ b/app/admin/routing/area_prefixes.rb
@@ -43,4 +43,5 @@ ActiveAdmin.register Routing::AreaPrefix do
   filter :id
   filter :prefix
   filter :area, input_html: { class: 'chosen' }
+  filter :prefix_covers, as: :string
 end

--- a/app/admin/routing/customers_auths.rb
+++ b/app/admin/routing/customers_auths.rb
@@ -235,6 +235,18 @@ ActiveAdmin.register CustomersAuth do
   filter :to_domain_array_contains, label: I18n.t('activerecord.attributes.customers_auth.to_domain')
   filter :x_yeti_auth_array_contains, label: I18n.t('activerecord.attributes.customers_auth.x_yeti_auth')
   filter :lua_script, input_html: { class: 'chosen' }
+  boolean_filter :require_incoming_auth
+  boolean_filter :check_account_balance
+  filter :gateway_incoming_auth_username_eq,
+         label: 'Incoming Auth Username',
+         as: :select,
+         input_html: { class: 'chosen' },
+         collection: proc { Gateway.distinct.pluck(:incoming_auth_username) }
+  filter :gateway_incoming_auth_password_eq,
+         label: 'Incoming Auth Password',
+         as: :select,
+         input_html: { class: 'chosen' },
+         collection: proc { Gateway.distinct.pluck(:incoming_auth_password) }
 
   form do |f|
     f.semantic_errors *f.object.errors.keys

--- a/app/admin/routing/customers_auths.rb
+++ b/app/admin/routing/customers_auths.rb
@@ -237,16 +237,12 @@ ActiveAdmin.register CustomersAuth do
   filter :lua_script, input_html: { class: 'chosen' }
   boolean_filter :require_incoming_auth
   boolean_filter :check_account_balance
-  filter :gateway_incoming_auth_username_eq,
+  filter :gateway_incoming_auth_username,
          label: 'Incoming Auth Username',
-         as: :select,
-         input_html: { class: 'chosen' },
-         collection: proc { Gateway.distinct.pluck(:incoming_auth_username) }
-  filter :gateway_incoming_auth_password_eq,
+         as: :string
+  filter :gateway_incoming_auth_password,
          label: 'Incoming Auth Password',
-         as: :select,
-         input_html: { class: 'chosen' },
-         collection: proc { Gateway.distinct.pluck(:incoming_auth_password) }
+         as: :string
 
   form do |f|
     f.semantic_errors *f.object.errors.keys

--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -34,6 +34,7 @@ ActiveAdmin.register Routing::Destination, as: 'Destination' do
                  skip_columns: [:routing_tag_ids]
 
   scope :low_quality
+  scope :time_valid
 
   filter :id
   filter :uuid_equals, label: 'UUID'
@@ -64,6 +65,15 @@ ActiveAdmin.register Routing::Destination, as: 'Destination' do
          }
 
   filter :external_id_eq, label: 'EXTERNAL_ID'
+  filter :valid_from, as: :date_time_range
+  filter :valid_till, as: :date_time_range
+  filter :rate_policy, input_html: { class: 'chosen' }, collection: proc { Routing::DestinationRatePolicy.pluck(:name, :id) }
+  boolean_filter :reverse_billing
+  filter :initial_interval
+  filter :next_interval
+  filter :asr_limit
+  filter :acd_limit
+  filter :short_calls_limit
 
   acts_as_filter_by_routing_tag_ids
 

--- a/app/admin/routing/numberlist_items.rb
+++ b/app/admin/routing/numberlist_items.rb
@@ -43,6 +43,10 @@ ActiveAdmin.register Routing::NumberlistItem do
   filter :numberlist, input_html: { class: 'chosen' }
   filter :key
   filter :lua_script, input_html: { class: 'chosen' }
+  filter :action, input_html: { class: 'chosen' }, collection: proc { Routing::NumberlistAction.pluck(:name, :id) }
+  filter :tag_action, input_html: { class: 'chosen' }, collection: proc { Routing::TagAction.pluck(:name, :id) }
+  filter :created_at, as: :date_time_range
+  filter :updated_at, as: :date_time_range
 
   controller do
     def update

--- a/app/admin/routing/numberlists.rb
+++ b/app/admin/routing/numberlists.rb
@@ -105,4 +105,5 @@ ActiveAdmin.register Routing::Numberlist, as: 'Numberlist' do
   filter :default_action
   filter :lua_script, input_html: { class: 'chosen' }
   filter :external_id, label: 'External ID'
+  filter :tag_action, input_html: { class: 'chosen' }, collection: proc { Routing::TagAction.pluck(:name, :id) }
 end

--- a/app/admin/routing/rateplans.rb
+++ b/app/admin/routing/rateplans.rb
@@ -36,6 +36,7 @@ ActiveAdmin.register Routing::Rateplan do
   filter :uuid_equals, label: 'UUID'
   filter :name
   filter :external_id
+  filter :profit_control_mode, input_html: { class: 'chosen' }, collection: proc { Routing::RateProfitControlMode.pluck(:name, :id) }
 
   form do |f|
     f.semantic_errors(*f.object.errors.keys)

--- a/app/admin/routing/routing_plan_lnp_rules.rb
+++ b/app/admin/routing/routing_plan_lnp_rules.rb
@@ -34,7 +34,10 @@ ActiveAdmin.register Lnp::RoutingPlanLnpRule do
   end
 
   filter :id
-  filter :name
+  filter :dst_prefix
+  filter :routing_plan, input_html: { class: 'chosen' }, collection: proc { Routing::RoutingPlan.pluck(:name, :id) }
+  filter :database, input_html: { class: 'chosen' }, collection: proc { Lnp::Database.pluck(:name, :id) }
+  filter :created_at, as: :date_time_range
 
   show do |_s|
     attributes_table do

--- a/app/admin/routing/routing_plans.rb
+++ b/app/admin/routing/routing_plans.rb
@@ -30,6 +30,9 @@ ActiveAdmin.register Routing::RoutingPlan do
   filter :sorting
   filter :use_lnp, as: :select, collection: [['Yes', true], ['No', false]]
   filter :customers_auths_account_id_eq, as: :select, label: 'Assigned to account', collection: -> { Account.customers_accounts }
+  filter :rate_delta_max
+  filter :max_rerouting_attempts
+  filter :routing_groups, input_html: { class: 'chosen' }, collection: proc { RoutingGroup.pluck(:name, :id) }
 
   index do
     selectable_column

--- a/app/models/routing/area_prefix.rb
+++ b/app/models/routing/area_prefix.rb
@@ -37,6 +37,7 @@ class Routing::AreaPrefix < Yeti::ActiveRecord
   end
 
   private
+
   def self.ransackable_scopes(_auth_object = nil)
     %i[
       prefix_covers

--- a/app/models/routing/area_prefix.rb
+++ b/app/models/routing/area_prefix.rb
@@ -28,7 +28,18 @@ class Routing::AreaPrefix < Yeti::ActiveRecord
   validates :prefix, format: { without: /\s/ }
   validates :area, presence: true
 
+  scope :prefix_covers, lambda { |prefix|
+    where("prefix_range(prefix) @> prefix_range('#{prefix}')")
+  }
+
   def display_name
     "#{prefix} | #{id}"
+  end
+
+  private
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[
+      prefix_covers
+    ]
   end
 end

--- a/app/models/routing/destination.rb
+++ b/app/models/routing/destination.rb
@@ -71,6 +71,7 @@ class Routing::Destination < Yeti::ActiveRecord
   include RoutingTagIdsScopeable
 
   scope :low_quality, -> { where quality_alarm: true }
+  scope :time_valid, -> { where('valid_till >= :time AND valid_from < :time', time: Time.now) }
 
   scope :where_customer, lambda { |id|
     joins(:rate_group).joins(:rateplans).joins(:customers_auths).where(CustomersAuth.table_name => { customer_id: id })

--- a/spec/features/routing/area_prefixes/filters_spec.rb
+++ b/spec/features/routing/area_prefixes/filters_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe 'Filtering the Area Prefix records', type: :feature do
 
   context 'filter by :prefix_covers' do
     let(:area) { FactoryBot.create(:area) }
-    let!(:area_prefixes) {[
-      FactoryBot.create(:area_prefix, area: area, prefix: '12'),
-      FactoryBot.create(:area_prefix, area: area, prefix: '1234'),
-      FactoryBot.create(:area_prefix, area: area, prefix: '123456')
-    ]}
+    let!(:area_prefixes) {
+      [
+        FactoryBot.create(:area_prefix, area: area, prefix: '12'),
+        FactoryBot.create(:area_prefix, area: area, prefix: '1234'),
+        FactoryBot.create(:area_prefix, area: area, prefix: '123456')
+      ]
+    }
 
     let(:filter_area_prefix_records) do
       within_filters { fill_in 'Prefix covers', with: filter_value }

--- a/spec/features/routing/area_prefixes/filters_spec.rb
+++ b/spec/features/routing/area_prefixes/filters_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Filtering the Area Prefix records', type: :feature do
+  include_context :login_as_admin
+
+  subject do
+    visit routing_area_prefixes_path
+    filter_area_prefix_records
+    within_filters { click_submit('Filter') }
+  end
+
+  let(:filter_value) { nil }
+
+  context 'filter by :prefix_covers' do
+    let(:area) { FactoryBot.create(:area) }
+    let!(:area_prefixes) {[
+      FactoryBot.create(:area_prefix, area: area, prefix: '12'),
+      FactoryBot.create(:area_prefix, area: area, prefix: '1234'),
+      FactoryBot.create(:area_prefix, area: area, prefix: '123456')
+    ]}
+
+    let(:filter_area_prefix_records) do
+      within_filters { fill_in 'Prefix covers', with: filter_value }
+    end
+
+    context 'when filtering by value 1' do
+      let(:filter_value) { '1' }
+
+      it 'should not return any records' do
+        subject
+        expect(page).not_to have_table
+        expect(page).to have_table_row(count: 0)
+      end
+    end
+
+    context 'when filtering by value 12' do
+      let(:filter_value) { '12' }
+
+      it 'should filtered records by covered prefix with 12' do
+        subject
+        expect(page).to have_table
+        expect(page).to have_table_row(count: 1)
+        area_prefixes.take(1).each do |area_prefix|
+          within_table_row(id: area_prefix.id) do
+            expect(page).to have_table_cell(column: 'Id', text: area_prefix.id)
+            expect(page).to have_table_cell(column: 'Prefix', text: area_prefix.prefix)
+          end
+        end
+      end
+    end
+
+    context 'when filtering by value 1234' do
+      let(:filter_value) { '1234' }
+
+      it 'should filtered records by covered prefix with 1234' do
+        subject
+        expect(page).to have_table
+        expect(page).to have_table_row(count: 2)
+        area_prefixes.take(2).each do |area_prefix|
+          within_table_row(id: area_prefix.id) do
+            expect(page).to have_table_cell(column: 'Id', text: area_prefix.id)
+            expect(page).to have_table_cell(column: 'Prefix', text: area_prefix.prefix)
+          end
+        end
+      end
+    end
+
+    context 'when filtering by value 123456' do
+      let(:filter_value) { '123456' }
+
+      it 'should filtered records by covered prefix with 123456' do
+        subject
+        expect(page).to have_table
+        expect(page).to have_table_row(count: 3)
+        area_prefixes.each do |area_prefix|
+          within_table_row(id: area_prefix.id) do
+            expect(page).to have_table_cell(column: 'Id', text: area_prefix.id)
+            expect(page).to have_table_cell(column: 'Prefix', text: area_prefix.prefix)
+          end
+        end
+      end
+    end
+
+    context 'when filtering by value 123456789' do
+      let(:filter_value) { '123456789' }
+
+      it 'should filtered records by covered prefix with 123456789' do
+        subject
+        expect(page).to have_table
+        expect(page).to have_table_row(count: 3)
+        area_prefixes.each do |area_prefix|
+          within_table_row(id: area_prefix.id) do
+            expect(page).to have_table_cell(column: 'Id', text: area_prefix.id)
+            expect(page).to have_table_cell(column: 'Prefix', text: area_prefix.prefix)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/yeti-switch/yeti-web/issues/528

## List of not implemented filters:
#### Gateways
- `username` - attribute is missing in the `Gateway` model
- `password` - attribute is missing in the `Gateway` model
#### Customer Auths
- `incoming_auth_username` - attribute is missing in the `CustomersAuth` model, but the same attribute exists in the parent `Gateway`, do we need to filter customer auths by the `incoming_auth_username` from `Gateway` association, or we just no need this filter anymore?
- `incoming_auth_password` - attribute is missing in the `CustomersAuth` model, but the same attribute exists in the parent `Gateway`, do we need to filter customer auths by the `incoming_auth_password` from `Gateway` association, or we just no need this filter anymore?
#### Destinations
- `Quick filter "Time valid"` - not clear for me how that filter should work? It will be great to get more description or any examples.
#### Area Prefixes
- `prefix_covers` - attribute is missing in the `AreaPrefix` model, but it has a `prefix` attribute and this filter already exists.
#### Cdr History
- `lega_remote_ip` - attribute is missing in the `Cdr` model
- `lega_local_ip` - attribute is missing in the `Cdr` model
- `legb_local_ip` - attribute is missing in the `Cdr` model
- `legb_remote_ip` - attribute is missing in the `Cdr` model
- `lega_originator_ip` - attribute is missing in the `Cdr` model
