### PR TITLE
Improve error reporting on parralel nodes rpc call exception

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -129,28 +129,4 @@ class Node < ApplicationRecord
       RealtimeData::ActiveCall.collection(api.calls)
     end
   end
-
-  # @param nodes [Array<Node>,nil] omit or pass nil to use all nodes.
-  # @param default [Object] value when error came (default empty array).
-  # @yield in thread for each node
-  # @yieldparam node [Node]
-  # @return [Array] flatten array of data returned by all threads.
-  # @example Usage
-  #
-  #   rows = Node.perform_parallel(default: []) do |node|
-  #     result = node.api.sip_options_probers
-  #     result.map { |row| row.merge(node: node) }
-  #   end
-  #
-  def self.perform_parallel(nodes = nil, default: [], &block)
-    nodes ||= all.to_a
-
-    data = Parallel.map(nodes, in_threads: nodes.size) do |node|
-      block.call(node)
-    rescue NodeApi::Error => e
-      Rails.logger.error { "#{e.class}: #{e.message}" }
-      default
-    end
-    data.flatten
-  end
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -102,9 +102,16 @@ class Node < ApplicationRecord
 
     begin
       api.public_send(method_name, *args.flatten)
+    rescue NodeApi::ConnectionError => e
+      if empty_on_error
+        logger.warn { "#{e.class} #{e.message}" }
+        []
+      else
+        raise e
+      end
     rescue StandardError => e
       if empty_on_error
-        logger.warn { e.message }
+        logger.warn { "#{e.class} #{e.message}" }
         logger.warn { e.backtrace.join '\n' }
         CaptureError.capture(e)
         []

--- a/app/models/realtime_data/sip_options_prober.rb
+++ b/app/models/realtime_data/sip_options_prober.rb
@@ -16,12 +16,11 @@ class RealtimeData::SipOptionsProber < YetiResource
     end
 
     def query_builder_collection(**_)
-      result = Node.perform_parallel(default: []) do |node|
+      result = NodeParallelRpc.call(default: [], default_on_error: true) do |node|
         result = node.api.sip_options_probers
         result.map { |row| row.merge(node: node) }
       end
-      records = result.map { |item| RealtimeData::SipOptionsProber.new(item) }
-      records
+      result.map { |item| RealtimeData::SipOptionsProber.new(item) }
     end
   end
 

--- a/app/models/yeti/rpc_calls/base.rb
+++ b/app/models/yeti/rpc_calls/base.rb
@@ -89,7 +89,7 @@ module Yeti
       end
 
       def parallel_nodes
-        Parallel.map(nodes, in_threads: nodes.size) { |node| yield(node) }
+        NodeParallelRpc.call(nodes: nodes) { |node| yield(node) }
       end
     end
   end

--- a/app/services/node_parallel_rpc.rb
+++ b/app/services/node_parallel_rpc.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class NodeParallelRpc
+  Error = Class.new(StandardError)
+
+  class << self
+    def call(nodes: nil, default: nil, default_on_error: false, &block)
+      new(nodes).call(default: default, default_on_error: default_on_error, &block)
+    end
+  end
+
+  # @param nodes [Array<Node>,nil] omit or pass nil to use all nodes.
+  def initialize(nodes = nil)
+    @nodes = nodes || Node.all.to_a
+  end
+
+  # @param default [Object] value when error came (default empty array).
+  # @yield in thread for each node
+  # @yieldparam node [Node]
+  # @return [Array] flatten array of data returned by all threads.
+  # @example Usage
+  #
+  #   rows = NodeParallelRpc.call(default: []) do |node|
+  #     result = node.api.sip_options_probers
+  #     result.map { |row| row.merge(node: node) }
+  #   end
+  #
+  def call(default: [], default_on_error: false, &block)
+    data = Parallel.map(@nodes, in_threads: @nodes.size) do |node|
+      if default_on_error
+        safe_process_node(node, default, &block)
+      else
+        process_node(node, &block)
+      end
+    end
+    data.flatten
+  rescue StandardError => e
+    # Here we capture error from thread created by Parallel and raise new one,
+    # because original exception will not have useful information, like where it were called.
+    CaptureError.log_error(e)
+    raise Error, "Caught #{e.class} #{e.message}"
+  end
+
+  private
+
+  def process_node(node)
+    yield node
+  end
+
+  def safe_process_node(node, default)
+    yield node
+  rescue NodeApi::Error => e
+    Rails.logger.error { "#{e.class}: #{e.message}" }
+    default
+  end
+end

