### PR TITLE
Admin UI and Admin API add allowed_ips validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ GEM
     net-ldap (0.16.1)
     netstring (0.0.3)
     nio4r (2.5.8)
-    nokogiri (1.12.3)
+    nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     oj (3.11.2)

--- a/app/admin/system/admin_users.rb
+++ b/app/admin/system/admin_users.rb
@@ -31,6 +31,7 @@ ActiveAdmin.register AdminUser do
     column :last_sign_in_at
     column :sign_in_count
     column :ssh_key, :ssh_key_tag
+    column :allowed_ips, :has_allowed_ips
   end
 
   show do
@@ -38,6 +39,7 @@ ActiveAdmin.register AdminUser do
       row :id
       row :username
       row :email
+      row :allowed_ips
       row :sign_in_count
       row :current_sign_in_at
       row :last_sign_in_at
@@ -55,12 +57,13 @@ ActiveAdmin.register AdminUser do
   end
 
   permit_params do
-    attrs = %i[ssh_key stateful_filters]
+    attrs = %i[ssh_key stateful_filters allowed_ips]
+    attrs_last = { allowed_ips: [] }
     unless AdminUser.ldap?
       attrs.concat %i[username email password password_confirmation]
-      attrs.push(roles: [])
+      attrs_last[:roles] = []
     end
-    attrs
+    attrs + [attrs_last]
   end
 
   # unless AdminUser.ldap?
@@ -79,6 +82,7 @@ ActiveAdmin.register AdminUser do
       end
       f.input :ssh_key
       f.input :stateful_filters
+      f.input :allowed_ips, as: :array_of_strings
     end
     f.actions
   end

--- a/app/controllers/api/rest/admin/auth_controller.rb
+++ b/app/controllers/api/rest/admin/auth_controller.rb
@@ -15,4 +15,17 @@ class Api::Rest::Admin::AuthController < Knock::AuthTokenController
     error = JSONAPI::Exceptions::AuthenticationFailed.new
     render status: :unauthorized, json: { errors: error.errors.map(&:to_hash) }
   end
+
+  def ip_not_allowed
+    error = JSONAPI::Exceptions::AuthenticationFailed.new(
+      detail: 'Your IP address is not allowed.'
+    )
+    render status: :unauthorized, json: { errors: error.errors.map(&:to_hash) }
+  end
+
+  def authenticate
+    super
+
+    ip_not_allowed unless entity.ip_allowed?(request.remote_ip)
+  end
 end

--- a/app/controllers/api/rest/admin/base_controller.rb
+++ b/app/controllers/api/rest/admin/base_controller.rb
@@ -29,6 +29,8 @@ class Api::Rest::Admin::BaseController < Api::RestController
   private
 
   def authenticate_admin_user!
-    unauthorized_entity('admin_user') unless authenticate_for(::AdminUser)
+    if !authenticate_for(::AdminUser) || !current_admin_user.ip_allowed?(request.remote_ip)
+      unauthorized_entity('admin_user')
+    end
   end
 end

--- a/app/decorators/admin_user_decorator.rb
+++ b/app/decorators/admin_user_decorator.rb
@@ -20,4 +20,18 @@ class AdminUserDecorator < ApplicationDecorator
   def pretty_saved_filters
     h.pre_wrap_json(model.saved_filters)
   end
+
+  def has_allowed_ips
+    if model.allowed_ips.nil?
+      status_tag(:no)
+    else
+      status_tag(:yes)
+    end
+  end
+
+  def pretty_allowed_ips
+    return if model.allowed_ips.nil?
+
+    pre_wrap model.allowed_ips.join("\n")
+  end
 end

--- a/app/models/concerns/admin_user_database_handler.rb
+++ b/app/models/concerns/admin_user_database_handler.rb
@@ -4,7 +4,7 @@ module AdminUserDatabaseHandler
   extend ActiveSupport::Concern
 
   included do
-    devise :database_authenticatable, :trackable, :validatable
+    devise :database_authenticatable, :trackable, :validatable, :ip_allowable
     alias_method :authenticate, :valid_password?
 
     before_validation do

--- a/app/models/concerns/admin_user_ldap_handler.rb
+++ b/app/models/concerns/admin_user_ldap_handler.rb
@@ -4,7 +4,7 @@ module AdminUserLdapHandler
   extend ActiveSupport::Concern
 
   included do
-    devise :ldap_authenticatable, :trackable
+    devise :ldap_authenticatable, :trackable, :ip_allowable
     before_update :get_ldap_attributes
     before_validation :get_ldap_attributes, on: :create
     include LdapPasswordHelper

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'devise_ip_allowable'
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -21,6 +21,7 @@ en:
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'
       inactive: 'Your account was not activated yet.'
+      ip_not_allowed: 'Your IP address is not allowed.'
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'

