### PR TITLE
scheduler add jobs monitoring in admin UI

### DIFF
--- a/app/admin/system/cron_jobs.rb
+++ b/app/admin/system/cron_jobs.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register CronJobInfo, as: 'Cron Job' do
+  menu parent: 'System', priority: 100
+
+  config.batch_actions = false
+  actions :index, :show
+
+  index do
+    column :name
+    column :last_success
+    column :last_run_at
+    column :last_duration
+    column :cron_line
+    actions
+  end
+
+  show do
+    columns do
+      column do
+        attributes_table do
+          row :name
+          row :last_success
+          row :last_run_at
+          row :last_duration
+          row :cron_line
+        end
+      end
+
+      column do
+        panel 'Last Exception' do
+          pre_wrap(resource.last_exception)
+        end
+      end
+    end
+  end
+end

--- a/app/models/cron_job_info.rb
+++ b/app/models/cron_job_info.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sys.jobs
+#
+#  id             :bigint(8)        not null, primary key
+#  last_duration  :decimal(, )
+#  last_exception :string
+#  last_run_at    :datetime
+#  name           :string           not null
+#
+class CronJobInfo < ApplicationRecord
+  self.table_name = 'sys.jobs'
+
+  delegate :cron_line, to: :handler_class
+
+  def last_success
+    return if last_run_at.nil?
+
+    last_exception.nil?
+  end
+
+  def handler_class
+    "Jobs::#{name}".constantize
+  end
+end

--- a/app/policies/cron_job_info_policy.rb
+++ b/app/policies/cron_job_info_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CronJobInfoPolicy < ::RolePolicy
+  section 'System/CronJob'
+
+  class Scope < ::RolePolicy::Scope
+  end
+end

--- a/config/policy_roles.yml.distr
+++ b/config/policy_roles.yml.distr
@@ -335,6 +335,11 @@ user:
     change: true
     remove: true
     perform: true
+  System/CronJob:
+    read: true
+    change: true
+    remove: true
+    perform: true
   System/NetworkPrefix:
     read: true
     change: true

--- a/db/migrate/20210630120418_create_cron_job_infos.rb
+++ b/db/migrate/20210630120418_create_cron_job_infos.rb
@@ -1,0 +1,29 @@
+class CreateCronJobInfos < ActiveRecord::Migration[5.2]
+  def change
+    create_table 'sys.jobs' do |t|
+      t.string :name, null: false, unique: true
+      t.decimal :last_duration
+      t.string :last_exception
+      t.timestamp :last_run_at
+    end
+
+    up_only do
+      execute <<-SQL
+        INSERT INTO sys.jobs (name) VALUES
+        ('CdrPartitioning'),
+        ('EventProcessor'),
+        ('CdrBatchCleaner'),
+        ('PartitionRemoving'),
+        ('CallsMonitoring'),
+        ('StatsClean'),
+        ('StatsAggregation'),
+        ('Invoice'),
+        ('ReportScheduler'),
+        ('TerminationQualityCheck'),
+        ('DialpeerRatesApply'),
+        ('AccountBalanceNotify'),
+        ('SyncDatabaseTables');
+      SQL
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25485,6 +25485,38 @@ ALTER SEQUENCE sys.guiconfig_id_seq OWNED BY sys.guiconfig.id;
 
 
 --
+-- Name: jobs; Type: TABLE; Schema: sys; Owner: -
+--
+
+CREATE TABLE sys.jobs (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    last_duration numeric,
+    last_exception character varying,
+    last_run_at timestamp without time zone
+);
+
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE; Schema: sys; Owner: -
+--
+
+CREATE SEQUENCE sys.jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: sys; Owner: -
+--
+
+ALTER SEQUENCE sys.jobs_id_seq OWNED BY sys.jobs.id;
+
+
+--
 -- Name: lnp_resolvers; Type: TABLE; Schema: sys; Owner: -
 --
 
