### PR TITLE
add optional true to all belongs_to associations for stats namespace

### DIFF
--- a/app/models/stats/active_call.rb
+++ b/app/models/stats/active_call.rb
@@ -12,7 +12,7 @@
 
 class Stats::ActiveCall < Stats::Base
   self.table_name = 'stats.active_calls'
-  belongs_to :node
+  belongs_to :node, optional: true
 
   include ::Chart
   self.chart_entity_column = :node_id

--- a/app/models/stats/active_call_account.rb
+++ b/app/models/stats/active_call_account.rb
@@ -17,7 +17,7 @@
 
 class Stats::ActiveCallAccount < Stats::Base
   self.table_name = 'stats.active_call_accounts'
-  belongs_to :account
+  belongs_to :account, optional: true
 
   include ::Chart
   self.chart_entity_column = :account_id

--- a/app/models/stats/active_call_orig_gateway.rb
+++ b/app/models/stats/active_call_orig_gateway.rb
@@ -12,7 +12,7 @@
 
 class Stats::ActiveCallOrigGateway < Stats::Base
   self.table_name = 'stats.active_call_orig_gateways'
-  belongs_to :gateway
+  belongs_to :gateway, optional: true
 
   include ::Chart
   self.chart_entity_column = :gateway_id

--- a/app/models/stats/active_call_term_gateway.rb
+++ b/app/models/stats/active_call_term_gateway.rb
@@ -12,7 +12,7 @@
 
 class Stats::ActiveCallTermGateway < Stats::Base
   self.table_name = 'stats.active_call_term_gateways'
-  belongs_to :gateway
+  belongs_to :gateway, optional: true
 
   include ::Chart
   self.chart_entity_column = :gateway_id


### PR DESCRIPTION
while writing calls monitoring stats yeti should not validate belongs to associations

1) objects are in different databases there are no foreign key
2) performace for calls monitoring - no validation needed
3) association can be removed while calls monitoring session - data should be stored successfully

currently it fails belongs_to must exists error