### PR TITLE
Allow json token request without csrf

### DIFF
--- a/app/controllers/api/rest/admin/auth_controller.rb
+++ b/app/controllers/api/rest/admin/auth_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::Rest::Admin::AuthController < Knock::AuthTokenController
   private
+  protect_from_forgery with: :null_session
 
   def entity_name
     'AdminUser'

--- a/app/controllers/api/rest/admin/auth_controller.rb
+++ b/app/controllers/api/rest/admin/auth_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::Rest::Admin::AuthController < Knock::AuthTokenController
   private
+
   protect_from_forgery with: :null_session
 
   def entity_name

--- a/app/controllers/api/rest/customer/v1/auth_controller.rb
+++ b/app/controllers/api/rest/customer/v1/auth_controller.rb
@@ -3,6 +3,8 @@
 class Api::Rest::Customer::V1::AuthController < Knock::AuthTokenController
   private
 
+  protect_from_forgery with: :null_session
+
   def entity_name
     'System::ApiAccess'
   end

--- a/app/controllers/api/rest_controller.rb
+++ b/app/controllers/api/rest_controller.rb
@@ -3,7 +3,7 @@
 require 'base64'
 
 class Api::RestController < ApiController
-  skip_before_action :verify_authenticity_token, raise: false
+  protect_from_forgery with: :null_session
 
   respond_to :json
   rescue_from ActiveRecord::RecordNotFound, with: :render_404

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory
   # config.active_storage.service = :test

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
+  # Enable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory

--- a/spec/acceptance/rest/admin/api/auth_spec.rb
+++ b/spec/acceptance/rest/admin/api/auth_spec.rb
@@ -7,8 +7,8 @@ RSpec.resource 'Authentication' do
   header 'Content-Type', 'application/json'
 
   post '/api/rest/admin/auth' do
-    parameter :username, 'Login', scope: :auth, requred: true
-    parameter :password, 'Password', scope: :auth, requred: true
+    parameter :username, 'Login', scope: :auth, required: true
+    parameter :password, 'Password', scope: :auth, required: true
 
     let(:username) { 'admin' }
     let(:password) { 'password' }

--- a/spec/acceptance/rest/customer/api/v1/auth_spec.rb
+++ b/spec/acceptance/rest/customer/api/v1/auth_spec.rb
@@ -7,8 +7,8 @@ RSpec.resource 'Authentication', document: :customer_v1 do
   header 'Content-Type', 'application/json'
 
   post '/api/rest/customer/v1/auth' do
-    parameter :login, 'Login', scope: :auth, requred: true
-    parameter :password, 'Password', scope: :auth, requred: true
+    parameter :login, 'Login', scope: :auth, required: true
+    parameter :password, 'Password', scope: :auth, required: true
 
     let(:login) { 'login' }
     let(:password) { 'password' }

--- a/spec/features/cdr/cdr_exports/delete_file_spec.rb
+++ b/spec/features/cdr/cdr_exports/delete_file_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'CDR exports', type: :feature do
+RSpec.describe 'CDR exports', type: :feature, js: true do
   include_context :login_as_admin
 
   describe 'delete_file' do


### PR DESCRIPTION
With recent csrf changes applied I could not request a token anymore for admin api access.
This worked in my case, any other suggestions are also appreciated. Copied from https://stackoverflow.com/a/34252150