### PR TITLE
fix admin UI background_tasks with Importing::ImportingDelayedJob

### DIFF
--- a/app/decorators/background_task_decorator.rb
+++ b/app/decorators/background_task_decorator.rb
@@ -5,10 +5,14 @@ class BackgroundTaskDecorator < Draper::Decorator
   decorates BackgroundTask
 
   def name
+    return model.payload_object.class.name unless model.payload_object.respond_to?(:job_data)
+
     model.payload_object.job_data['job_class']
   end
 
   def args
+    return '-' unless model.payload_object.respond_to?(:job_data)
+
     model.payload_object.job_data['arguments'].join("\n,")
   end
 

--- a/spec/features/system/background_tasks/index_background_task_spec.rb
+++ b/spec/features/system/background_tasks/index_background_task_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe 'Index System Background Tasks', type: :feature do
 
   include_context :login_as_admin
 
+  let!(:importing_task) do
+    allow(GuiConfig).to receive(:import_max_threads).and_return(1)
+    Importing::ImportingDelayedJob.create_jobs(Importing::Rateplan, controller_info: { ip: '127.0.0.1' })
+    BackgroundTask.last!
+  end
+
   let!(:background_tasks) do
     active_jobs = with_real_active_job_adapter do
       [
@@ -28,5 +34,6 @@ RSpec.describe 'Index System Background Tasks', type: :feature do
     background_tasks.each do |background_task|
       expect(page).to have_css('.resource_id_link', text: background_task.id)
     end
+    expect(page).to have_css('.resource_id_link', text: importing_task.id)
   end
 end

--- a/spec/features/system/background_tasks/show_spec.rb
+++ b/spec/features/system/background_tasks/show_spec.rb
@@ -71,4 +71,19 @@ RSpec.describe 'Show System Background Task', type: :feature do
 
     include_examples :responds_successfully
   end
+
+  context 'with Importing::ImportingDelayedJob' do
+    let!(:background_task) do
+      allow(GuiConfig).to receive(:import_max_threads).and_return(1)
+      Importing::ImportingDelayedJob.create_jobs(Importing::Rateplan, controller_info: { ip: '127.0.0.1' })
+      BackgroundTask.last!
+    end
+
+    it 'responds successfully' do
+      subject
+      expect(page).to have_attribute_row('ID', exact_text: background_task.id)
+      expect(page).to have_attribute_row('name', exact_text: 'Importing::ImportingDelayedJob')
+      expect(page).to have_attribute_row('args', exact_text: '-')
+    end
+  end
 end


### PR DESCRIPTION
```
ActionView::Template::Error (undefined method job_data' for #<Importing::ImportingDelayedJob:0x00007fdf896e5440>):
[8b4fb2db-920f-4187-890c-cbae46bed590]     1: insert_tag renderer_for(:index)
[8b4fb2db-920f-4187-890c-cbae46bed590]   
[8b4fb2db-920f-4187-890c-cbae46bed590] app/decorators/background_task_decorator.rb:8:in name'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:142:in public_send'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:142:in render_data'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:134:in block in build_table_cell'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:133:in build_table_cell'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:59:in block (2 levels) in column'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:58:in block in column'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:57:in column'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/index_as_table.rb:38:in column'
[8b4fb2db-920f-4187-890c-cbae46bed590] app/admin/system/background_tasks.rb:18:in block (2 levels) in <main>'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/index_as_table.rb:62:in instance_exec'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/index_as_table.rb:62:in block in build'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/components/table_for.rb:30:in build'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/index_as_table.rb:21:in table_for'
[8b4fb2db-920f-4187-890c-cbae46bed590] lib/active_admin/views/index_as_table.rb:60:in build'
[8b4fb2db-920f-4187-890c-cbae46bed590] config/initializers/instrumentation_notification.rb:32:in block in process_action'
[8b4fb2db-920f-4187-890c-cbae46bed590] config/initializers/instrumentation_notification.rb:31:in process_action'
```