### PR TITLE
added styles for correct display colors of status tag

### DIFF
--- a/app/assets/stylesheets/active_admin/components/status_tags.scss
+++ b/app/assets/stylesheets/active_admin/components/status_tags.scss
@@ -1,0 +1,11 @@
+.status_tag {
+  &.ok, &.published, &.complete, &.completed, &.green, &.yes { background: #8daa92; }
+  &.warn, &.warning, &.orange { background: #e29b20; }
+  &.error, &.errored, &.red { background: #d45f53; }
+  &.empty, &.unknown, &.none, &.no {
+    background: unset;
+    color: #bbbbbb;
+    font-weight: bold;
+    font-size: 0.8em;
+  }
+}


### PR DESCRIPTION


<img width="1440" alt="Screenshot 2021-02-17 at 14 14 12" src="https://user-images.githubusercontent.com/10907664/108202903-76c32e00-712a-11eb-9968-1da0cd89d08f.png">