@@ -26520,6 +26552,13 @@ ALTER TABLE ONLY sys.delayed_jobs ALTER COLUMN id SET DEFAULT nextval('sys.delay
 --
 
 ALTER TABLE ONLY sys.guiconfig ALTER COLUMN id SET DEFAULT nextval('sys.guiconfig_id_seq'::regclass);
+
+
+--
+-- Name: jobs id; Type: DEFAULT; Schema: sys; Owner: -
+--
+
+ALTER TABLE ONLY sys.jobs ALTER COLUMN id SET DEFAULT nextval('sys.jobs_id_seq'::regclass);
 
 
 --
@@ -28282,6 +28321,14 @@ ALTER TABLE ONLY sys.guiconfig
 
 
 --
+-- Name: jobs jobs_pkey; Type: CONSTRAINT; Schema: sys; Owner: -
+--
+
+ALTER TABLE ONLY sys.jobs
+    ADD CONSTRAINT jobs_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: lnp_resolvers lnp_resolvers_name_key; Type: CONSTRAINT; Schema: sys; Owner: -
 --
 
@@ -29820,6 +29867,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20210328145540'),
 ('20210415123322'),
 ('20210605094810'),
-('20210606143950');
+('20210606143950'),
+('20210630120418');
 
 

--- a/spec/factories/cron_job_infos.rb
+++ b/spec/factories/cron_job_infos.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sys.jobs
+#
+#  id             :bigint(8)        not null, primary key
+#  last_duration  :decimal(, )
+#  last_exception :string
+#  last_run_at    :datetime
+#  name           :string           not null
+#
+FactoryBot.define do
+  factory :cron_job_info, class: CronJobInfo do
+    name { nil } # required
+
+    trait :active do
+      last_run_at { 1.minute.ago.utc }
+      last_duration { rand(100) + rand.round(6) }
+    end
+
+    trait :failed do
+      active
+      last_exception { "StandardError test error\n#{caller.join("\n")}" }
+    end
+  end
+end

--- a/spec/features/system/cron_jobs/index_spec.rb
+++ b/spec/features/system/cron_jobs/index_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Cron Jobs index', js: true do
+  subject do
+    visit cron_jobs_path
+  end
+
+  include_context :login_as_admin
+
+  let!(:jobs) do
+    CronJobInfo.all.to_a
+  end
+  let(:success_job) do
+    jobs.first
+  end
+  let(:failed_job) do
+    jobs.second
+  end
+  let(:empty_jobs) do
+    jobs - [success_job, failed_job]
+  end
+  before do
+    success_job.update!(last_run_at: Time.zone.now, last_duration: 123.456)
+    failed_job.update!(last_run_at: 1.minute.ago, last_duration: 0.01, last_exception: 'some error')
+  end
+
+  it 'renders index page correctly' do
+    subject
+    expect(page).to have_table_row count: jobs.count
+    empty_jobs.each do |job_info|
+      within_table_row(id: job_info.id) do
+        expect(page).to have_table_cell column: 'Name', exact_text: job_info.name
+        expect(page).to have_table_cell column: 'Last Success', exact_text: ''
+        expect(page).to have_table_cell column: 'Last Run At', exact_text: ''
+        expect(page).to have_table_cell column: 'Last Duration', exact_text: ''
+        expect(page).to have_table_cell column: 'Cron Line', exact_text: job_info.handler_class.cron_line
+      end
+    end
+    within_table_row(id: success_job.id) do
+      expect(page).to have_table_cell column: 'Name', exact_text: success_job.name
+      expect(page).to have_table_cell column: 'Last Success', exact_text: 'YES'
+      expect(page).to have_table_cell column: 'Last Run At', exact_text: success_job.last_run_at.strftime('%F %T')
+      expect(page).to have_table_cell column: 'Last Duration', exact_text: success_job.last_duration.to_s
+      expect(page).to have_table_cell column: 'Cron Line', exact_text: success_job.handler_class.cron_line
+    end
+    within_table_row(id: failed_job.id) do
+      expect(page).to have_table_cell column: 'Name', exact_text: failed_job.name
+      expect(page).to have_table_cell column: 'Last Success', exact_text: 'NO'
+      expect(page).to have_table_cell column: 'Last Run At', exact_text: failed_job.last_run_at.strftime('%F %T')
+      expect(page).to have_table_cell column: 'Last Duration', exact_text: failed_job.last_duration.to_s
+      expect(page).to have_table_cell column: 'Cron Line', exact_text: failed_job.handler_class.cron_line
+    end
+  end
+end

--- a/spec/features/system/cron_jobs/show_spec.rb
+++ b/spec/features/system/cron_jobs/show_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Cron Job show', js: true do
+  subject do
+    visit cron_job_path(record.id)
+  end
+
+  include_context :login_as_admin
+
+  let!(:record) do
+    CronJobInfo.take!
+  end
+
+  context 'with empty cron job info' do
+    it 'renders show page correctly' do
+      subject
+      expect(page).to have_attribute_row('NAME', exact_text: record.name)
+      expect(page).to have_attribute_row('LAST SUCCESS', exact_text: 'EMPTY')
+      expect(page).to have_attribute_row('LAST RUN AT', exact_text: 'EMPTY') # last_run_at.strftime('%F %T')
+      expect(page).to have_attribute_row('LAST DURATION', exact_text: 'EMPTY')
+      expect(page).to have_attribute_row('CRON LINE', exact_text: record.handler_class.cron_line)
+      within_panel 'Last Exception' do
+        expect(page).to have_text('', exact: true)
+      end
+    end
+  end
+
+  context 'with success cron job info' do
+    before do
+      record.update!(last_run_at: Time.zone.now, last_duration: 123.456)
+    end
+
+    it 'renders show page correctly' do
+      subject
+      expect(page).to have_attribute_row('NAME', exact_text: record.name)
+      expect(page).to have_attribute_row('LAST SUCCESS', exact_text: 'YES')
+      expect(page).to have_attribute_row('LAST RUN AT', exact_text: record.last_run_at.strftime('%F %T'))
+      expect(page).to have_attribute_row('LAST DURATION', exact_text: record.last_duration.to_s)
+      expect(page).to have_attribute_row('CRON LINE', exact_text: record.handler_class.cron_line)
+      within_panel 'Last Exception' do
+        expect(page).to have_text('', exact: true)
+      end
+    end
+  end
+
+  context 'with failed cron job info' do
+    before do
+      record.update!(last_run_at: 1.minute.ago, last_duration: 0.01, last_exception: 'some error')
+    end
+
+    it 'renders show page correctly' do
+      subject
+      expect(page).to have_attribute_row('NAME', exact_text: record.name)
+      expect(page).to have_attribute_row('LAST SUCCESS', exact_text: 'NO')
+      expect(page).to have_attribute_row('LAST RUN AT', exact_text: record.last_run_at.strftime('%F %T'))
+      expect(page).to have_attribute_row('LAST DURATION', exact_text: record.last_duration.to_s)
+      expect(page).to have_attribute_row('CRON LINE', exact_text: record.handler_class.cron_line)
+      within_panel 'Last Exception' do
+        expect(page).to have_text('some error', exact: true)
+      end
+    end
+  end
+end

--- a/spec/fixtures/sys.jobs.yml
+++ b/spec/fixtures/sys.jobs.yml
@@ -1,0 +1,48 @@
+# == Schema Information
+#
+# Table name: sys.jobs
+#
+#  id             :bigint(8)        not null, primary key
+#  last_duration  :decimal(, )
+#  last_exception :string
+#  last_run_at    :datetime
+#  name           :string           not null
+#
+CdrPartitioning:
+  name: 'CdrPartitioning'
+
+EventProcessor:
+  name: 'EventProcessor'
+
+CdrBatchCleaner:
+  name: 'CdrBatchCleaner'
+
+PartitionRemoving:
+  name: 'PartitionRemoving'
+
+CallsMonitoring:
+  name: 'CallsMonitoring'
+
+StatsClean:
+  name: 'StatsClean'
+
+StatsAggregation:
+  name: 'StatsAggregation'
+
+Invoice:
+  name: 'Invoice'
+
+ReportScheduler:
+  name: 'ReportScheduler'
+
+TerminationQualityCheck:
+  name: 'TerminationQualityCheck'
+
+DialpeerRatesApply:
+  name: 'DialpeerRatesApply'
+
+AccountBalanceNotify:
+  name: 'AccountBalanceNotify'
+
+SyncDatabaseTables:
+  name: 'SyncDatabaseTables'

--- a/spec/lib/yeti_scheduler_spec.rb
+++ b/spec/lib/yeti_scheduler_spec.rb
@@ -90,25 +90,30 @@ RSpec.describe YetiScheduler do
 
   describe '#run_handler' do
     subject do
-      described_instance.run_handler(handler_class_stub, job_double, time_double)
+      described_instance.run_handler(handler_class, job_double, time_double)
     end
 
     let!(:described_instance) { described_class.new(wait: true) }
-    let!(:handler_class_stub) { double(scheduler_options: scheduler_options) }
-    let(:scheduler_options) { { name: handler_name, overlap: false } }
-    let(:handler_name) { 'TestName' }
+    let(:scheduler_options) { handler_class.scheduler_options }
     let!(:job_double) { instance_double(Rufus::Scheduler::CronJob, name: handler_name) }
     let!(:time_double) { instance_double(EtOrbi::EoTime) }
 
     before do
       expect(Yeti::ActiveRecord.connection_pool).to receive(:connection).once.ordered
       expect(Cdr::Base.connection_pool).to receive(:connection).once.ordered
+
+      # We stubbing active record model because we required to stub connection_pool connect/release.
+      # Without such stubs tests wil break.
+      job_info_class = double
+      stub_const('CronJobInfo', job_info_class)
+      expect(job_info_class).to receive(:find_by!).with(name: handler_name).once.and_return(job_info_stub)
     end
+    let(:job_info_stub) { double }
     let(:matcher_options_before) do
       satisfy do |options|
         expect(options).to be_a_kind_of(Scheduler::Base::RunOptions)
         expect(options.name).to eq(handler_name)
-        expect(options.handler_class).to eq(handler_class_stub)
+        expect(options.handler_class).to eq(handler_class)
         expect(options.job).to eq(job_double)
         expect(options.time).to eq(time_double)
         expect(options.started_at).to be_within(1).of(Time.zone.now)
@@ -119,127 +124,146 @@ RSpec.describe YetiScheduler do
       end
     end
 
-    context 'when handler executes successfully' do
-      let(:matcher_options_after) do
-        satisfy do |options|
-          expect(options).to be_a_kind_of(Scheduler::Base::RunOptions)
-          expect(options.name).to eq(handler_name)
-          expect(options.handler_class).to eq(handler_class_stub)
-          expect(options.job).to eq(job_double)
-          expect(options.time).to eq(time_double)
-          expect(options.started_at).to be_within(1).of(Time.zone.now)
-          expect(options.ended_at).to be_within(1).of(Time.zone.now)
-          expect(options.duration).to be > 0
-          expect(options.success).to eq(true)
-          expect(options.exception).to be_nil
-        end
-      end
-      let(:test_middleware) do
-        Class.new(Scheduler::Middleware::Base) do
-          def call(options)
-            app.call(options)
-            self.class.check!(options)
-          end
-        end
-      end
-
-      before do
-        YetiScheduler.use(test_middleware)
-        expect(handler_class_stub).to receive(:call).with(matcher_options_before).once.ordered
-        expect(test_middleware).to receive(:check!).with(matcher_options_after).once.ordered
-        expect(Yeti::ActiveRecord.connection_pool).to receive(:release_connection).once.ordered
-        expect(Cdr::Base.connection_pool).to receive(:release_connection).once.ordered
-      end
-
-      after do
-        YetiScheduler._middlewares.pop
-      end
-
-      context 'with disabled prometheus' do
-        before do
-          allow(PrometheusConfig).to receive(:enabled?).and_return(false)
-          expect(YetiCronJobProcessor).to_not receive(:collect)
-        end
-
-        it 'runs successfully' do
-          expect(CaptureError).to_not receive(:capture)
-          subject
-        end
-      end
-
-      context 'with enabled prometheus' do
-        before do
-          allow(PrometheusConfig).to receive(:enabled?).and_return(true)
-          expect(YetiCronJobProcessor).to receive(:collect).with(
-            name: handler_name,
-            success: true,
-            duration: be > 0
-          ).once
-        end
-
-        it 'runs successfully' do
-          expect(CaptureError).to_not receive(:capture)
-          subject
-        end
+    shared_examples :runs_successfully do
+      it 'runs successfully' do
+        expect(CaptureError).to_not receive(:capture)
+        subject
       end
     end
 
-    context 'when handler executes with exception' do
-      let(:raised_exception) { StandardError.new('test') }
-      let(:capture_payload) do
-        {
-          tags: { component: described_class.name, job_name: handler_name },
-          extra: {
-            options: {
-              name: handler_name,
-              handler_class: handler_class_stub,
-              job: job_double,
-              time: time_double,
-              started_at: be_within(1).of(Time.zone.now),
-              ended_at: be_within(1).of(Time.zone.now),
-              duration: be > 0,
-              success: false,
-              exception: raised_exception
-            },
-            scheduler_options: scheduler_options
-          }
-        }
+    shared_examples :runs_with_captured_exception do
+      it 'runs with captured exception' do
+        expect(CaptureError).to receive(:capture).with(
+          raised_exception, capture_payload
+        ).once.ordered
+        subject
       end
-      before do
-        expect(handler_class_stub).to receive(:call).with(matcher_options_before).once.ordered.and_raise(raised_exception)
-        expect(Yeti::ActiveRecord.connection_pool).to receive(:release_connection).once.ordered
-        expect(Cdr::Base.connection_pool).to receive(:release_connection).once.ordered
-      end
+    end
 
-      context 'with disabled prometheus' do
-        before do
-          allow(PrometheusConfig).to receive(:enabled?).and_return(false)
-          expect(YetiCronJobProcessor).to_not receive(:collect)
+    YetiScheduler._cron_handlers.each do |handler|
+      context "with handler_class #{handler}" do
+        let!(:handler_class) { handler }
+        let(:handler_name) { scheduler_options[:name] }
+
+        context 'when handler executes successfully' do
+          let(:matcher_options_after) do
+            satisfy do |options|
+              expect(options).to be_a_kind_of(Scheduler::Base::RunOptions)
+              expect(options.name).to eq(handler_name)
+              expect(options.handler_class).to eq(handler_class)
+              expect(options.job).to eq(job_double)
+              expect(options.time).to eq(time_double)
+              expect(options.started_at).to be_within(1).of(Time.zone.now)
+              expect(options.ended_at).to be_within(1).of(Time.zone.now)
+              expect(options.duration).to be > 0
+              expect(options.success).to eq(true)
+              expect(options.exception).to be_nil
+            end
+          end
+          let(:test_middleware) do
+            Class.new(Scheduler::Middleware::Base) do
+              def call(options)
+                app.call(options)
+                self.class.check!(options)
+              end
+            end
+          end
+
+          before do
+            YetiScheduler.use(test_middleware)
+            expect(handler_class).to receive(:call).with(matcher_options_before).once.ordered
+            expect(test_middleware).to receive(:check!).with(matcher_options_after).once.ordered
+            expect(Yeti::ActiveRecord.connection_pool).to receive(:release_connection).once.ordered
+            expect(Cdr::Base.connection_pool).to receive(:release_connection).once.ordered
+
+            expect(job_info_stub).to receive(:update!).with(
+              last_run_at: be_within(1).of(Time.zone.now),
+              last_duration: be > 0,
+              last_exception: nil
+            ).once
+          end
+
+          after do
+            YetiScheduler._middlewares.pop
+          end
+
+          context 'with disabled prometheus' do
+            before do
+              allow(PrometheusConfig).to receive(:enabled?).and_return(false)
+              expect(YetiCronJobProcessor).to_not receive(:collect)
+            end
+
+            include_examples :runs_successfully
+          end
+
+          context 'with enabled prometheus' do
+            before do
+              allow(PrometheusConfig).to receive(:enabled?).and_return(true)
+              expect(YetiCronJobProcessor).to receive(:collect).with(
+                name: handler_name,
+                success: true,
+                duration: be > 0
+              ).once
+            end
+
+            include_examples :runs_successfully
+          end
         end
 
-        it 'runs with captured exception' do
-          expect(CaptureError).to receive(:capture).with(
-            raised_exception, capture_payload
-          ).once.ordered
-          subject
-        end
-      end
+        context 'when handler executes with exception' do
+          let(:raised_exception) { StandardError.new('test') }
+          let(:capture_payload) do
+            {
+              tags: { component: described_class.name, job_name: handler_name },
+              extra: {
+                options: {
+                  name: handler_name,
+                  handler_class: handler_class,
+                  job: job_double,
+                  time: time_double,
+                  started_at: be_within(1).of(Time.zone.now),
+                  ended_at: be_within(1).of(Time.zone.now),
+                  duration: be > 0,
+                  success: false,
+                  exception: raised_exception
+                },
+                scheduler_options: scheduler_options
+              }
+            }
+          end
+          before do
+            expect(handler_class).to receive(:call).with(matcher_options_before).once.ordered.and_raise(raised_exception)
+            expect(Yeti::ActiveRecord.connection_pool).to receive(:release_connection).once.ordered
+            expect(Cdr::Base.connection_pool).to receive(:release_connection).once.ordered
 
-      context 'with enabled prometheus' do
-        before do
-          allow(PrometheusConfig).to receive(:enabled?).and_return(true)
-          expect(YetiCronJobProcessor).to receive(:collect).with(
-            name: handler_name,
-            success: false,
-            duration: be > 0
-          ).once
-        end
+            expect(job_info_stub).to receive(:update!).with(
+              last_run_at: be_within(1).of(Time.zone.now),
+              last_duration: be > 0,
+              last_exception: be_present
+            ).once
+          end
 
-        it 'runs with captured exception' do
-          expect(CaptureError).to receive(:capture).with(
-            raised_exception, capture_payload
-          ).once.ordered
-          subject
+          context 'with disabled prometheus' do
+            before do
+              allow(PrometheusConfig).to receive(:enabled?).and_return(false)
+              expect(YetiCronJobProcessor).to_not receive(:collect)
+            end
+
+            include_examples :runs_with_captured_exception
+          end
+
+          context 'with enabled prometheus' do
+            before do
+              allow(PrometheusConfig).to receive(:enabled?).and_return(true)
+              expect(YetiCronJobProcessor).to receive(:collect).with(
+                name: handler_name,
+                success: false,
+                duration: be > 0
+              ).once
+            end
+
+            include_examples :runs_with_captured_exception
+          end
         end
       end
     end

--- a/spec/models/cron_job_info_spec.rb
+++ b/spec/models/cron_job_info_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sys.jobs
+#
+#  id             :bigint(8)        not null, primary key
+#  last_duration  :decimal(, )
+#  last_exception :string
+#  last_run_at    :datetime
+#  name           :string           not null
+#
+RSpec.describe CronJobInfo, '#update' do
+  subject do
+    record.update(update_params)
+  end
+
+  let!(:record) { CronJobInfo.find_by!(name: 'CallsMonitoring') }
+  let(:update_params) do
+    {
+      last_run_at: 1.minute.ago.change(usec: 0),
+      last_duration: 50.123,
+      last_exception: nil
+    }
+  end
+
+  context 'without last_exception' do
+    it 'updates record' do
+      subject
+      expect(record.errors).to be_empty
+      expect(subject).to eq(true)
+      expect(record.reload).to have_attributes(update_params)
+    end
+  end
+
+  context 'with last_exception' do
+    let(:update_params) do
+      super().merge last_exception: "some string\nmulti line"
+    end
+
+    it 'updates record' do
+      subject
+      expect(record.errors).to be_empty
+      expect(subject).to eq(true)
+      expect(record.reload).to have_attributes(update_params)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,7 @@ RSpec.configure do |config|
     'class4.routing_tag_modes',
     'class4.gateway_group_balancing_modes',
     'sys.timezones',
+    'sys.jobs',
     'sys.sip_schemas'
   ]
 


### PR DESCRIPTION
add ability to see information about last cron job run in admin UI without prometheus 

* add cron_job_info with columns `name` `last_duration` `last_run_at` `last_exception`
* add admin UI System -> Cron Jobs with index and show pages
* update appropriate cron_job_info record on each scheduler run