### PR TITLE
fix vulnerability puma CVE-2022-24790

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,7 +429,7 @@ GEM
     pgq_prometheus (0.2.3)
       prometheus_exporter
     public_suffix (4.0.6)
-    puma (5.6.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
Name: puma
Version: 5.6.2
CVE: CVE-2022-24790
GHSA: GHSA-h99w-9q5r-gjq9
Criticality: Unknown
URL: https://github.com/puma/puma/security/advisories/GHSA-h99w-9q5r-gjq9
Title: HTTP Request Smuggling in puma
Solution: upgrade to ~> 4.3.12, >= 5.6.4