--- a/lib/capture_error.rb
+++ b/lib/capture_error.rb
@@ -139,6 +139,18 @@ module CaptureError
       exception.instance_variable_set(EXCEPTION_CTX_VAR_NAME, context)
     end
 
+    def log_error(error, skip_backtrace: false)
+      Rails.logger.error do
+        msg = ["<#{error.class}>: #{error.message}"]
+        msg.concat(error.backtrace) unless skip_backtrace
+        msg.join("\n")
+      end
+      if error.cause && error.cause != error
+        Rails.logger.error { 'caused by:' }
+        log_error(error.cause, skip_backtrace: skip_backtrace)
+      end
+    end
+
     private
 
     def with_capture_context(context, exception: nil)

--- a/lib/capture_error/base_methods.rb
+++ b/lib/capture_error/base_methods.rb
@@ -40,15 +40,7 @@ module CaptureError
     end
 
     def log_error(error, skip_backtrace: false)
-      Rails.logger.error do
-        msg = ["<#{error.class}>: #{error.message}"]
-        msg.concat(error.backtrace) unless skip_backtrace
-        msg.join("\n")
-      end
-      if error.cause && error.cause != error
-        Rails.logger.error { 'caused by:' }
-        log_error(error.cause, skip_backtrace: skip_backtrace)
-      end
+      CaptureError.log_error(error, skip_backtrace: skip_backtrace)
     end
   end
 end

--- a/spec/features/realtime_data/active_calls/index_spec.rb
+++ b/spec/features/realtime_data/active_calls/index_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Active Calls Index', js: true do
   include_context :stub_parallel_map
 
   let(:visit_params) { nil }
+  let(:filter_records!) { nil }
   let(:stub_jrpc_show_calls!) do
     stub_jrpc_request(node.rpc_endpoint, 'yeti.show.calls', []).and_return(
       calls_attributes.map(&:stringify_keys)
@@ -124,14 +125,33 @@ RSpec.describe 'Active Calls Index', js: true do
   end
 
   context 'without filters' do
-    let(:visit_params) { {} }
     let(:stub_jrpc_show_calls!) { nil }
-    let(:filter_records!) { nil }
 
     it 'renders no table' do
       subject
       expect(page).to have_page_title('Active Calls')
       expect(page).to have_selector('.blank_slate', text: 'Please, specify at least 1 filter')
+      expect(page).to_not have_flash_message(type: :error)
+      expect(page).to_not have_flash_message(type: :warning)
+      expect(page).to_not have_table
+    end
+  end
+
+  context 'when connection failed' do
+    let(:filter_records!) do
+      within_filters do
+        fill_in_chosen 'Node', with: node.name
+        click_submit('Filter')
+      end
+    end
+    let(:stub_jrpc_show_calls!) do
+      stub_jrpc_connect_error(node.rpc_endpoint)
+    end
+
+    it 'renders no table' do
+      subject
+      expect(page).to have_page_title('Active Calls')
+      expect(page).to have_selector('.blank_slate', text: 'No Active Calls found')
       expect(page).to_not have_flash_message(type: :error)
       expect(page).to_not have_flash_message(type: :warning)
       expect(page).to_not have_table

--- a/spec/features/realtime_data/active_calls/index_spec.rb
+++ b/spec/features/realtime_data/active_calls/index_spec.rb
@@ -156,5 +156,12 @@ RSpec.describe 'Active Calls Index', js: true do
       expect(page).to_not have_flash_message(type: :warning)
       expect(page).to_not have_table
     end
+
+    include_examples :does_not_capture_error do
+      let(:does_not_capture_error_subject) do
+        subject
+        expect(page).to have_page_title('Active Calls')
+      end
+    end
   end
 end

--- a/spec/support/examples/does_not_capture_error.rb
+++ b/spec/support/examples/does_not_capture_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples :does_not_capture_error do |safe: false|
+  let(:does_not_capture_error_subject) do
+    safe ? safe_subject : subject
+  end
+
+  it 'captures exception' do
+    expect(CaptureError).not_to receive(:capture)
+    does_not_capture_error_subject
+  end
+end


### PR DESCRIPTION
* encapsulate all Node parallel rpc calls into service, reraise exception when it occurred in Parallel thread
* ensure Realtime Data Active Calls works properly when node is down
* do not send sentry error when node api respond with NodeApi::ConnectionError during safe calls fetching