### PR TITLE
CI: change nightly version scheme from +0, +1 etc to +nightly0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ exclude_files :=	config/database.yml \
 			*.o \
 			*.a
 
-version = $(shell git describe --tags --exact 2>/dev/null || { git describe --tags | sed -E 's/-([0-9]+)-[^-]*$$/+\1/'; })
+version = $(shell ./ci/gen_version.sh)
 debian_version = $(shell echo $(version) | sed 's/_/~/' | sed 's/-master/~master/' | sed 's/-rc/~rc/')-1
 commit = $(shell git rev-parse HEAD)
 

--- a/ci/gen_version.sh
+++ b/ci/gen_version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if git describe --tags --exact &>/dev/null; then
+	git describe --tags --exact | sed 's/$/+nightly0/'
+else
+	git describe --tags | sed -E 's/-([0-9]+)-[^-]*$/+nightly\1/'
+fi


### PR DESCRIPTION
Nightly version for a tagged commit is the tag without changes
which collides with release package. Since nightly package builds
are launched on every push to master, quick github release right after merge
creates condition when 2 different packages with the same version
are pushed into the repo