### PR TITLE
CI: allow ip6 in pgsql image

### DIFF
--- a/ci/pg11.Dockerfile
+++ b/ci/pg11.Dockerfile
@@ -36,7 +36,8 @@ RUN	sed -Ei "/^#?listen_addresses +=/s/.*/listen_addresses = '*'/"		"$PGCONFIG" 
 	sed -Ei "/^#?ssl +=/s/.*/ssl = off/"					"$PGCONFIG" && \
 	sed -Ei "/^#?autovacuum +=/s/.*/autovacuum = off/"			"$PGCONFIG" && \
 	cat "$PGCONFIG" && \
-	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
+	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf && \
+	echo "host all all ::/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
 
 EXPOSE 5432
 USER postgres:postgres

--- a/ci/pg12.Dockerfile
+++ b/ci/pg12.Dockerfile
@@ -33,7 +33,8 @@ RUN	sed -Ei "/^#?listen_addresses +=/s/.*/listen_addresses = '*'/"		"$PGCONFIG" 
 	sed -Ei "/^#?ssl +=/s/.*/ssl = off/"					"$PGCONFIG" && \
 	sed -Ei "/^#?autovacuum +=/s/.*/autovacuum = off/"			"$PGCONFIG" && \
 	cat "$PGCONFIG" && \
-	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
+	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf && \
+	echo "host all all ::/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
 
 EXPOSE 5432
 USER postgres:postgres

--- a/ci/pg13.Dockerfile
+++ b/ci/pg13.Dockerfile
@@ -33,7 +33,8 @@ RUN	sed -Ei "/^#?listen_addresses +=/s/.*/listen_addresses = '*'/"		"$PGCONFIG" 
 	sed -Ei "/^#?ssl +=/s/.*/ssl = off/"					"$PGCONFIG" && \
 	sed -Ei "/^#?autovacuum +=/s/.*/autovacuum = off/"			"$PGCONFIG" && \
 	cat "$PGCONFIG" && \
-	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
+	echo "host all all 0.0.0.0/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf && \
+	echo "host all all ::/0 trust" >> /etc/postgresql/$PGVER/main/pg_hba.conf
 
 EXPOSE 5432
 USER postgres:postgres


### PR DESCRIPTION
some ci environments that use these images enable ip6 for containers