### PR TITLE
Fix delayed job service

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,10 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  if ENV['IS_DELAYED_JOB'].present?
+    MiniRacer::Platform.set_flags! :single_threaded
+  end
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
   config.assets.js_compressor = Uglifier.new(harmony: true)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -70,4 +70,10 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = true
   end
+
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/debian/yeti-web.yeti-delayed-job.service
+++ b/debian/yeti-web.yeti-delayed-job.service
@@ -18,6 +18,7 @@ Environment=RACK_ENV=production
 Environment=RAKE_ENV=production
 Environment=BUNDLE_GEMFILE=/opt/yeti-web/Gemfile
 Environment=GEM_PATH=/opt/yeti-web/vendor/bundler
+Environment=IS_DELAYED_JOB=true
 
 
 RuntimeDirectory=yeti-delayed-job


### PR DESCRIPTION
fix miniracer segfault during delayed job forking

```
WARNING: V8 isolate was forked, it can not be disposed and memory will not be reclaimed till the Ruby process exits.
It is VERY likely your process will hang.
If you wish to use v8 in forked environment please ensure the platform is initialized with:
MiniRacer::Platform.set_flags! :single_threaded
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/bin/bundle: [BUG] Segmentation fault at 0x00007fa277dce9d0
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]

-- Machine register context ------------------------------------------------
 RIP: 0x00007fa283257297 RBP: 0x00007ffd3e86e820 RSP: 0x00007ffd3e86e770
 RAX: 0x0000000000000000 RBX: 0x00005616720aad60 RCX: 0x0000000000000000
 RDX: 0x0000000000000000 RDI: 0x00007fa277dce700 RSI: 0x0000000000000000
  R8: 0x0000000000000001  R9: 0x00005616720aaa88 R10: 0x00007fa283934dc0
 R11: 0x00007fa283257ff0 R12: 0x00005616720aaa30 R13: 0x00007fa279793640
 R14: 0x00005616720aad60 R15: 0x0000561671f8eb18 EFL: 0x0000000000010206

-- C level backtrace information -------------------------------------------
/home/senid/.rvm/rubies/ruby-3.2.2/lib/libruby.so.3.2(rb_print_backtrace+0x11) [0x7fa2837ae87f] vm_dump.c:785
/home/senid/.rvm/rubies/ruby-3.2.2/lib/libruby.so.3.2(rb_vm_bugreport) vm_dump.c:1080
/home/senid/.rvm/rubies/ruby-3.2.2/lib/libruby.so.3.2(rb_bug_for_fatal_signal+0xf0) [0x7fa2835a9a80] error.c:813
/home/senid/.rvm/rubies/ruby-3.2.2/lib/libruby.so.3.2(sigsegv+0x49) [0x7fa283700d19] signal.c:964
/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7fa283261140] ../sysdeps/pthread/funlockfile.c:28
/lib/x86_64-linux-gnu/libpthread.so.0(__pthread_clockjoin_ex+0x27) [0x7fa283257297] pthread_join_common.c:89
/lib/x86_64-linux-gnu/libpthread.so.0(__pthread_clockjoin_ex) (null):0
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa27979362f) [0x7fa27979362f]
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa2797937d5) [0x7fa2797937d5]
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa2797927ed) [0x7fa2797927ed]
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa279792a31) [0x7fa279792a31]
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa278b41ffa) [0x7fa278b41ffa]
/home/senid/.rvm/gems/ruby-3.2.2@yeti-web/extensions/x86_64-linux/3.2.0/mini_racer-0.6.3/mini_racer_extension.so(0x7fa278b41b7a) [0x7fa278b41b7a]
/lib/x86_64-linux-gnu/libc.so.6(__run_exit_handlers+0xf7) [0x7fa2830b44d7] exit.c:108
/lib/x86_64-linux-gnu/libc.so.6(exit+0x1a) [0x7fa2830b467a] exit.c:139
/lib/x86_64-linux-gnu/libc.so.6(exit) (null):0
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1) [0x7fa28309cd11] ../csu/libc-start.c:342
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main) (null):0
[0x56166ccc415a]
```