### PR TITLE
improve rspec config

### DIFF
--- a/pgq-processors/spec/spec_helper.rb
+++ b/pgq-processors/spec/spec_helper.rb
@@ -22,6 +22,18 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|
+    #  disable the should syntax...
     c.syntax = :expect
+    # Prevents expectation failure message truncation
+    c.max_formatted_output_length = nil
+    c.on_potential_false_positives = :raise
+    c.strict_predicate_matchers = true
+  end
+
+  config.mock_with :rspec do |c|
+    c.allow_message_expectations_on_nil = false
+    c.verify_partial_doubles = true
+    c.verify_doubled_constant_names = true
+    c.transfer_nested_constants = false
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,9 +31,9 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 include Warden::Test::Helpers
 Warden.test_mode!
 
-RSpec::Matchers.define_negated_matcher :not_eq, :eq
+RSpec::Matchers.
 
-RSpec.configure do |config|
+  RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join 'spec/fixtures'
 
@@ -182,6 +182,17 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     #  disable the should syntax...
     c.syntax = :expect
+    # Prevents expectation failure message truncation
+    c.max_formatted_output_length = nil
+    c.on_potential_false_positives = :raise
+    c.strict_predicate_matchers = true
+  end
+
+  config.mock_with :rspec do |c|
+    c.allow_message_expectations_on_nil = false
+    c.verify_partial_doubles = true
+    c.verify_doubled_constant_names = true
+    c.transfer_nested_constants = false
   end
 end
 

--- a/spec/support/rspec_match_failure_patch.rb
+++ b/spec/support/rspec_match_failure_patch.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# Prevents expectation failure message truncation
-# by setting max_formatted_output_length=nil for default formatter.
-# @see RSpec::Support::ObjectFormatter#format
-RSpec::Support::ObjectFormatter.instance_variable_set(
-  :@default_instance,
-  RSpec::Support::ObjectFormatter.new(nil)
-)


### PR DESCRIPTION
motivation:

warnings like below are appearing in CI and they are possible false positive tests

```
WARNING: An expectation of `:now` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`. Called from spec/support/contexts/stub_calculate_period_current_time.rb:12:in `block (2 levels) in <top (required)>'.
```