### PR TITLE
fix sentry events reporting

### DIFF
--- a/lib/capture_error.rb
+++ b/lib/capture_error.rb
@@ -37,7 +37,7 @@ module CaptureError
           ActiveSupport::ParameterFilter.new(['Authorization'])
         ]
         sentry_config.before_send = lambda { |event, _hint = nil|
-          filters.each { |filter| event = filter.filter(event) }
+          filters.each { |filter| event = filter.filter(event.to_hash) }
           event
         }
 


### PR DESCRIPTION
fixes #1155

following snippet helps me to debug the problem

```ruby
require 'sentry-ruby'
require 'sentry-rails'

module SentryDebug
    def send_event(event, hint = nil)
      super
    rescue StandardError => e
      CaptureError.log_error(e)
      raise e
    end
end

Sentry::Client.prepend(SentryDebug)
```

following error appear during sending event to sentry
```
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-ruby-core-5.0.0/lib/sentry/event.rb:46:in `initialize'
/home/senid/.rvm/gems/ruby-2.7.6/gems/activesupport-6.1.6.1/lib/active_support/parameter_filter.rb:99:in `new'
/home/senid/.rvm/gems/ruby-2.7.6/gems/activesupport-6.1.6.1/lib/active_support/parameter_filter.rb:99:in `call'
/home/senid/.rvm/gems/ruby-2.7.6/gems/activesupport-6.1.6.1/lib/active_support/parameter_filter.rb:44:in `filter'
/app/lib/capture_error.rb:40:in `block (3 levels) in configure!'
/app/lib/capture_error.rb:40:in `each'
/app/lib/capture_error.rb:40:in `block (2 levels) in configure!'
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-ruby-core-5.0.0/lib/sentry/client.rb:122:in `send_event'
/app/config/initializers/sentry.rb:8:in `send_event'
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-ruby-core-5.0.0/lib/sentry/client.rb:160:in `block in dispatch_background_event'
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-rails-5.0.0/lib/sentry/rails/background_worker.rb:6:in `block in _perform'
/home/senid/.rvm/gems/ruby-2.7.6/gems/activerecord-6.1.6.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-rails-5.0.0/lib/sentry/rails/background_worker.rb:5:in `_perform'
/home/senid/.rvm/gems/ruby-2.7.6/gems/sentry-ruby-core-5.0.0/lib/sentry/background_worker.rb:54:in `block in perform'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `run_task'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:343:in `block (3 levels) in create_worker'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `loop'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block (2 levels) in create_worker'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:333:in `catch'
/home/senid/.rvm/gems/ruby-2.7.6/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:333:in `block in create_worker'
exception happened in background worker: missing keyword: :configuration
```