--- a/db/migrate/20210919130327_add_allowed_ips_to_admin_users.rb
+++ b/db/migrate/20210919130327_add_allowed_ips_to_admin_users.rb
@@ -1,0 +1,15 @@
+class AddAllowedIpsToAdminUsers < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE admin_users
+      ADD COLUMN allowed_ips inet[]
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE admin_users
+      DROP COLUMN allowed_ips
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24275,7 +24275,8 @@ CREATE TABLE gui.admin_users (
     visible_columns json DEFAULT '{}'::json NOT NULL,
     per_page json DEFAULT '{}'::json NOT NULL,
     saved_filters json DEFAULT '{}'::json NOT NULL,
-    roles character varying[] NOT NULL
+    roles character varying[] NOT NULL,
+    allowed_ips inet[]
 );
 
 
@@ -29790,7 +29791,8 @@ ALTER TABLE ONLY sys.sensors
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
+SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import
+;
 
 INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20170822151410'),
@@ -29871,6 +29873,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20210605094810'),
 ('20210606143950'),
 ('20210630120418'),
-('20210825190138');
+('20210825190138'),
+('20210919130327');
 
 

--- a/lib/devise_ip_allowable.rb
+++ b/lib/devise_ip_allowable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'devise'
+
+Warden::Manager.after_set_user do |record, warden, options|
+  proxy = Devise::Hooks::Proxy.new(warden)
+  scope = options[:scope]
+  env = warden.request.env
+  remote_ip = warden.request.remote_ip
+
+  if record&.respond_to?(:ip_allowed?) && warden.authenticated?(scope) &&
+     !env['devise.skip_ip_allowable'] && !record.ip_allowed?(remote_ip)
+
+    Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
+    throw :warden, scope: scope, message: :ip_not_allowed
+  end
+end
+
+module Devise
+  module Models
+    module IpAllowable
+      extend ActiveSupport::Concern
+
+      def ip_allowed?(remote_ip)
+        return true if allowed_ips.blank?
+
+        allowed_ips.any? { |ip_address| IPAddr.new(ip_address).include?(remote_ip) }
+      end
+    end
+  end
+end
+
+Devise.add_module :ip_allowable, model: 'devise/models/ip_allowable'

--- a/spec/features/dashboard/index_dashboard_spec.rb
+++ b/spec/features/dashboard/index_dashboard_spec.rb
@@ -1,13 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Index Dashboard', type: :feature do
-  include_context :login_as_admin
-
-  it 'n+1 checks' do
-    items = create_list(:event, 5, :uniq_command)
+  subject do
     visit dashboard_path
-    items.each do |item|
+  end
+
+  include_context :login_as_admin
+  let!(:unique_commands) do
+    create_list(:event, 5, :uniq_command)
+  end
+
+  it 'renders dashboard' do
+    subject
+    expect(page).to have_current_path dashboard_path
+    unique_commands.each do |item|
       expect(page).to have_css('td.col-command', text: item.command)
+    end
+  end
+
+  context 'when admin_user.allowed_ips match request.remote_ip' do
+    before do
+      admin_user.update! allowed_ips: ['127.0.0.1']
+    end
+
+    it 'renders dashboard' do
+      subject
+      expect(page).to have_current_path dashboard_path
+      unique_commands.each do |item|
+        expect(page).to have_css('td.col-command', text: item.command)
+      end
+    end
+  end
+
+  context 'when admin_user.allowed_ips does not match request.remote_ip' do
+    before do
+      admin_user.update! allowed_ips: ['10.1.2.3']
+    end
+
+    it 'does not sign in' do
+      subject
+      expect(page).to have_current_path new_admin_user_session_path
+      expect(page).to have_flash_message 'Your IP address is not allowed.', type: :alert
     end
   end
 end

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -1,14 +1,71 @@
 # frozen_string_literal: true
 
-RSpec.describe 'the signin process', type: :feature do
+RSpec.describe 'the sign in process', js: true do
   subject do
-    login_as(admin_user, scope: :admin_user)
+    visit new_admin_user_session_path
+    fill_form!
+    click_button 'Login'
   end
 
-  let!(:admin_user) { FactoryBot.create(:admin_user) }
+  let!(:admin_user) { FactoryBot.create(:admin_user, admin_user_attrs) }
+  let(:admin_user_attrs) { { password: 'passwd' } }
 
