### PR TITLE
sort dialpeers.routing_tag_ids during create, edit, batch update and import  

### DIFF
--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -222,11 +222,13 @@ ActiveAdmin.register Dialpeer do
       f.input :enabled
       f.input :routing_group, input_html: { class: 'chosen' }
 
-      f.input :routing_tag_ids, as: :select,
-                                collection: DialpeerDecorator.decorate(f.object).routing_tag_options,
-                                multiple: true,
-                                include_hidden: false,
-                                input_html: { class: 'chosen' }
+      f.input :routing_tag_ids,
+              as: :select,
+              label: 'Routing tags',
+              collection: DialpeerDecorator.decorate(f.object).routing_tag_options,
+              multiple: true,
+              include_hidden: false,
+              input_html: { class: 'chosen' }
 
       f.input :routing_tag_mode
       f.contractor_input :vendor_id, label: 'Vendor'

--- a/app/lib/routing_tags_sort.rb
+++ b/app/lib/routing_tags_sort.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RoutingTagsSort
+  module_function
+
+  # @param routing_tag_ids [Array<Integer,nil>]
+  # @example
+  #
+  #   RoutingTagsSort.call [1,3,nil,2] #=> [1,2,3,nil]
+  #   RoutingTagsSort.call [1,nil,3,3,nil,2] #=> [1,2,3,nil]
+  #
+  def call(routing_tag_ids)
+    routing_tag_ids.uniq.sort do |a, b|
+      if a.nil?
+        1
+      elsif b.nil?
+        -1
+      else
+        a <=> b
+      end
+    end
+  end
+end

--- a/app/models/dialpeer.rb
+++ b/app/models/dialpeer.rb
@@ -131,6 +131,10 @@ class Dialpeer < ApplicationRecord
     end
   end
 
+  before_save do
+    self.routing_tag_ids = RoutingTagsSort.call(routing_tag_ids)
+  end
+
   before_create do
     if batch_prefix.present?
       prefixes = batch_prefix.delete(' ').split(',').uniq

--- a/app/models/importing/base.rb
+++ b/app/models/importing/base.rb
@@ -155,6 +155,7 @@ class Importing::Base < ApplicationRecord
   # Use this method for resolving:
   #   routing_tag_names => routing_tag_ids
   #   tag_action_value_names => tag_action_value
+  # Sorts routing_tag_ids in same way as RoutingTagsSort#call
   def self.resolve_array_of_tags(ids_column, names_column)
     sql = "
       UPDATE #{table_name} ta
@@ -162,12 +163,14 @@ class Importing::Base < ApplicationRecord
             SELECT id::smallint
             FROM #{Routing::RoutingTag.table_name}
             WHERE name = ANY ( string_to_array(replace(ta.#{names_column}, ', ', ',')::varchar, ',')::varchar[] )
+            ORDER BY id ASC
           )
       WHERE ta.#{ids_column} = '{}' AND ta.#{names_column} <> '';
     "
     ApplicationRecord.connection.execute(sql)
   end
 
+  # Sorts routing_tag_ids in same way as RoutingTagsSort#call
   def self.resolve_null_tag(ids_column, names_column)
     sql = "
       UPDATE #{table_name} ta

--- a/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
@@ -1,11 +1,105 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Create new Dialpeer', type: :feature do
-  include_context :login_as_admin
+RSpec.describe 'Edit Dialpeer', js: true do
+  subject do
+    visit edit_dialpeer_path(record.id)
+    fill_form!
+    submit_form!
+  end
 
-  context 'unset "Tag action value"' do
-    include_examples :test_unset_routing_tag_ids,
-                     controller_name: :dialpeers,
-                     factory: :dialpeer
+  include_context :login_as_admin
+  let(:submit_form!) do
+    click_button 'Update Dialpeer'
+  end
+
+  let!(:routing_tags) do
+    FactoryBot.create_list(:routing_tag, 5)
+  end
+  let!(:record) do
+    FactoryBot.create(:dialpeer)
+  end
+
+  context 'when nothing changed' do
+    let(:fill_form!) { nil }
+    let!(:record) do
+      FactoryBot.create(
+        :dialpeer,
+        routing_tag_ids: [routing_tags[0].id, nil],
+        # empty string applied by default when dialpeer created from admin UI
+        dst_rewrite_result: '',
+        dst_rewrite_rule: '',
+        src_name_rewrite_result: '',
+        src_name_rewrite_rule: '',
+        src_rewrite_result: '',
+        src_rewrite_rule: '',
+        # timestamps cropped to minutes when dialpeer created from admin UI
+        valid_from: 1.day.ago.change(sec: 0),
+        valid_till: 1.day.ago.change(sec: 0)
+      )
+    end
+
+    it 'does not change attributes' do
+      expect {
+        subject
+        expect(page).to have_flash_message('Dialpeer was successfully updated.', type: :notice)
+      }.not_to change {
+        record.reload.attributes
+      }
+    end
+  end
+
+  context 'with rates change' do
+    let(:fill_form!) do
+      fill_in 'Initial rate', with: '0.31'
+      fill_in 'Next rate', with: '0.72'
+    end
+
+    it 'changes rates' do
+      subject
+      expect(page).to have_flash_message('Dialpeer was successfully updated.', type: :notice)
+      expect(record.reload).to have_attributes(
+                                 initial_rate: 0.31,
+                                 next_rate: 0.72
+                               )
+    end
+  end
+
+  context 'with empty routing tags' do
+    let!(:record) do
+      FactoryBot.create(:dialpeer, routing_tag_ids: [routing_tags[2].id, nil])
+    end
+    let(:fill_form!) do
+      chosen_deselect_values 'Routing tags', values: [routing_tags[2].name, Routing::RoutingTag::ANY_TAG]
+    end
+
+    it 'changes routing tags' do
+      subject
+      expect(page).to have_flash_message('Dialpeer was successfully updated.', type: :notice)
+      expect(record.reload).to have_attributes(
+                                 routing_tag_ids: []
+                               )
+    end
+  end
+
+  context 'with filled routing tags' do
+    let(:fill_form!) do
+      fill_in_chosen 'Routing tags', with: Routing::RoutingTag::ANY_TAG, multiple: true
+      fill_in_chosen 'Routing tags', with: routing_tags[3].name, multiple: true
+      fill_in_chosen 'Routing tags', with: routing_tags[1].name, multiple: true
+      fill_in_chosen 'Routing tags', with: routing_tags[2].name, multiple: true
+    end
+
+    it 'changes routing tags' do
+      subject
+      expect(page).to have_flash_message('Dialpeer was successfully updated.', type: :notice)
+      expect(record.reload).to have_attributes(
+                                 routing_tag_ids: [
+                                   routing_tags[1].id,
+                                   routing_tags[2].id,
+                                   routing_tags[3].id,
+                                   nil
+                                 ]
+                               )
+    end
   end
 end

--- a/spec/features/routing/dialpeers/new_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/new_dialpeer_spec.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Create new Dialpeer', type: :feature, js: true do
+RSpec.describe 'Create new Dialpeer', js: true do
   subject do
-    aa_form.submit
+    visit new_dialpeer_path
+    fill_form!
+    submit_form!
   end
 
-  active_admin_form_for Dialpeer, 'new'
+  let(:submit_form!) do
+    click_button 'Create Dialpeer'
+  end
+
   include_context :login_as_admin
 
   let!(:vendor) { FactoryBot.create(:vendor, name: 'John Doe') }
@@ -13,6 +18,9 @@ RSpec.describe 'Create new Dialpeer', type: :feature, js: true do
   let!(:routing_group) { FactoryBot.create(:routing_group) }
   let!(:routeset_discriminator) { FactoryBot.create(:routeset_discriminator) }
   let!(:gateway) { FactoryBot.create(:gateway, contractor: vendor) }
+  let!(:routing_tags) do
+    FactoryBot.create_list(:routing_tag, 5)
+  end
   before do
     FactoryBot.create(:routing_group)
     FactoryBot.create(:routeset_discriminator)
@@ -21,32 +29,66 @@ RSpec.describe 'Create new Dialpeer', type: :feature, js: true do
     FactoryBot.create(:gateway, contractor: vendor_2)
     FactoryBot.create(:account, contractor: vendor)
     FactoryBot.create(:gateway, contractor: vendor)
-
-    visit new_dialpeer_path
-
-    aa_form.set_text 'Initial rate', '0.1'
-    aa_form.set_text 'Next rate', '0.2'
-    aa_form.search_chosen 'Vendor', vendor.display_name, ajax: true
-    aa_form.search_chosen 'Account', account.display_name, ajax: true
-    aa_form.select_chosen 'Routing group', routing_group.display_name
-    aa_form.select_chosen 'Routeset discriminator', routeset_discriminator.display_name
-    aa_form.select_chosen 'Gateway', gateway.display_name
+  end
+  let(:fill_form!) do
+    fill_in 'Initial rate', with: '0.1'
+    fill_in 'Next rate', with: '0.2'
+    fill_in_chosen 'Vendor', with: vendor.display_name, ajax: true
+    fill_in_chosen 'Account', with: account.display_name, ajax: true
+    fill_in_chosen 'Routing group', with: routing_group.display_name
+    fill_in_chosen 'Routeset discriminator', with: routeset_discriminator.display_name
+    fill_in_chosen 'Gateway', with: gateway.display_name
   end
 
   it 'creates record' do
-    subject
+    expect {
+      subject
+      expect(page).to have_flash_message('Dialpeer was successfully created.', type: :notice)
+    }.to change { Dialpeer.count }.by(1)
+
     record = Dialpeer.last
-    expect(record).to be_present
     expect(record).to have_attributes(
       vendor_id: vendor.id,
       account_id: account.id,
       routing_group_id: routing_group.id,
       routeset_discriminator_id: routeset_discriminator.id,
       initial_rate: 0.1,
-      next_rate: 0.2
+      next_rate: 0.2,
+      routing_tag_ids: []
     )
   end
 
-  include_examples :changes_records_qty_of, Dialpeer, by: 1
-  include_examples :shows_flash_message, :notice, 'Dialpeer was successfully created.'
+  context 'with filled routing tags' do
+    let(:fill_form!) do
+      super()
+      fill_in_chosen 'Routing tags', with: routing_tags[4].name, multiple: true
+      fill_in_chosen 'Routing tags', with: routing_tags[2].name, multiple: true
+      fill_in_chosen 'Routing tags', with: Routing::RoutingTag::ANY_TAG, multiple: true
+      fill_in_chosen 'Routing tags', with: routing_tags[0].name, multiple: true
+    end
+
+    it 'creates record' do
+      expect {
+        subject
+        expect(page).to have_flash_message('Dialpeer was successfully created.', type: :notice)
+      }.to change { Dialpeer.count }.by(1)
+
+      record = Dialpeer.last
+      expect(record).to have_attributes(
+                          vendor_id: vendor.id,
+                          account_id: account.id,
+                          routing_group_id: routing_group.id,
+                          routeset_discriminator_id: routeset_discriminator.id,
+                          initial_rate: 0.1,
+                          next_rate: 0.2,
+                          # routing_tag_ids are correctly sorted
+                          routing_tag_ids: [
+                            routing_tags[0].id,
+                            routing_tags[2].id,
+                            routing_tags[4].id,
+                            nil
+                          ]
+                        )
+    end
+  end
 end

--- a/spec/models/importing/importing_dialpeer_spec.rb
+++ b/spec/models/importing/importing_dialpeer_spec.rb
@@ -53,4 +53,31 @@ RSpec.describe Importing::Dialpeer do
 
     let(:real_item) { described_class.import_class.last }
   end
+
+  context 'when routing_tag_names filled' do
+    let!(:routing_tags) do
+      [
+        FactoryBot.create(:routing_tag, name: 'rt1'),
+        FactoryBot.create(:routing_tag, name: 'rt2')
+      ]
+    end
+    include_context :init_importing_dialpeer,
+                    prefix: '111',
+                    routing_tag_ids: [],
+                    routing_tag_names: "rt2,#{Routing::RoutingTag::ANY_TAG},rt1"
+    include_context :init_dialpeer, prefix: '111'
+
+    let(:real_item) { described_class.import_class.last }
+
+    it 'stores ordered routing_tag_ids in importing dialpeer record' do
+      expect { subject }.to change {
+        @importing_dialpeer.reload.routing_tag_ids
+      }.from([]).to(
+        # correctly sorted: rt1, rt2, ANY_TAG
+        [routing_tags[0].id, routing_tags[1].id, nil]
+      )
+    end
+
+    include_examples 'after_import_hook when real items match'
+  end
 end

--- a/spec/support/helpers/chosen.rb
+++ b/spec/support/helpers/chosen.rb
@@ -68,6 +68,15 @@ module Helpers
       chosen_node.find('abbr.search-choice-close').click
     end
 
+    def chosen_deselect_values(label, values:, exact: false)
+      select_selector = chosen_container_selector(label, exact: exact)
+      chosen_node = page.find(select_selector)
+      values.each do |value|
+        item = chosen_node.find('li.search-choice', text: value.to_s)
+        item.find('a.search-choice-close').click
+      end
+    end
+
     # Checks chosen select presence on page
     # @param label [String] field label.
     # @param options [Hash]


### PR DESCRIPTION
sorted order: ASC NULLS LAST


P.S. migration were removed by dmitry.s request - will be performed manually

```
class DialpeersSortRoutingTagIds < ActiveRecord::Migration[6.1]
  def up
    execute %q{
      CREATE OR REPLACE FUNCTION sys.array_sort (ANYARRAY)
      RETURNS ANYARRAY LANGUAGE SQL
      AS $$
      SELECT ARRAY(SELECT unnest($1) ORDER BY 1 ASC NULLS LAST)
      $$
    }

    execute %q{
      UPDATE class4.dialpeers SET routing_tag_ids = sys.array_sort(routing_tag_ids)
    }
  end

  def down
    execute %q{
      DROP FUNCTION IF EXISTS sys.array_sort (ANYARRAY)
    }
  end
end
```