### PR TITLE
added styles for correct display colors of status tag tag

### DIFF
--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -21,6 +21,7 @@
 @import "active_admin_date_range_preset";
 @import "font-awesome";
 @import "active_admin/components/active_admin_scoped_collection_actions";
+@import "active_admin/components/status_tags";
 @import "vendor/highlightjs/default";
 
 fieldset.inputs {


### PR DESCRIPTION
<img width="1330" alt="Screenshot 2021-02-18 at 11 40 11" src="https://user-images.githubusercontent.com/10907664/108337700-11307980-71de-11eb-9728-90a25a04c1d7.png">


fixes #885