-  it 'signs me in' do
-    subject
-    expect { visit root_path }.to_not raise_error
+  shared_examples :signs_in_successfully do
+    it 'signs in successfully' do
+      subject
+      expect(page).to have_current_path root_path
+      expect(page).to have_flash_message 'Signed in successfully.', type: :notice
+    end
+  end
+
+  shared_examples :does_not_sign_in do |message|
+    it 'does not sign in' do
+      subject
+      expect(page).to have_current_path new_admin_user_session_path
+      expect(page).to have_flash_message message, type: :alert
+    end
+  end
+
+  let(:fill_form!) do
+    fill_in 'Username', with: admin_user.username
+    fill_in 'Password', with: admin_user_attrs[:password]
+  end
+
+  context 'with correct username and password' do
+    include_examples :signs_in_successfully
+  end
+
+  context 'when password not match' do
+    let(:fill_form!) do
+      fill_in 'Username', with: admin_user.username
+      fill_in 'Password', with: 'invalid'
+    end
+
+    include_examples :does_not_sign_in, 'Invalid email or password.'
+  end
+
+  context 'when invalid non-exist username' do
+    let(:fill_form!) do
+      fill_in 'Username', with: 'non-exist'
+      fill_in 'Password', with: admin_user_attrs[:password]
+    end
+
+    include_examples :does_not_sign_in, 'Invalid Username or password.'
+  end
+
+  context 'when allowed_ips are filled with not match ip' do
+    let(:admin_user_attrs) do
+      super().merge allowed_ips: ['192.168.1.123']
+    end
+
+    include_examples :does_not_sign_in, 'Your IP address is not allowed.'
+  end
+
+  context 'when allowed_ips are filled with match ip' do
+    let(:admin_user_attrs) do
+      super().merge allowed_ips: ['127.0.0.0/24']
+    end
+
+    include_examples :signs_in_successfully
   end
 end

--- a/spec/requests/api/rest/admin/accoounts_spec.rb
+++ b/spec/requests/api/rest/admin/accoounts_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::AccountsController, type: :request do
         accounts.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/api_accesses_spec.rb
+++ b/spec/requests/api/rest/admin/api_accesses_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::ApiAccessesController, type: :request do
         api_accesses.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/billing/invoice_periods_spec.rb
+++ b/spec/requests/api/rest/admin/billing/invoice_periods_spec.rb
@@ -20,5 +20,7 @@ RSpec.describe Api::Rest::Admin::Billing::InvoicePeriodController, type: :reques
         invoice_periods.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/billing/invoice_templates_spec.rb
+++ b/spec/requests/api/rest/admin/billing/invoice_templates_spec.rb
@@ -20,5 +20,7 @@ RSpec.describe Api::Rest::Admin::Billing::InvoiceTemplateController, type: :requ
         invoice_templates.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/cdr/auth_logs_spec.rb
+++ b/spec/requests/api/rest/admin/cdr/auth_logs_spec.rb
@@ -20,5 +20,7 @@ RSpec.describe Api::Rest::Admin::Cdr::AuthLogsController, type: :request do
         auth_logs.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
+++ b/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrExportsController, type: :request do
       end
     end
 
+    it_behaves_like :json_api_admin_check_authorization, status: 201
+
     context 'with only required attributes' do
       include_examples :creates_cdr_export
       include_examples :returns_json_api_record, relationships: [], status: 201 do
@@ -299,5 +301,7 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrExportsController, type: :request do
     end
 
     include_examples :responds_with_status, 204, without_body: true
+
+    it_behaves_like :json_api_admin_check_authorization, status: 204
   end
 end

--- a/spec/requests/api/rest/admin/cdr/cdrs_spec.rb
+++ b/spec/requests/api/rest/admin/cdr/cdrs_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrsController, type: :request do
         cdrs.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/codec_groups_spec.rb
+++ b/spec/requests/api/rest/admin/codec_groups_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::CodecGroupsController, type: :request do
         codec_groups.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/contacts_spec.rb
+++ b/spec/requests/api/rest/admin/contacts_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::Rest::Admin::ContactsController, type: :request do
         contacts.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'GET /api/rest/admin/contacts/{id}' do
@@ -43,6 +45,8 @@ RSpec.describe Api::Rest::Admin::ContactsController, type: :request do
       let(:json_api_record_id) { record_id }
       let(:json_api_record_attributes) { contact_response_attributes }
     end
+
+    it_behaves_like :json_api_admin_check_authorization
 
     context 'with include destination' do
       let(:request_query) { { include: 'contractor' } }
@@ -98,6 +102,8 @@ RSpec.describe Api::Rest::Admin::ContactsController, type: :request do
     end
 
     include_examples :changes_records_qty_of, Billing::Contact, by: 1
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
   end
 
   describe 'PATCH /api/rest/admin/contacts/{id}' do
@@ -120,6 +126,8 @@ RSpec.describe Api::Rest::Admin::ContactsController, type: :request do
         hash_including(json_api_request_attributes)
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'DELETE /api/rest/admin/contacts/{id}' do
@@ -135,5 +143,7 @@ RSpec.describe Api::Rest::Admin::ContactsController, type: :request do
 
     include_examples :responds_with_status, 204
     include_examples :changes_records_qty_of, Billing::Contact, by: -1
+
+    it_behaves_like :json_api_admin_check_authorization, status: 204
   end
 end

--- a/spec/requests/api/rest/admin/contractors_spec.rb
+++ b/spec/requests/api/rest/admin/contractors_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::Rest::Admin::ContractorsController, type: :request do
       end
     end
 
+    it_behaves_like :json_api_admin_check_authorization
+
     context 'with filter by smtp_connection.id' do
       let!(:smtp_connection) { create(:smtp_connection) }
       let!(:other_smtp_connection) { create(:smtp_connection) }

--- a/spec/requests/api/rest/admin/customers_auth_spec.rb
+++ b/spec/requests/api/rest/admin/customers_auth_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::Rest::Admin::CustomersAuthsController, type: :request do
       end
     end
 
+    it_behaves_like :json_api_admin_check_authorization
+
     context 'with filter by customer.id' do
       let!(:customer) { create(:customer) }
       let!(:other_customer) { create(:customer) }

--- a/spec/requests/api/rest/admin/destination_next_rates_spec.rb
+++ b/spec/requests/api/rest/admin/destination_next_rates_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
         next_rates.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'GET /api/rest/admin/routing/destination-next-rates/{id}' do
@@ -50,6 +52,8 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
       let(:json_api_record_id) { record_id }
       let(:json_api_record_attributes) { next_rate_response_attributes }
     end
+
+    it_behaves_like :json_api_admin_check_authorization
 
     context 'with include destination' do
       let(:request_query) { { include: 'destination' } }
@@ -118,6 +122,8 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
     end
 
     include_examples :changes_records_qty_of, Routing::DestinationNextRate, by: 1
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
   end
 
   describe 'PATCH /api/rest/admin/routing/destination-next-rates/{id}' do
@@ -141,6 +147,8 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
         hash_including(json_api_request_attributes)
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'DELETE /api/rest/admin/routing/destination-next-rates/{id}' do
@@ -157,5 +165,7 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
 
     include_examples :responds_with_status, 204
     include_examples :changes_records_qty_of, Routing::DestinationNextRate, by: -1
+
+    it_behaves_like :json_api_admin_check_authorization, status: 204
   end
 end

--- a/spec/requests/api/rest/admin/dialpeer_next_rates_spec.rb
+++ b/spec/requests/api/rest/admin/dialpeer_next_rates_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::DialpeerNextRatesController, type: :request do
         dialpeer_next_rates.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/dialpeer_spec.rb
+++ b/spec/requests/api/rest/admin/dialpeer_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::Rest::Admin::DialpeersController do
         dialpeers.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'POST api/rest/admin/dialpeers' do
@@ -31,6 +33,92 @@ RSpec.describe Api::Rest::Admin::DialpeersController do
     let(:account) { FactoryBot.create(:account, contractor: vendor) }
     let(:routing_tag_mode) { Routing::RoutingTagMode.take! }
     let(:routeset_discriminator) { Routing::RoutesetDiscriminator.take || FactoryBot.create(:routeset_discriminator) }
+    let(:gateway) { FactoryBot.create(:gateway, vendor: vendor) }
+
+    let(:json_api_request_body) do
+      {
+        data: {
+          type: json_api_resource_type,
+          attributes: json_api_request_attributes,
+          relationships: json_api_request_relationships
+        }
+      }
+    end
+    let(:json_api_request_attributes) do
+      {
+        'acd-limit': '0.01',
+        'enabled': 'true',
+        'prefix': '_test_',
+        'asr-limit': '0.02',
+        'next-rate': '0.01',
+        'initial-rate': '0.01',
+        'connect-fee': '0.01',
+        'valid-from': '2020-02-02',
+        'valid-till': '2020-02-02',
+        'routing-tag-ids': [@tag_ua.id]
+      }
+    end
+    let(:json_api_request_relationships) do
+      {
+        'routing-group': { data: { id: routing_group.id.to_s, type: 'routing_groups' } },
+        'account': { data: { id: account.id.to_s, type: 'accounts' } },
+        'routing-tag-mode': { data: { id: routing_tag_mode.id.to_s, type: 'routing_tag_modes' } },
+        'routeset-discriminator': { data: { id: routeset_discriminator.id.to_s, type: 'routeset_discriminators' } },
+        'vendor': { data: { id: vendor.id.to_s, type: 'contractors' } },
+        'gateway': { data: { id: gateway.id.to_s, type: 'gateways' } }
+      }
+    end
+    let(:last_dialpeer) { Dialpeer.last! }
+
+    relationships = %i[
+      routing-group
+      account
+      routing-tag-mode
+      routeset-discriminator
+      vendor
+      dialpeer-next-rates
+      gateway
+      gateway-group
+    ]
+    include_examples :returns_json_api_record, relationships: relationships, status: 201 do
+      let(:json_api_record_id) { last_dialpeer.id.to_s }
+      let(:json_api_record_attributes) do
+        {
+          'acd-limit': 0.01,
+          'asr-limit': 0.02,
+          'connect-fee': '0.01',
+          'created-at': last_dialpeer.created_at.iso8601(3),
+          'dst-number-max-length': 100,
+          'dst-number-min-length': 0,
+          'dst-rewrite-result': nil,
+          'dst-rewrite-rule': nil,
+          'exclusive-route': false,
+          'external-id': nil,
+          'force-hit-rate': nil,
+          'initial-interval': 1,
+          'initial-rate': '0.01',
+          'lcr-rate-multiplier': '1.0',
+          'network-prefix-id': nil,
+          'next-interval': 1,
+          'next-rate': '0.01',
+          'routing-tag-ids': [@tag_ua.id],
+          'short-calls-limit': 1.0,
+          'src-rewrite-result': nil,
+          'src-rewrite-rule': nil,
+          'valid-from': Time.parse('2020-02-02').in_time_zone.iso8601(3),
+          'valid-till': Time.parse('2020-02-02').in_time_zone.iso8601(3),
+          capacity: nil,
+          enabled: true,
+          locked: false,
+          prefix: '_test_',
+          priority: 100
+        }
+      end
+    end
+
+    include_examples :changes_records_qty_of, Dialpeer, by: 1
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
 
     context 'without gateway_id and gateway_group_id' do
       let(:json_api_request_body) do

--- a/spec/requests/api/rest/admin/disconnect_policy_resource_spec.rb
+++ b/spec/requests/api/rest/admin/disconnect_policy_resource_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::DisconnectPoliciesController, type: :request do
         disconnect_policies.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/diversion_policies_spec.rb
+++ b/spec/requests/api/rest/admin/diversion_policies_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::DiversionPoliciesController, type: :request do
         diversion_policies.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/dump_levels_spec.rb
+++ b/spec/requests/api/rest/admin/dump_levels_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::DumpLevelsController, type: :request do
         dump_levels.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/gateway_inband_dtmf_filtering_modes_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/gateway_inband_dtmf_filtering_modes_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::GatewayInbandDtmfFilteringModesContr
         gateway_inband_dtmf_filtering_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/gateway_media_encryption_modes_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/gateway_media_encryption_modes_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::GatewayMediaEncryptionModesControlle
         gateway_media_encryption_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/gateway_network_protocol_priorities_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/gateway_network_protocol_priorities_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::GatewayNetworkProtocolPrioritiesCont
         gateway_network_protocol_priorities.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/gateway_rel100_modes_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/gateway_rel100_modes_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::GatewayRel100ModesController, type: 
         gateway_rel100_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/radius/accounting_profiles_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/radius/accounting_profiles_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Equipment::Radius::AccountingProfilesController, type: :request do
   include_context :json_api_admin_helpers, type: :'accounting-profiles', prefix: 'equipment/radius'
 
-  describe 'GET /api/rest/admin/equipment/accounting-profiles' do
+  describe 'GET /api/rest/admin/equipment/radius/accounting-profiles' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::Radius::AccountingProfilesController
         accounting_profiles.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/radius/auth_profile_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/radius/auth_profile_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Equipment::Radius::AuthProfilesController, type: :request do
   include_context :json_api_admin_helpers, type: :'auth-profiles', prefix: 'equipment/radius'
 
-  describe 'GET /api/rest/admin/equipment/auth-profiles' do
+  describe 'GET /api/rest/admin/equipment/radius/auth-profiles' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::Radius::AuthProfilesController, type
         auth_profiles.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/equipment/registrations_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/registrations_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Api::Rest::Admin::Equipment::RegistrationsController do
 
     include_examples :responds_with_status, 200
     include_examples :jsonapi_responds_with_pagination_links
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'GET /api/rest/admin/equipment/registrations/:id' do
@@ -72,6 +74,8 @@ RSpec.describe Api::Rest::Admin::Equipment::RegistrationsController do
     let(:request_params) { nil }
     let!(:registration) { create(:registration, :filled, registration_attrs) }
     let(:registration_attrs) { {} }
+
+    it_behaves_like :json_api_admin_check_authorization
 
     context 'without query' do
       it 'does not have relationships data' do
@@ -171,6 +175,8 @@ RSpec.describe Api::Rest::Admin::Equipment::RegistrationsController do
     end
     let(:json_api_request_relationships) { {} }
     let(:registration) { Equipment::Registration.last! }
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
 
     context 'with only required fields' do
       it 'creates registration' do
@@ -293,6 +299,8 @@ RSpec.describe Api::Rest::Admin::Equipment::RegistrationsController do
 
       include_examples :responds_with_status, 200
       include_examples :responds_jsonapi_registration
