### PR TITLE
Vulnerabilities nokogiri 1.14.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,7 @@ GEM
       net-protocol
     netstring (0.0.3)
     nio4r (2.5.8)
-    nokogiri (1.14.2)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oj (3.11.2)


### PR DESCRIPTION
Name: nokogiri
Version: 1.14.2
GHSA: GHSA-pxvg-2qj5-37jq
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-pxvg-2qj5-37jq
Title: Update packaged libxml2 to v2.10.4 to resolve multiple CVEs
Solution: upgrade to '>= 1.14.3'

Vulnerabilities found!