### PR TITLE
fix vulnerability nokogiri GHSA-2qc6-mcvw-92cw

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
     net-ldap (0.16.1)
     netstring (0.0.3)
     nio4r (2.5.8)
-    nokogiri (1.13.6)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.11.2)


### PR DESCRIPTION
Name: nokogiri
Version: 1.13.6
GHSA: GHSA-2qc6-mcvw-92cw
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2qc6-mcvw-92cw
Title: Update bundled libxml2 to v2.10.3 to resolve multiple CVEs
Solution: upgrade to >= 1.13.9