+
+      it_behaves_like :json_api_admin_check_authorization
     end
 
     context 'when update sip-schema' do
@@ -331,5 +339,7 @@ RSpec.describe Api::Rest::Admin::Equipment::RegistrationsController do
     end
 
     include_examples :responds_with_status, 204, without_body: true
+
+    it_behaves_like :json_api_admin_check_authorization, status: 204
   end
 end

--- a/spec/requests/api/rest/admin/equipment/sip_oprions_probers_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/sip_oprions_probers_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe Api::Rest::Admin::Equipment::SipOptionsProbersController do
 
     include_examples :responds_with_status, 200
     include_examples :jsonapi_responds_with_pagination_links
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'GET /api/rest/admin/equipment/sip-options-probers/:id' do
@@ -74,6 +76,8 @@ RSpec.describe Api::Rest::Admin::Equipment::SipOptionsProbersController do
     let(:request_params) { nil }
     let!(:sip_options_prober) { create(:sip_options_prober, sip_options_prober_attrs) }
     let(:sip_options_prober_attrs) { { pop: pops[0], node: nodes[0] } }
+
+    it_behaves_like :json_api_admin_check_authorization
 
     context 'without query' do
       it 'does not have relationships data' do
@@ -172,6 +176,8 @@ RSpec.describe Api::Rest::Admin::Equipment::SipOptionsProbersController do
     end
     let(:json_api_request_relationships) { {} }
     let(:sip_options_prober) { Equipment::SipOptionsProber.last! }
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
 
     context 'with only required fields' do
       it 'creates sip options prober' do
@@ -286,6 +292,8 @@ RSpec.describe Api::Rest::Admin::Equipment::SipOptionsProbersController do
 
       include_examples :responds_with_status, 200
       include_examples :responds_jsonapi_sip_options_prober
+
+      it_behaves_like :json_api_admin_check_authorization
     end
 
     context 'when update external id to exist external id' do
@@ -329,5 +337,7 @@ RSpec.describe Api::Rest::Admin::Equipment::SipOptionsProbersController do
     end
 
     include_examples :responds_with_status, 204, without_body: true
+
+    it_behaves_like :json_api_admin_check_authorization, status: 204
   end
 end

--- a/spec/requests/api/rest/admin/equipment/transport_protocols_spec.rb
+++ b/spec/requests/api/rest/admin/equipment/transport_protocols_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Equipment::TransportProtocolsController, type: 
         transport_protocols.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/filter_types_spec.rb
+++ b/spec/requests/api/rest/admin/filter_types_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::FilterTypesController, type: :request do
         filter_types.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/gateway_groups_spec.rb
+++ b/spec/requests/api/rest/admin/gateway_groups_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::AccountsController, type: :request do
         gateway_groups.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/gateways_spec.rb
+++ b/spec/requests/api/rest/admin/gateways_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
       end
     end
 
+    it_behaves_like :json_api_admin_check_authorization
+
     context 'with filter by contractor.id' do
       let!(:contractor) { create(:vendor) }
       let!(:other_contractor) { create(:vendor) }
@@ -546,6 +548,8 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
       let(:json_api_record_id) { record_id }
       let(:json_api_record_attributes) { gateway_response_attributes }
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 
   describe 'POST /api/rest/admin/gateways' do
@@ -623,6 +627,8 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
         hash_including(json_api_request_attributes)
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization, status: 201
 
     it 'creates gateway with correct attributes' do
       expect { subject }.to change { Gateway.count }.by(1)
@@ -712,5 +718,7 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
         hash_including(json_api_request_attributes)
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/node_spec.rb
+++ b/spec/requests/api/rest/admin/node_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::NodesController, type: :request do
         nodes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/payments_spec.rb
+++ b/spec/requests/api/rest/admin/payments_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::PaymentsController, type: :request do
         payments.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/pop_spec.rb
+++ b/spec/requests/api/rest/admin/pop_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::PopsController, type: :request do
         pops.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
+++ b/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::AreaPrefixesController, type: :request do
   include_context :json_api_admin_helpers, type: :'area-prefixes', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/area-prefixes' do
+  describe 'GET /api/rest/admin/routing/area-prefixes' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::AreaPrefixesController, type: :request
         area_prefixes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/areas_spec.rb
+++ b/spec/requests/api/rest/admin/routing/areas_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::AreasController, type: :request do
   include_context :json_api_admin_helpers, type: :areas, prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/areas' do
+  describe 'GET /api/rest/admin/routing/areas' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::AreasController, type: :request do
         areas.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/destination_next_rates_spec.rb
+++ b/spec/requests/api/rest/admin/routing/destination_next_rates_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: :request do
   include_context :json_api_admin_helpers, type: :'destination-next-rates', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/destination-next-rates' do
