### PR TITLE
fix puma config handling db connections after rails 6.1

### DIFF
--- a/config/puma_conteinerized.rb
+++ b/config/puma_conteinerized.rb
@@ -28,8 +28,10 @@ log_formatter do |str|
 end
 
 before_fork do
-  ApplicationRecord.connection.disconnect!
-  Cdr::Base.connection.disconnect!
+  # Proper way to clear db connections.
+  # Like AR initializer does in active_record/railtie.rb:265
+  ActiveRecord::Base.clear_active_connections!
+  ActiveRecord::Base.flush_idle_connections!
 
   require 'puma_worker_killer'
 
@@ -71,11 +73,6 @@ before_fork do
 end
 
 on_worker_boot do
-  ActiveSupport.on_load(:active_record) do
-    ApplicationRecord.establish_connection
-    Cdr::Base.establish_connection
-  end
-
   if PrometheusConfig.enabled?
     require 'prometheus_exporter/instrumentation'
     PrometheusExporter::Instrumentation::Process.start(type: 'web')

--- a/config/puma_production.rb
+++ b/config/puma_production.rb
@@ -24,8 +24,10 @@ log_formatter do |str|
 end
 
 before_fork do
-  ApplicationRecord.connection.disconnect!
-  Cdr::Base.connection.disconnect!
+  # Proper way to clear db connections.
+  # Like AR initializer does in active_record/railtie.rb:265
+  ActiveRecord::Base.clear_active_connections!
+  ActiveRecord::Base.flush_idle_connections!
 
   require 'puma_worker_killer'
 
@@ -67,11 +69,6 @@ before_fork do
 end
 
 on_worker_boot do
-  ActiveSupport.on_load(:active_record) do
-    ApplicationRecord.establish_connection
-    Cdr::Base.establish_connection
-  end
-
   if PrometheusConfig.enabled?
     require 'prometheus_exporter/instrumentation'
     PrometheusExporter::Instrumentation::Process.start(type: 'web')


### PR DESCRIPTION
regression in #800

solves:
```
PG::InvalidSchemaName: ERROR:  schema "cdr" does not exist
LINE 8:  WHERE a.attrelid = '"cdr"."cdr"'::regclass
                            ^

  from active_record/connection_adapters/postgresql/database_statements.rb:19:in `exec'
  from active_record/connection_adapters/postgresql/database_statements.rb:19:in `block (2 levels) in query'
  from active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
  from active_support/concurrency/share_lock.rb:187:in `yield_shares'
  from active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
  from active_record/connection_adapters/postgresql/database_statements.rb:18:in `block in query'
  from active_record/connection_adapters/abstract_adapter.rb:696:in `block (2 levels) in log'
  from active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
  from active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
  from active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
  from active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
  from active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
  from active_record/connection_adapters/abstract_adapter.rb:695:in `block in log'
  from active_support/notifications/instrumenter.rb:24:in `instrument'
  from active_record/connection_adapters/abstract_adapter.rb:687:in `log'
  from active_record/connection_adapters/postgresql/database_statements.rb:17:in `query'
  from active_record/connection_adapters/postgresql_adapter.rb:820:in `column_definitions'
  from active_record/connection_adapters/abstract/schema_statements.rb:116:in `columns'
  from active_record/connection_adapters/schema_cache.rb:112:in `block in columns'
  from active_record/connection_adapters/schema_cache.rb:111:in `fetch'
```