### PR TITLE
customer v1 api invoices add account filters

### DIFF
--- a/app/resources/api/rest/customer/v1/account_resource.rb
+++ b/app/resources/api/rest/customer/v1/account_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::AccountResource < BaseResource
+class Api::Rest::Customer::V1::AccountResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Account'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :name,
              :balance, :min_balance, :max_balance,
@@ -26,13 +22,9 @@ class Api::Rest::Customer::V1::AccountResource < BaseResource
   ransack_filter :termination_capacity, type: :number
   ransack_filter :total_capacity, type: :number
 
-  def self.records(options = {})
-    apply_allowed_accounts(super(options), options)
-  end
-
-  def self.apply_allowed_accounts(_records, options)
+  def self.apply_allowed_accounts(records, options)
     context = options[:context]
-    scope = _records.where(contractor_id: context[:customer_id])
+    scope = records.where(contractor_id: context[:customer_id])
     scope = scope.where(id: context[:allowed_account_ids]) if context[:allowed_account_ids].present?
     scope
   end

--- a/app/resources/api/rest/customer/v1/base_resource.rb
+++ b/app/resources/api/rest/customer/v1/base_resource.rb
@@ -3,9 +3,34 @@
 class Api::Rest::Customer::V1::BaseResource < ::BaseResource
   abstract
   immutable
+  key_type :uuid
+  primary_key :uuid
+  paginator :paged
 
-  def self.association_uuid_filter(attr, column: nil, class_name:)
-    verify = ->(values) { class_name.constantize.where(uuid: values).pluck(:id) }
-    ransack_filter attr, type: :uuid, column: column, verify: verify
+  class << self
+    def records(options = {})
+      records = super(options)
+      apply_allowed_accounts(records, options)
+    end
+
+    def apply_allowed_accounts(records, _options)
+      records
+    end
+
+    def association_uuid_filter(attr, column: nil, class_name:)
+      column ||= attr
+      klass = class_name.constantize
+      verify = ->(values) { klass.where(uuid: values).pluck(:id) }
+      ransack_filter attr, type: :uuid, column: column, verify: verify
+    end
+
+    private
+
+    def inherited(subclass)
+      super
+      subclass.key_type(resource_key_type)
+      subclass.primary_key(_primary_key)
+      subclass.paginator(_paginator)
+    end
   end
 end

--- a/app/resources/api/rest/customer/v1/cdr_resource.rb
+++ b/app/resources/api/rest/customer/v1/cdr_resource.rb
@@ -3,10 +3,6 @@
 class Api::Rest::Customer::V1::CdrResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Cdr::Cdr'
 
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
-
   def self.default_sort
     [{ field: 'time_start', direction: :desc }]
   end
@@ -180,14 +176,9 @@ class Api::Rest::Customer::V1::CdrResource < Api::Rest::Customer::V1::BaseResour
 
   association_uuid_filter :account_id, column: :customer_acc_id, class_name: 'Account'
 
-  # TODO: move to BaseResource
-  def self.records(options = {})
-    apply_allowed_accounts(super(options), options)
-  end
-
-  def self.apply_allowed_accounts(_records, options)
+  def self.apply_allowed_accounts(records, options)
     context = options[:context]
-    scope = _records.where_customer(context[:customer_id])
+    scope = records.where_customer(context[:customer_id])
     scope = scope.where_account(context[:allowed_account_ids]) if context[:allowed_account_ids].present?
     scope
   end

--- a/app/resources/api/rest/customer/v1/chart_active_call_resource.rb
+++ b/app/resources/api/rest/customer/v1/chart_active_call_resource.rb
@@ -2,7 +2,7 @@
 
 class Api::Rest::Customer::V1::ChartActiveCallResource < Api::Rest::Customer::V1::BaseResource
   model_name 'JsonapiModel::ActiveCallAccount'
-  key_type :uuid
+  primary_key :id
 
   before_replace_fields do
     _model.customer = context[:current_customer].customer

--- a/app/resources/api/rest/customer/v1/chart_originated_cp_resource.rb
+++ b/app/resources/api/rest/customer/v1/chart_originated_cp_resource.rb
@@ -2,7 +2,7 @@
 
 class Api::Rest::Customer::V1::ChartOriginatedCpResource < Api::Rest::Customer::V1::BaseResource
   model_name 'JsonapiModel::OriginatedCps'
-  key_type :uuid
+  primary_key :id
 
   before_replace_fields do
     _model.customer = context[:current_customer].customer