+  describe 'GET /api/rest/admin/routing/destination-next-rates' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationNextRatesController, type: 
         destination_next_rates.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/destination_rate_policies_spec.rb
+++ b/spec/requests/api/rest/admin/routing/destination_rate_policies_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::DestinationRatePoliciesController, type: :request do
   include_context :json_api_admin_helpers, type: :'destination-rate-policies', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/destination-rate-policies' do
+  describe 'GET /api/rest/admin/routing/destination-rate-policies' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationRatePoliciesController, typ
         destination_rate_policies.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/destinations_spec.rb
+++ b/spec/requests/api/rest/admin/routing/destinations_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::DestinationsController, type: :request do
   include_context :json_api_admin_helpers, type: :destinations, prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/destinations' do
+  describe 'GET /api/rest/admin/routing/destinations' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::DestinationsController, type: :request
         destination_rate_policies.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/numberlist_actions_spec.rb
+++ b/spec/requests/api/rest/admin/routing/numberlist_actions_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::NumberlistActionsController, type: :re
         numberlist_actions.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/numberlist_items_spec.rb
+++ b/spec/requests/api/rest/admin/routing/numberlist_items_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::NumberlistItemsController, type: :requ
         numberlist_items.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/numberlists_spec.rb
+++ b/spec/requests/api/rest/admin/routing/numberlists_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::NumberlistsController, type: :request 
         numberlists.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/rate_profit_control_modes_spec.rb
+++ b/spec/requests/api/rest/admin/routing/rate_profit_control_modes_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RateProfitControlModesController, type: :request do
   include_context :json_api_admin_helpers, type: :'rate-profit-control-modes', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/rate-profit-control-modes' do
+  describe 'GET /api/rest/admin/routing/rate-profit-control-modes' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::RateProfitControlModesController, type
         rate_profit_control_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/rateplans_spec.rb
+++ b/spec/requests/api/rest/admin/routing/rateplans_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RateplansController, type: :request do
   include_context :json_api_admin_helpers, type: :rateplans, prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/rateplans' do
+  describe 'GET /api/rest/admin/routing/rateplans' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::RateplansController, type: :request do
         rateplans.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/routeset_discriminators_spec.rb
+++ b/spec/requests/api/rest/admin/routing/routeset_discriminators_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RoutesetDiscriminatorsController, type: :request do
   include_context :json_api_admin_helpers, type: :'routeset-discriminators', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/routeset-discriminators' do
+  describe 'GET /api/rest/admin/routing/routeset-discriminators' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::Routing::RoutesetDiscriminatorsController, type
         routeset_discriminators.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/routing_tag_detection_rules_spec.rb
+++ b/spec/requests/api/rest/admin/routing/routing_tag_detection_rules_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RoutingTagDetectionRulesController, type: :request do
   include_context :json_api_admin_helpers, type: :'routing-tag-detection-rules', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/routing-tag-detection-rules' do
+  describe 'GET /api/rest/admin/routing/routing-tag-detection-rules' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::RoutingTagDetectionRulesController, ty
         routing_tag_detection_rules.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/routing_tag_modes_spec.rb
+++ b/spec/requests/api/rest/admin/routing/routing_tag_modes_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RoutingTagModesController, type: :request do
   include_context :json_api_admin_helpers, type: :'routing-tag-modes', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/routing-tag-modes' do
+  describe 'GET /api/rest/admin/routing/routing-tag-modes' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::RoutingTagModesController, type: :requ
         routing_tag_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/routing_tags_spec.rb
+++ b/spec/requests/api/rest/admin/routing/routing_tags_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::RoutingTagsController, type: :request do
   include_context :json_api_admin_helpers, type: :'routing-tags', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/routing-tags' do
+  describe 'GET /api/rest/admin/routing/routing-tags' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::RoutingTagsController, type: :request 
         routing_tags.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing/tag_action_spec.rb
+++ b/spec/requests/api/rest/admin/routing/tag_action_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Api::Rest::Admin::Routing::TagActionsController, type: :request do
   include_context :json_api_admin_helpers, type: :'tag-actions', prefix: 'routing'
 
-  describe 'GET /api/rest/admin/equipment/tag-actions' do
+  describe 'GET /api/rest/admin/routing/tag-actions' do
     subject do
       get json_api_request_path, params: nil, headers: json_api_request_headers
     end
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::Routing::TagActionsController, type: :request d
         tag_actions.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing_groups_spec.rb
+++ b/spec/requests/api/rest/admin/routing_groups_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::RoutingGroupsController, type: :request do
         routing_groups.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/routing_plans_spec.rb
+++ b/spec/requests/api/rest/admin/routing_plans_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::RoutingPlansController, type: :request do
         routing_plans.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/sdp_c_locations_spec.rb
+++ b/spec/requests/api/rest/admin/sdp_c_locations_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::SdpCLocationsController, type: :request do
         sdp_c_locations.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/session_refresh_methods_spec.rb
