### PR TITLE
do not enqueue PingCallbackUrlJob when cdr export has empty string callback_url

### DIFF
--- a/app/jobs/worker/cdr_export_job.rb
+++ b/app/jobs/worker/cdr_export_job.rb
@@ -21,7 +21,7 @@ module Worker
       cdr_export.update!(status: CdrExport::STATUS_FAILED)
     ensure
       # ping callback_url
-      if cdr_export.callback_url
+      if cdr_export.callback_url.present?
         params = { export_id: cdr_export.id, status: cdr_export.status }
         PingCallbackUrlJob.perform_later(cdr_export.callback_url, params)
       end

--- a/spec/jobs/worker/cdr_export_job_spec.rb
+++ b/spec/jobs/worker/cdr_export_job_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe Worker::CdrExportJob, type: :job do
     end
   end
 
+  context 'when callback_url is an empty string' do
+    let(:callback_url) { '' }
+
+    it 'ping callback dj should not be enqueued' do
+      expect { subject }.not_to have_enqueued_job(Worker::PingCallbackUrlJob)
+    end
+
+    include_examples :performs_cdr_export
+  end
+
   context 'when callback_url defined' do
     let(:cdr_export_attrs) do
       super().merge callback_url: 'http://example.com/notify'


### PR DESCRIPTION
when cdr_export created via admin Ui form it has empty string callback_url by default