--- a/app/resources/api/rest/customer/v1/check_rate_resource.rb
+++ b/app/resources/api/rest/customer/v1/check_rate_resource.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::CheckRateResource < BaseResource
+class Api::Rest::Customer::V1::CheckRateResource < Api::Rest::Customer::V1::BaseResource
   singleton
   model_name 'JsonapiModel::CheckRate'
-
-  key_type :uuid
+  primary_key :id
 
   attributes :rateplan_id, :number, :rates
 end

--- a/app/resources/api/rest/customer/v1/invoice_resource.rb
+++ b/app/resources/api/rest/customer/v1/invoice_resource.rb
@@ -32,6 +32,8 @@ class Api::Rest::Customer::V1::InvoiceResource < Api::Rest::Customer::V1::BaseRe
   ransack_filter :first_successful_call_at, type: :datetime
   ransack_filter :last_successful_call_at, type: :datetime
 
+  association_uuid_filter :account_id, class_name: 'Account'
+
   def has_pdf
     _model.invoice_document&.pdf_data.present?
   end

--- a/app/resources/api/rest/customer/v1/invoice_resource.rb
+++ b/app/resources/api/rest/customer/v1/invoice_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::InvoiceResource < BaseResource
+class Api::Rest::Customer::V1::InvoiceResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Billing::Invoice'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :reference,
              :start_date,
@@ -38,11 +34,6 @@ class Api::Rest::Customer::V1::InvoiceResource < BaseResource
 
   def has_pdf
     _model.invoice_document&.pdf_data.present?
-  end
-
-  def self.records(options = {})
-    records = super(options)
-    apply_allowed_accounts(records, options)
   end
 
   def self.apply_allowed_accounts(records, options)

--- a/app/resources/api/rest/customer/v1/network_prefix_resource.rb
+++ b/app/resources/api/rest/customer/v1/network_prefix_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::NetworkPrefixResource < BaseResource
+class Api::Rest::Customer::V1::NetworkPrefixResource < Api::Rest::Customer::V1::BaseResource
   model_name 'System::NetworkPrefix'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :prefix,
              :number_min_length,

--- a/app/resources/api/rest/customer/v1/network_resource.rb
+++ b/app/resources/api/rest/customer/v1/network_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::NetworkResource < BaseResource
+class Api::Rest::Customer::V1::NetworkResource < Api::Rest::Customer::V1::BaseResource
   model_name 'System::Network'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :name
 

--- a/app/resources/api/rest/customer/v1/network_type_resource.rb
+++ b/app/resources/api/rest/customer/v1/network_type_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::NetworkTypeResource < BaseResource
+class Api::Rest::Customer::V1::NetworkTypeResource < Api::Rest::Customer::V1::BaseResource
   model_name 'System::NetworkType'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :name
 

--- a/app/resources/api/rest/customer/v1/rate_resource.rb
+++ b/app/resources/api/rest/customer/v1/rate_resource.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::RateResource < BaseResource
+class Api::Rest::Customer::V1::RateResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Routing::Destination'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :prefix,
              :initial_rate,
@@ -43,10 +39,6 @@ class Api::Rest::Customer::V1::RateResource < BaseResource
   ransack_filter :dst_number_min_length, type: :number
   ransack_filter :dst_number_max_length, type: :number
   ransack_filter :reverse_billing, type: :boolean
-
-  def self.records(options = {})
-    apply_allowed_accounts(super(options), options)
-  end
 
   def self.apply_allowed_accounts(_records, options)
     context = options[:context]

--- a/app/resources/api/rest/customer/v1/rateplan_resource.rb
+++ b/app/resources/api/rest/customer/v1/rateplan_resource.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::RateplanResource < BaseResource
+class Api::Rest::Customer::V1::RateplanResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Routing::Rateplan'
-
-  key_type :uuid
-  primary_key :uuid
-  paginator :paged
 
   attributes :name
 
   ransack_filter :name, type: :string
-
-  def self.records(options = {})
-    apply_allowed_accounts(super(options), options)
-  end
 
   def self.apply_allowed_accounts(records, options)
     context = options[:context]

--- a/app/resources/api/rest/customer/v1/transport_protocol_resource.rb
+++ b/app/resources/api/rest/customer/v1/transport_protocol_resource.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
-class Api::Rest::Customer::V1::TransportProtocolResource < BaseResource
+class Api::Rest::Customer::V1::TransportProtocolResource < Api::Rest::Customer::V1::BaseResource
   model_name 'Equipment::TransportProtocol'
+  primary_key :id
+  key_type :integer
+  paginator :none
 
   attributes :name
 end


### PR DESCRIPTION
* customer v1 api invoices add filters: account_id_eq, account_id_not_eq, account_id_in, account_id_not_in
* DRY customer v1 api resources

fixes #1037 