### PR TITLE
CdrExport add time_start_lt filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
     net-ldap (0.16.1)
     netstring (0.0.3)
     nio4r (2.5.8)
-    nokogiri (1.13.2)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.11.2)

--- a/app/admin/cdr/cdr_exports.rb
+++ b/app/admin/cdr/cdr_exports.rb
@@ -97,7 +97,8 @@ ActiveAdmin.register CdrExport, as: 'CDR Export' do
     end
   end
 
-  permit_params filters: CdrExport::FiltersModel.attribute_types.keys.map(&:to_sym),
+  permit_params :callback_url,
+                filters: CdrExport::FiltersModel.attribute_types.keys.map(&:to_sym),
                 fields: []
 
   form do |f|
@@ -118,7 +119,8 @@ ActiveAdmin.register CdrExport, as: 'CDR Export' do
       boolean_options = [['Any', nil], ['Yes', true], ['No', false]]
 
       ff.input :time_start_gteq, as: :date_time_picker, required: true
-      ff.input :time_start_lteq, as: :date_time_picker, required: true
+      ff.input :time_start_lteq, as: :date_time_picker, required: false
+      ff.input :time_start_lt, as: :date_time_picker, required: false
 
       ff.contractor_input :customer_id_eq,
                           label: 'Customer id eq',

--- a/app/models/cdr_export.rb
+++ b/app/models/cdr_export.rb
@@ -22,6 +22,7 @@ class CdrExport < ApplicationRecord
   class FiltersModel < JsonAttributeModel
     attribute :time_start_gteq, :db_datetime
     attribute :time_start_lteq, :db_datetime
+    attribute :time_start_lt, :db_datetime
     attribute :customer_id_eq, :integer
     attribute :customer_external_id_eq, :integer
     attribute :customer_acc_id_eq, :integer
@@ -65,7 +66,7 @@ class CdrExport < ApplicationRecord
 
   # need for activeadmin form
   attr_accessor :customer_acc_id_eq,
-                :is_last_cdr_eq, :time_start_gteq, :time_start_lteq
+                :is_last_cdr_eq, :time_start_gteq, :time_start_lteq, :time_start_lt
 
   json_attribute :filters, class_name: 'CdrExport::FiltersModel'
 
@@ -76,8 +77,12 @@ class CdrExport < ApplicationRecord
       errors.add(:filters, message)
     end
 
-    if filters.time_start_gteq.nil? || filters.time_start_lteq.nil?
-      errors.add(:filters, 'requires time_start_lteq & time_start_gteq')
+    if filters.time_start_gteq.nil?
+      errors.add(:filters, 'requires time_start_gteq')
+    end
+
+    if filters.time_start_lt.nil? && filters.time_start_lteq.nil?
+      errors.add(:filters, 'requires time_start_lteq')
     end
   end
   validate do

--- a/app/resources/api/rest/admin/cdr/cdr_resource.rb
+++ b/app/resources/api/rest/admin/cdr/cdr_resource.rb
@@ -199,12 +199,6 @@ class Api::Rest::Admin::Cdr::CdrResource < BaseResource
     end
     _scope
   }
-  filter :time_start_gteq, apply: lambda { |records, values, _options|
-    records.where('time_start >= ?', values[0])
-  }
-  filter :time_start_lteq, apply: lambda { |records, values, _options|
-    records.where('time_start <= ?', values[0])
-  }
   filter :customer_acc_external_id_eq, apply: lambda { |records, values, _options|
     records.where(customer_acc_external_id: values)
   }

--- a/lib/active_admin/inputs/date_time_picker_input.rb
+++ b/lib/active_admin/inputs/date_time_picker_input.rb
@@ -6,9 +6,9 @@ module ActiveAdmin
       val = object.public_send(input_name || method)
       if val.blank?
         val
-      elsif column.type == :date
+      elsif column&.type == :date || val.is_a?(Date)
         val
-      elsif column.type == :string
+      elsif column&.type == :string || val.is_a?(String)
         begin
           DateTime.parse(val).strftime(format)
         rescue StandardError

