### PR TITLE
fix api docs response body

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,9 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'parallel_tests'
   gem 'rspec-rails'
-  gem 'rspec_api_documentation', '~> 5.0.0'
+  # https://github.com/zipmark/rspec_api_documentation/pull/458
+  # present only on master
+  gem 'rspec_api_documentation', github: 'zipmark/rspec_api_documentation'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,15 @@ GIT
       nokogiri (>= 1.5.0)
       rubyzip (~> 1.2)
 
+GIT
+  remote: https://github.com/zipmark/rspec_api_documentation.git
+  revision: d3892cc7388460a98476734963face5a7a2ac158
+  specs:
+    rspec_api_documentation (6.1.0)
+      activesupport (>= 3.0.0)
+      mustache (~> 1.0, >= 0.99.4)
+      rspec (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -399,7 +408,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.4.2)
-    mustache (1.0.5)
+    mustache (1.1.1)
     net-ldap (0.16.1)
     netstring (0.0.3)
     nio4r (2.5.8)
@@ -497,10 +506,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rspec_api_documentation (5.0.0)
-      activesupport (>= 3.0.0)
-      mustache (~> 1.0, >= 0.99.4)
-      rspec (~> 3.0)
     rubocop (0.84.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -677,7 +682,7 @@ DEPENDENCIES
   ransack
   responders
   rspec-rails
-  rspec_api_documentation (~> 5.0.0)
+  rspec_api_documentation!
   rubocop
   rubocop-performance
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -199,6 +199,16 @@ RspecApiDocumentation.configure do |config|
     c.docs_dir = Rails.root.join 'doc/api/customer/v1'
     c.api_name = 'Customer API V2'
   end
+
+  config.response_body_formatter = proc do |content_type, response_body|
+    if %r{application/.*json}.match?(content_type)
+      JSON.pretty_generate(JSON.parse(response_body))
+    elsif response_body.encoding == Encoding::ASCII_8BIT
+      '[binary data]'
+    else
+      response_body
+    end
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
were always `[binary data]` after upgrade rack

see https://github.com/zipmark/rspec_api_documentation/issues/456