### PR TITLE
fix vulnerability rexml CVE-2021-28965

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)


### PR DESCRIPTION
```
Name: rexml
Version: 3.2.4
Advisory: CVE-2021-28965
Criticality: Unknown
URL: https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/
Title: XML round-trip vulnerability in REXML
Solution: upgrade to >= 3.2.5
```