### PR TITLE
use chosen js for Customer filter on the Report interval cdrs items page

### DIFF
--- a/app/admin/reports/interval_data.rb
+++ b/app/admin/reports/interval_data.rb
@@ -38,8 +38,35 @@ ActiveAdmin.register Report::IntervalData, as: 'IntervalItem' do
   filter :id
   filter :timestamp
 
+  contractor_filter :customer_id,
+                    label: 'Customer',
+                    path_params: { q: { customer_eq: true, ordered_by: :name } },
+                    if: proc { parent.group_by.include?('customer_id') }
+  contractor_filter :vendor_id,
+                    label: 'Vendor',
+                    path_params: { q: { vendor_eq: true, ordered_by: :name } },
+                    if: proc { parent.group_by.include?('vendor_id') }
+
+  with_options as: :select, input_html: { class: :chosen } do |f|
+    f.filter :rateplan_id, if: proc { parent.group_by.include?('rateplan_id') }
+    f.filter :routing_group_id, if: proc { parent.group_by.include?('routing_group_id') }
+    f.filter :orig_gw_id, if: proc { parent.group_by.include?('orig_gw_id') }
+    f.filter :term_gw_id, if: proc { parent.group_by.include?('term_gw_id') }
+    f.filter :customer_auth_id, if: proc { parent.group_by.include?('customer_auth_id') }
+    f.account_filter :vendor_acc_id, label: 'Vendor acc', if: proc { parent.group_by.include?('vendor_acc_id') }
+    f.account_filter :customer_acc_id, label: 'Customer acc', if: proc { parent.group_by.include?('customer_acc_id') }
+    f.filter :vendor_invoice_id, if: proc { parent.group_by.include?('vendor_invoice_id') }
+    f.filter :customer_invoice_id, if: proc { parent.group_by.include?('customer_invoice_id') }
+    f.filter :node_id, if: proc { parent.group_by.include?('node_id') }
+    f.filter :pop_id, if: proc { parent.group_by.include?('pop_id') }
+    f.filter :dst_country_id, if: proc { parent.group_by.include?('dst_country_id') }
+    f.filter :dst_network_id, if: proc { parent.group_by.include?('dst_network_id') }
+    f.filter :disconnect_initiator_id, if: proc { parent.group_by.include?('disconnect_initiator_id') },
+                                       collection: proc { Cdr::Cdr::DISCONNECT_INITIATORS.invert }
+  end
+
   Report::IntervalCdr::CDR_COLUMNS.each do |key|
-    next if %i[destination_id dialpeer_id vendor_id].include? key
+    next if key.to_s.end_with?('_id')
 
     filter key.to_s[0..-4].to_sym, if: proc {
       @report_interval_cdr.group_by_include? key

--- a/spec/features/reports/interval_cdrs/index_interval_cdr_items_spec.rb
+++ b/spec/features/reports/interval_cdrs/index_interval_cdr_items_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Index interval cdr interval items', js: true do
   let(:timestamp) { Time.now.utc }
   let(:aggregated_value) { 755.0 }
 
-  it 'should have table with correct data' do
+  it 'should render index page properly' do
     subject
     expect(page).to have_table
     within_table_row(id: interval_data.id) do
@@ -104,6 +104,22 @@ RSpec.describe 'Index interval cdr interval items', js: true do
       expect(page).to have_table_cell(text: 'Fixed', column: 'Destination Rate Policy')
       expect(page).to have_table_cell(text: 'Switch', column: 'Disconnect Initiator')
     end
+
+    expect(page).to have_select 'Customer', visible: false
+    expect(page).to have_select 'Vendor', visible: false
+    expect(page).to have_select 'Rateplan', visible: false
+    expect(page).to have_select 'Routing group', visible: false
+    expect(page).to have_select 'Orig gw', visible: false
+    expect(page).to have_select 'Term gw', visible: false
+    expect(page).to have_select 'Customer auth', visible: false
+    expect(page).to have_select 'Vendor acc', visible: false
+    expect(page).to have_select 'Customer acc', visible: false
+    expect(page).to have_select 'Vendor invoice', visible: false
+    expect(page).to have_select 'Customer invoice', visible: false
+    expect(page).to have_select 'Node', visible: false
+    expect(page).to have_select 'Pop', visible: false
+    expect(page).to have_select 'Dst country', visible: false
+    expect(page).to have_select 'Dst network', visible: false
   end
 
   describe 'csv', js: false do


### PR DESCRIPTION
Bug when rendering the Association filters on the "Interval Items" index page.
Instead of native select options should be used Chosen JS library

**Acceptance criteria**:

 - for Customer filters use AJAX search

Affected page: Reports -> Interval Cdr report -> click "Data" link from row action


Screenshots:

<img width="1380" alt="Screenshot 2023-04-06 at 11 21 10" src="https://user-images.githubusercontent.com/10907664/230318260-bed058b5-a2ab-4d84-8d2f-a44372a663f6.png">
