### PR TITLE
added styles for correct display colors of status tag tag

### DIFF
--- a/app/assets/stylesheets/active_admin/components/status_tags.scss
+++ b/app/assets/stylesheets/active_admin/components/status_tags.scss
@@ -2,7 +2,7 @@
   &.ok, &.published, &.complete, &.completed, &.green, &.yes { background: #8daa92; }
   &.warn, &.warning, &.orange { background: #e29b20; }
   &.error, &.errored, &.red { background: #d45f53; }
-  &.empty, &.unknown, &.none, &.no {
+  &.empty, &.unknown, &.none {
     background: unset;
     color: #bbbbbb;
     font-weight: bold;


### PR DESCRIPTION
<img width="707" alt="Screenshot 2021-02-18 at 18 44 23" src="https://user-images.githubusercontent.com/10907664/108390419-532ae100-7219-11eb-82dc-0056f943938d.png">


fixes #885
