### PR TITLE
fix password autocomplete on admin user edit

### DIFF
--- a/app/admin/system/admin_users.rb
+++ b/app/admin/system/admin_users.rb
@@ -70,8 +70,8 @@ ActiveAdmin.register AdminUser do
       unless AdminUser.ldap?
         f.input :email
         f.input :username
-        f.input :password
-        f.input :password_confirmation
+        f.input :password, input_html: { autocomplete: 'new-password' }
+        f.input :password_confirmation, input_html: { autocomplete: 'new-password' }
         f.input :roles,
                 as: :select,
                 collection: AdminUser.available_roles,


### PR DESCRIPTION
chrome will not prefill with existing password, chrome will add option to generate secure password

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete