### PR TITLE
Improvements for Admin API destinations endpoint

### DIFF
--- a/app/resources/api/rest/admin/routing/destination_resource.rb
+++ b/app/resources/api/rest/admin/routing/destination_resource.rb
@@ -2,6 +2,11 @@
 
 class Api::Rest::Admin::Routing::DestinationResource < ::BaseResource
   model_name 'Routing::Destination'
+
+  module CONST
+    SYSTEM_NAMESPACE_RELATIONS = %w[Country].freeze
+  end.freeze
+
   attributes :enabled, :next_rate, :connect_fee, :initial_interval, :next_interval, :dp_margin_fixed,
              :dp_margin_percent, :initial_rate, :asr_limit, :acd_limit, :short_calls_limit,
              :prefix, :reject_calls, :use_dp_intervals, :valid_from, :valid_till, :external_id,
@@ -12,6 +17,7 @@ class Api::Rest::Admin::Routing::DestinationResource < ::BaseResource
 
   has_one :rate_group, class_name: 'RateGroup'
   has_one :routing_tag_mode, class_name: 'RoutingTagMode'
+  has_one :country, class_name: 'Country', force_routed: true, foreign_key_on: :related
 
   filters :external_id, :prefix, :rate_group_id
 
@@ -39,6 +45,8 @@ class Api::Rest::Admin::Routing::DestinationResource < ::BaseResource
   ransack_filter :reverse_billing, type: :boolean
   ransack_filter :profit_control_mode_id, type: :number
   ransack_filter :rate_policy_id, type: :number
+  ransack_filter :rateplan_id, type: :foreign_key, column: :rate_group_rateplans_id
+  ransack_filter :country_id, type: :foreign_key, column: :network_prefix_country_id
 
   def self.updatable_fields(_context)
     %i[
@@ -72,5 +80,13 @@ class Api::Rest::Admin::Routing::DestinationResource < ::BaseResource
 
   def self.creatable_fields(context)
     updatable_fields(context)
+  end
+
+  def self.resource_for(type)
+    if type.in?(CONST::SYSTEM_NAMESPACE_RELATIONS)
+      "Api::Rest::Admin::System::#{type}Resource".safe_constantize
+    else
+      super
+    end
   end
 end

--- a/app/services/ransack_filter_builder.rb
+++ b/app/services/ransack_filter_builder.rb
@@ -8,7 +8,8 @@ class RansackFilterBuilder
     number: %w[eq not_eq gt gteq lt lteq in not_in],
     string: %w[eq not_eq cont start end in not_in cont_any],
     uuid: %w[eq not_eq in not_in],
-    enum: %w[eq not_eq in not_in]
+    enum: %w[eq not_eq in not_in],
+    foreign_key: %w[eq not_eq in not_in]
   }.freeze
 
   RANSACK_ARRAY_SUFFIXES = %w[in not_in cont_any].freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,7 +143,9 @@ Rails.application.routes.draw do
             jsonapi_resources :routing_tags
             jsonapi_resources :routing_tag_modes
             jsonapi_resources :routeset_discriminators
-            jsonapi_resources :destinations
+            jsonapi_resources :destinations do
+              # remove relationships endpoints because they fail work with cross namespace relationships.
+            end
             jsonapi_resources :destination_next_rates
           end
         end


### PR DESCRIPTION
Added `Country` relationship.
Added filters: 
* `rateplan_id` - supported predicates: eq, not_eq, in, not_in;
* `country_id` - supported predicates: eq, not_eq, in, not_in.