--- a/spec/acceptance/rest/admin/api/cdr/cdr_exports_spec.rb
+++ b/spec/acceptance/rest/admin/api/cdr/cdr_exports_spec.rb
@@ -24,8 +24,9 @@ RSpec.resource 'Cdr Exports' do
     let(:fields) { %w[id success] }
     let(:filters) do
       {
-        time_start_gteq: '2018-01-01',
-        time_start_lteq: '2018-01-02',
+        time_start_gteq: '2018-01-01 00:00:00',
+        time_start_lteq: '2018-01-01 23:59:59.999999',
+        time_start_lt: '2018-01-02 00:00:00',
         customer_id_eq: 1234,
         customer_external_id_eq: 1235,
         customer_acc_id_eq: 1236,

--- a/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
+++ b/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
@@ -31,25 +31,23 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(page).to have_current_path cdr_export_path(cdr_export)
 
       expect(cdr_export).to have_attributes(
-        callback_url: nil,
+        callback_url: '',
         fields: %w[id success],
         status: 'Pending',
-        filters: CdrExport::FiltersModel.new(
-          'time_start_gteq' => '2018-01-01',
-          'time_start_lteq' => '2018-03-01',
-          'customer_acc_id_eq' => account.id.to_s,
-          'src_prefix_in_contains' => '',
-          'src_prefix_routing_contains' => '',
-          'src_prefix_out_contains' => '',
-          'dst_prefix_in_contains' => '',
-          'dst_prefix_routing_contains' => '',
-          'dst_prefix_out_contains' => '',
-          'src_country_id_eq' => '',
-          'dst_country_id_eq' => '',
-          'routing_tag_ids_include' => '',
-          'routing_tag_ids_exclude' => ''
-        )
+        filters: a_kind_of(CdrExport::FiltersModel)
       )
+      filters = cdr_export.filters.as_json.symbolize_keys
+      expect(filters).to match(
+          time_start_gteq: '2018-01-01T00:00:00.000Z',
+          time_start_lteq: '2018-03-01T00:00:00.000Z',
+          customer_acc_id_eq: account.id,
+          src_prefix_in_contains: '',
+          src_prefix_routing_contains: '',
+          src_prefix_out_contains: '',
+          dst_prefix_in_contains: '',
+          dst_prefix_routing_contains: '',
+          dst_prefix_out_contains: ''
+        )
     end
   end
 
@@ -71,25 +69,23 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(page).to have_current_path cdr_export_path(cdr_export)
 
       expect(cdr_export).to have_attributes(
-        callback_url: nil,
+        callback_url: '',
         fields: %w[id customer_id success],
         status: 'Pending',
-        filters: CdrExport::FiltersModel.new(
-          'time_start_gteq' => '2018-01-01',
-          'time_start_lteq' => '2018-03-01',
-          'customer_acc_id_eq' => account.id.to_s,
-          'src_prefix_in_contains' => '',
-          'src_prefix_routing_contains' => '',
-          'src_prefix_out_contains' => '',
-          'dst_prefix_in_contains' => '',
-          'dst_prefix_routing_contains' => '',
-          'dst_prefix_out_contains' => '',
-          'src_country_id_eq' => '',
-          'dst_country_id_eq' => '',
-          'routing_tag_ids_include' => '',
-          'routing_tag_ids_exclude' => ''
-        )
+        filters: a_kind_of(CdrExport::FiltersModel)
       )
+      filters = cdr_export.filters.as_json.symbolize_keys
+      expect(filters).to match(
+          time_start_gteq: '2018-01-01T00:00:00.000Z',
+          time_start_lteq: '2018-03-01T00:00:00.000Z',
+          customer_acc_id_eq: account.id,
+          src_prefix_in_contains: '',
+          src_prefix_routing_contains: '',
+          src_prefix_out_contains: '',
+          dst_prefix_in_contains: '',
+          dst_prefix_routing_contains: '',
+          dst_prefix_out_contains: ''
+        )
     end
   end
 
@@ -139,6 +135,7 @@ RSpec.describe 'Create new CDR export', js: true do
         fill_in_chosen 'Term gw id eq', with: "#{gateway2.name} | #{gateway2.id}"
         fill_in 'Time start gteq', with: '2018-01-01'
         fill_in 'Time start lteq', with: '2018-03-01'
+        fill_in 'Time start lt', with: '2018-03-01', exact: true
 
         # all allowed filters must be filled in this test.
         CdrExport::FiltersModel.attribute_types.each_key do |filter_key|
@@ -160,7 +157,7 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(page).to have_current_path cdr_export_path(cdr_export)
 
       expect(cdr_export).to have_attributes(
-                              callback_url: nil,
+                              callback_url: '',
                               fields: %w[id success],
                               status: 'Pending',
                               filters: a_kind_of(CdrExport::FiltersModel)
@@ -169,6 +166,7 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(filters).to match(
                            time_start_gteq: '2018-01-01T00:00:00.000Z',
                            time_start_lteq: '2018-03-01T00:00:00.000Z',
+                           time_start_lt: '2018-03-01T00:00:00.000Z',
                            customer_external_id_eq: 1231,
                            customer_id_eq: customer.id,
                            customer_acc_external_id_eq: 1232,
@@ -201,6 +199,43 @@ RSpec.describe 'Create new CDR export', js: true do
     end
   end
 
+  context 'with filter time_start_lt' do
+    before do
+      visit new_cdr_export_path
+
+      fill_in_chosen 'Fields', with: 'success', multiple: true
+      fill_in_chosen 'Fields', with: 'id', multiple: true, exact: true
+      fill_in 'Time start gteq', with: '2018-01-01'
+      fill_in 'Time start lt', with: '2018-03-01', exact: true
+    end
+
+    it 'cdr export should be created' do
+      subject
+      expect(page).to have_text('Cdr export was successfully created.')
+
+      cdr_export = CdrExport.last!
+      expect(page).to have_current_path cdr_export_path(cdr_export)
+
+      expect(cdr_export).to have_attributes(
+                              callback_url: '',
+                              fields: %w[id success],
+                              status: 'Pending',
+                              filters: a_kind_of(CdrExport::FiltersModel)
+                            )
+      filters = cdr_export.filters.as_json.symbolize_keys
+      expect(filters).to match(
+                           time_start_gteq: '2018-01-01T00:00:00.000Z',
+                           time_start_lt: '2018-03-01T00:00:00.000Z',
+                           src_prefix_in_contains: '',
+                           src_prefix_routing_contains: '',
+                           src_prefix_out_contains: '',
+                           dst_prefix_in_contains: '',
+                           dst_prefix_routing_contains: '',
+                           dst_prefix_out_contains: ''
+                         )
+    end
+  end
+
   context 'with incorrect filters' do
     before do
       visit new_cdr_export_path
@@ -211,7 +246,27 @@ RSpec.describe 'Create new CDR export', js: true do
 
     it 'should rise semantic error' do
       subject
-      expect(page).to have_semantic_error('Filters can\'t be blank and requires time_start_lteq & time_start_gteq')
+      expect(page).to have_semantic_errors(count: 1)
+      expect(page).to have_semantic_error(
+                        'Filters can\'t be blank, requires time_start_gteq, and requires time_start_lteq'
+                      )
+    end
+  end
+
+  context 'without fields' do
+    before do
+      visit new_cdr_export_path
+
+      fill_in 'Time start gteq', with: '2018-01-01'
+      fill_in 'Time start lteq', with: '2018-03-01', exact: true
+    end
+
+    it 'should rise semantic error' do
+      subject
+      expect(page).to have_semantic_errors(count: 1)
+      expect(page).to have_semantic_error(
+                        'Fields can\'t be blank'
+                      )
     end
   end
 end

--- a/spec/jobs/worker/cdr_export_job_spec.rb
+++ b/spec/jobs/worker/cdr_export_job_spec.rb
@@ -4,30 +4,42 @@ RSpec.describe Worker::CdrExportJob, type: :job do
   subject do
     described_class.perform_now(cdr_export.id)
   end
+
   let!(:cdr_export) do
-    FactoryBot.create(:cdr_export, callback_url: callback_url)
+    FactoryBot.create(:cdr_export, cdr_export_attrs)
+  end
+  let(:cdr_export_attrs) do
+    { callback_url: callback_url }
   end
   let(:callback_url) { nil }
 
-  it 'SQL request copy to CSV should be performed' do
-    cdr_connection = double(:cdr_connection)
-    expect(Cdr::Cdr).to receive(:connection).and_return(cdr_connection)
-    # let's say this SQL should be performed
-    # valid SQL will be tested in model spec
-    export_sql = 'SELECT * FROM cdr.cdr'
-    expect_any_instance_of(CdrExport).to receive(:export_sql).and_return(export_sql)
-    expect(cdr_connection).to receive(:execute).with("COPY (#{export_sql}) TO PROGRAM 'gzip > /tmp/#{cdr_export.id}.csv.gz' WITH (FORMAT CSV, HEADER, FORCE_QUOTE *);")
-    subject
+  shared_examples :performs_cdr_export do
+    it 'SQL request copy to CSV should be performed' do
+      cdr_connection = double(:cdr_connection)
+      expect(Cdr::Cdr).to receive(:connection).and_return(cdr_connection)
+      # let's say this SQL should be performed
+      # valid SQL will be tested in model spec
+      export_sql = 'SELECT * FROM cdr.cdr'
+      expect_any_instance_of(CdrExport).to receive(:export_sql).and_return(export_sql)
+      expect(cdr_connection).to receive(:execute).with("COPY (#{export_sql}) TO PROGRAM 'gzip > /tmp/#{cdr_export.id}.csv.gz' WITH (FORMAT CSV, HEADER, FORCE_QUOTE *);")
+      subject
+    end
+
+    it 'cdr_export status should be completed' do
+      expect { subject }.to change { cdr_export.reload.status }.from(CdrExport::STATUS_PENDING).to(CdrExport::STATUS_COMPLETED)
+    end
+
+    it 'rows_count should be saved to cdr_export' do
+      allow_any_instance_of(PG::Result).to receive(:cmd_tuples).and_return(5)
+      expect { subject }.to change { cdr_export.reload.rows_count }.from(nil).to(5)
+    end
   end
 
-  it 'cdr_export status should be completed' do
-    expect { subject }.to change { cdr_export.reload.status }.from(CdrExport::STATUS_PENDING).to(CdrExport::STATUS_COMPLETED)
+  it 'ping callback dj should not be enqueued' do
+    expect { subject }.not_to have_enqueued_job(Worker::PingCallbackUrlJob)
   end
 
-  it 'rows_count should be saved to cdr_export' do
-    allow_any_instance_of(PG::Result).to receive(:cmd_tuples).and_return(5)
-    expect { subject }.to change { cdr_export.reload.rows_count }.from(nil).to(5)
-  end
+  include_examples :performs_cdr_export
 
   context 'when failure' do
     before do
@@ -39,24 +51,29 @@ RSpec.describe Worker::CdrExportJob, type: :job do
   end
 
   context 'when callback_url defined' do
-    let(:callback_url) do
-      'http://example.com/notify'
+    let(:cdr_export_attrs) do
+      super().merge callback_url: 'http://example.com/notify'
     end
+
     it 'ping callback dj should be enqueued' do
       expect { subject }.to have_enqueued_job(Worker::PingCallbackUrlJob).with(
-        callback_url,
+        cdr_export_attrs[:callback_url],
         export_id: cdr_export.id,
         status: 'Completed'
       )
     end
+
+    include_examples :performs_cdr_export
   end
 
-  context 'when callback_url not defined' do
-    let(:callback_url) do
-      nil
+  context 'when cdr_export has time_start_lt filter' do
+    let(:cdr_export_attrs) do
+      super().merge filters: {
+        time_start_gteq: '2018-01-01 00:00:00',
+        time_start_lt: '2018-03-01 00:00:00'
+      }
     end
-    it 'ping callback dj should not be enqueued' do
-      expect { subject }.not_to have_enqueued_job(Worker::PingCallbackUrlJob)
-    end
+
+    include_examples :performs_cdr_export
   end
 end

--- a/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
+++ b/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
@@ -152,6 +152,26 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrExportsController, type: :request do
       end
     end
 
+    context 'with time_start_lt' do
+      let(:json_api_request_attributes) do
+        super().merge filters: {
+          time_start_gteq: '2018-01-01T00:00:00.000Z',
+          time_start_lt: '2018-01-02T00:00:00.000Z'
+        }
+      end
+
+      include_examples :creates_cdr_export
+      include_examples :returns_json_api_record, relationships: [], status: 201 do
+        let(:json_api_record_id) { last_record.id.to_s }
+        let(:json_api_record_attributes) do
+          json_api_request_attributes.merge 'callback-url': nil,
+                                            'created-at': be_present,
+                                            'export-type': 'Base',
+                                            status: 'Pending'
+        end
+      end
+    end
+
     context 'with all allowed filters' do
       let(:json_api_request_attributes) do
         super().merge filters: {


### PR DESCRIPTION
* CdrExport add time_start_lt filter
* remove duplicated filters on /api/rest/admin/cdr/cdrs
* fix vulnerabilities nokogiri CVE-2022-24839 CVE-2022-24836 CVE-2022-23437 CVE-2018-25032

```
Name: nokogiri
Version: 1.13.2
CVE: CVE-2022-24839
GHSA: https://github.com/advisories/GHSA-gx8x-g87m-h5q6
Criticality: High
URL: [GHSA-9849-p7jc-9rmv](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv)
Title: Denial of Service (DoS) in Nokogiri on JRuby
Solution: upgrade to >= 1.13.4

Name: nokogiri
Version: 1.13.2
CVE: https://github.com/advisories/GHSA-crjr-9rc5-ghw8
GHSA: https://github.com/advisories/GHSA-crjr-9rc5-ghw8
Criticality: High
URL: [GHSA-crjr-9rc5-ghw8](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-crjr-9rc5-ghw8)
Title: Inefficient Regular Expression Complexity in Nokogiri
Solution: upgrade to >= 1.13.4

Name: nokogiri
Version: 1.13.2
CVE: https://github.com/advisories/GHSA-h65f-jvqw-m9fj
GHSA: https://github.com/advisories/GHSA-xxx9-3xcr-gjj3
Criticality: Medium
URL: [GHSA-xxx9-3xcr-gjj3](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3)
Title: XML Injection in Xerces Java affects Nokogiri
Solution: upgrade to >= 1.13.4

Name: nokogiri
Version: 1.13.2
CVE: https://github.com/advisories/GHSA-jc36-42cf-vqwj
GHSA: https://github.com/advisories/GHSA-v6gp-9mmm-c6p5
Criticality: High
URL: [GHSA-v6gp-9mmm-c6p5](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5)
Title: Out-of-bounds Write in zlib affects Nokogiri
Solution: upgrade to >= 1.13.4
```