+++ b/spec/requests/api/rest/admin/session_refresh_methods_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::SessionRefreshMethodsController, type: :request
         session_refresh_methods.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/sortings_spec.rb
+++ b/spec/requests/api/rest/admin/sortings_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::SortingsController, type: :request do
         sortings.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/country_spec.rb
+++ b/spec/requests/api/rest/admin/system/country_spec.rb
@@ -22,5 +22,7 @@ RSpec.describe Api::Rest::Admin::System::CountriesController, type: :request do
         countries.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/dtmf_receive_modes_spec.rb
+++ b/spec/requests/api/rest/admin/system/dtmf_receive_modes_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::System::DtmfReceiveModesController, type: :requ
         dtmf_receive_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/dtmf_send_modes_spec.rb
+++ b/spec/requests/api/rest/admin/system/dtmf_send_modes_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::System::DtmfSendModesController, type: :request
         dtmf_send_modes.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/network_types_spec.rb
+++ b/spec/requests/api/rest/admin/system/network_types_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::System::NetworkTypesController, type: :request 
         network_types.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/networks_spec.rb
+++ b/spec/requests/api/rest/admin/system/networks_spec.rb
@@ -22,5 +22,7 @@ RSpec.describe Api::Rest::Admin::System::NetworksController, type: :request do
         networks.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/sensor_levels_spec.rb
+++ b/spec/requests/api/rest/admin/system/sensor_levels_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::System::SensorLevelsController, type: :request 
         sensor_levels.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/sensors_spec.rb
+++ b/spec/requests/api/rest/admin/system/sensors_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::System::SensorsController, type: :request do
         sensors.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/sip_schemas_spec.rb
+++ b/spec/requests/api/rest/admin/system/sip_schemas_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::System::SipSchemasController, type: :request do
         sip_schemas.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/smtp_connections_spec.rb
+++ b/spec/requests/api/rest/admin/system/smtp_connections_spec.rb
@@ -18,5 +18,7 @@ RSpec.describe Api::Rest::Admin::System::SmtpConnectionsController, type: :reque
         smtp_connections.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/requests/api/rest/admin/system/timezones_spec.rb
+++ b/spec/requests/api/rest/admin/system/timezones_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe Api::Rest::Admin::System::TimezonesController, type: :request do
         timezones.map { |r| r.id.to_s }
       end
     end
+
+    it_behaves_like :json_api_admin_check_authorization
   end
 end

--- a/spec/support/examples/json_api/json_api_admin_check_authorization.rb
+++ b/spec/support/examples/json_api/json_api_admin_check_authorization.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples :json_api_admin_check_authorization do |status: 200|
+  let(:when_valid_auth) { nil }
+
+  context 'with invalid auth token' do
+    let(:json_api_auth_token) { 'invalid' }
+
+    include_examples :responds_with_status, 401, without_body: true
+  end
+
+  context 'without Authorization header' do
+    let(:json_api_request_headers) { super().except('Authorization') }
+
+    include_examples :responds_with_status, 401, without_body: true
+  end
+
+  context 'with expired auth token' do
+    let(:json_api_auth_token) do
+      ::Knock::AuthToken.new(payload: { sub: admin_user.id, exp: 1.minute.ago.to_i }).token
+    end
+
+    include_examples :responds_with_status, 401, without_body: true
+  end
+
+  context 'when admin_user.allowed_ips does not match request.remote_ip' do
+    before do
+      admin_user.update! allowed_ips: ['10.4.3.2']
+    end
+
+    include_examples :responds_with_status, 401, without_body: true
+  end
+
+  context 'when admin_user.allowed_ips does not match request.remote_ip' do
+    before do
+      admin_user.update! allowed_ips: ['127.0.0.1']
+      when_valid_auth
+    end
+
+    include_examples :responds_with_status, status
+  end
+end


### PR DESCRIPTION
fixes #1023

- [x] Admin UI admin_user add allowed_ips show/edit
- [x] Admin UI add check allowed_ips during authorization and authentication
- [x] Admin API add check allowed_ips during authorization and authentication
- [x] Admin UI add tests for login with filled allowed_ips
- [x] Admin UI add tests for dashboard render with filled allowed_ips
- [x] Admin API add tests for /auth request with filled allowed_ips
- [x] Admin API add tests for API endpoints with filled allowed_ips

fix vulnerability nokogiri CVE-2021-41098 
```
Name: nokogiri
Version: 1.12.3
CVE: CVE-2021-41098
GHSA: GHSA-2rr5-8q37-2w7h
Criticality: High
URL: GHSA-2rr5-8q37-2w7h
Title: Improper Restriction of XML External Entity Reference (XXE) in Nokogiri on JRuby
Solution: upgrade to >= 1.12.5
```