### PR TITLE
fix API forgery origin check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,7 @@ gem 'devise_ldap_authenticatable', github: 'cschiewek/devise_ldap_authenticatabl
 gem 'net-ldap', '~> 0.16.0'
 
 # Seamless JWT authentication for Rails API
-# need this fix https://github.com/nsarno/knock/pull/126
-gem 'knock', github: 'nsarno/knock', ref: '66b60437a5acc28e4863f011ab59324dc1b5d0ae'
+gem 'knock', github: 'nsarno/knock'
 
 # ActiveAdmin
 gem 'active_admin_date_range_preset', github: 'workgena/active_admin_date_range_preset'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,13 +48,12 @@ GIT
 
 GIT
   remote: https://github.com/nsarno/knock.git
-  revision: 66b60437a5acc28e4863f011ab59324dc1b5d0ae
-  ref: 66b60437a5acc28e4863f011ab59324dc1b5d0ae
+  revision: 37e403a7c6d44f585b56a086245e41566a8d6fe1
   specs:
-    knock (2.1.1)
+    knock (2.2.0)
       bcrypt (~> 3.1)
-      jwt (~> 1.5)
-      rails (>= 4.2)
+      jwt (~> 2.2.1)
+      rails (>= 5)
 
 GIT
   remote: https://github.com/workgena/active_admin_date_range_preset.git
@@ -340,7 +339,7 @@ GEM
       activerecord (>= 4.1)
       concurrent-ruby
       railties (>= 4.1)
-    jwt (1.5.6)
+    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)

--- a/app/controllers/api/rest/admin/auth_controller.rb
+++ b/app/controllers/api/rest/admin/auth_controller.rb
@@ -3,8 +3,6 @@
 class Api::Rest::Admin::AuthController < Knock::AuthTokenController
   private
 
-  protect_from_forgery with: :null_session
-
   def entity_name
     'AdminUser'
   end

--- a/app/controllers/api/rest/customer/v1/auth_controller.rb
+++ b/app/controllers/api/rest/customer/v1/auth_controller.rb
@@ -3,8 +3,6 @@
 class Api::Rest::Customer::V1::AuthController < Knock::AuthTokenController
   private
 
-  protect_from_forgery with: :null_session
-
   def entity_name
     'System::ApiAccess'
   end

--- a/app/controllers/api/rest/customer/v1/base_controller.rb
+++ b/app/controllers/api/rest/customer/v1/base_controller.rb
@@ -18,16 +18,16 @@ class Api::Rest::Customer::V1::BaseController < Api::RestController
   end
 
   def current_customer
-    current_system_apiaccess
+    current_system_api_access
   end
 
   def capture_user
-    return if current_system_apiaccess.nil?
+    return if current_system_api_access.nil?
 
     {
-      id: current_system_apiaccess.id,
-      customer_id: current_system_apiaccess.customer_id,
-      login: current_system_apiaccess.login,
+      id: current_system_api_access.id,
+      customer_id: current_system_api_access.customer_id,
+      login: current_system_api_access.login,
       class: 'System::ApiAccess'
     }
   end

--- a/app/controllers/api/rest/system/ip_access_controller.rb
+++ b/app/controllers/api/rest/system/ip_access_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::Rest::System::IpAccessController < Api::RestController
   def index
-    respond_with addresses
+    render json: addresses
   end
 
   private

--- a/app/controllers/api/rest/system/jobs_controller.rb
+++ b/app/controllers/api/rest/system/jobs_controller.rb
@@ -2,15 +2,12 @@
 
 class Api::Rest::System::JobsController < Api::RestController
   def run
-    #    BaseJob.transaction do
     @job = BaseJob.launch!(params[:id])
-    #    end
-    #    @job.run!
-    respond_with(@job)
+    render json: @job, status: :no_content
   end
 
   def index
-    respond_with BaseJob.all
+    render json: BaseJob.all
   end
 
   def capture_tags

--- a/app/controllers/api/rest_controller.rb
+++ b/app/controllers/api/rest_controller.rb
@@ -3,8 +3,6 @@
 require 'base64'
 
 class Api::RestController < ApiController
-  protect_from_forgery with: :null_session
-
   respond_to :json
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
   rescue_from AbstractController::ActionNotFound, with: :render_404

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApiController < ActionController::Base
+class ApiController < ActionController::API
   around_action :db_logging
 
   def db_logging


### PR DESCRIPTION
API specific controllers should skip unnecessary layers (forgery protection, HTML rendering, translations, etc). so let's inherit them from ActionController::API instead of full featured ActionController::Base

also we need to upgrade knock gem as latest version already has solution on top of ActionController::API