### PR TITLE
use cryptomus payment gateway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,3 +152,5 @@ gem 'webrick', '~> 1.8', require: false
 gem 'cronex', '~> 0.12.0'
 
 gem 'click_house'
+
+gem 'cryptomus', '~> 0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,8 @@ GEM
     cronex (0.12.0)
       tzinfo
       unicode
+    cryptomus (0.2.0)
+      faraday (~> 2.7)
     cuprite (0.11)
       capybara (>= 2.1, < 4)
       ferrum (~> 0.9.0)
@@ -679,6 +681,7 @@ DEPENDENCIES
   click_house
   config
   cronex (~> 0.12.0)
+  cryptomus (~> 0.2.0)
   cuprite
   d3-rails (= 3.5.2)
   daemons

--- a/app/admin/billing/accounts.rb
+++ b/app/admin/billing/accounts.rb
@@ -119,12 +119,8 @@ ActiveAdmin.register Account do
   end
 
   sidebar 'Create Payment', only: [:show] do
-    active_admin_form_for(Payment.new(account_id: params[:id]),
-                          url: payment_account_path(params[:id]),
-                          as: :payment,
-                          method: :post) do |f|
+    active_admin_form_for(Payment.new, url: payment_account_path(params[:id]), as: :payment, method: :post) do |f|
       f.inputs do
-        f.input :account_id, as: :hidden
         f.input :amount, input_html: { style: 'width: 200px' }
         f.input :notes, input_html: { style: 'width: 200px' }
       end
@@ -291,8 +287,9 @@ ActiveAdmin.register Account do
 
   member_action :payment, method: :post do
     authorize!
-    payment_params = params.require(:payment).permit(:account_id, :amount, :notes)
+    payment_params = params.require(:payment).permit(:amount, :notes)
     payment = Payment.new(payment_params)
+    payment.account = Draper.undecorate(resource)
     if payment.save
       flash[:notice] = 'Payment created!'
     else

--- a/app/admin/billing/payments.rb
+++ b/app/admin/billing/payments.rb
@@ -17,7 +17,8 @@ ActiveAdmin.register Payment do
                  [:account_name, proc { |row| row.account.try(:name) }],
                  :amount,
                  :notes,
-                 :private_notes
+                 :private_notes,
+                 :status
 
   controller do
     def scoped_collection
@@ -41,15 +42,16 @@ ActiveAdmin.register Payment do
     id_column
     column :created_at
     column :account, footer: lambda {
-                               strong do
-                                 'Total:'
-                               end
-                             }
+      strong do
+        'Total:'
+      end
+    }
+    column :status, :status_formatted, sortable: :status_id
     column :amount, footer: lambda {
-                              strong do
-                                @footer_data[:total_amount]
-                              end
-                            }
+      strong do
+        @footer_data[:total_amount]
+      end
+    }
     column :private_notes
     column :notes
     column :uuid
@@ -59,19 +61,59 @@ ActiveAdmin.register Payment do
   filter :uuid_equals, label: 'UUID'
   filter :created_at, as: :date_time_range
   account_filter :account_id_eq
+  filter :status_id,
+         label: 'Status',
+         as: :select,
+         collection: proc { Payment::CONST::STATUS_IDS },
+         input_html: { class: 'chosen' }
   filter :amount
   filter :private_notes
   filter :notes
 
-  show do |_s|
-    attributes_table do
-      row :id
-      row :uuid
-      row :created_at
-      row :account
-      row :amount
-      row :private_notes
-      row :notes
+  action_item :check_cryptomus, only: :show do
+    if resource.pending?
+      link_to 'Check Cryptomus', check_cryptomus_payment_path(resource.id), method: :put
     end
+  end
+
+  show do |_s|
+    tabs do
+      tab :details do
+        attributes_table do
+          row :id
+          row :uuid
+          row :created_at
+          row :account
+          row :status, :status_formatted
+          row :amount
+          row :private_notes
+          row :notes
+        end
+      end
+
+      if payment.pending?
+        tab :cryptomus_info do
+          pre do
+            cryptomus_info = Cryptomus::Client.payment(order_id: resource.id.to_s)
+            JSON.pretty_generate(cryptomus_info)
+          rescue Cryptomus::Errors::ApiError => e
+            "Response status #{e.status}\n#{JSON.pretty_generate(e.response_body)}"
+          end
+        end
+      end
+    end
+  end
+
+  member_action :check_cryptomus, method: :put do
+    begin
+      payment = Draper.undecorate(resource)
+      CryptomusPayment::CheckStatus.call(payment:)
+      flash[:notice] = 'Payment status updated.'
+    rescue CryptomusPayment::CheckStatus::Error => e
+      flash[:error] = e.message
+    rescue Cryptomus::Errors::ApiError => e
+      flash[:error] = "Response status #{e.status}"
+    end
+    redirect_to payment_path(resource.id)
   end
 end

--- a/app/controllers/api/rest/customer/v1/cryptomus_payments_controller.rb
+++ b/app/controllers/api/rest/customer/v1/cryptomus_payments_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::Rest::Customer::V1::CryptomusPaymentsController < Api::Rest::Customer::V1::BaseController
+end

--- a/app/controllers/cryptomus_webhooks_controller.rb
+++ b/app/controllers/cryptomus_webhooks_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CryptomusWebhooksController < ActionController::API
+  include CaptureError::ControllerMethods
+
+  rescue_from StandardError, with: :handle_exceptions
+  rescue_from ActiveRecord::RecordNotFound, with: :handle_exceptions
+
+  # https://doc.cryptomus.com/payments/webhook
+  def create
+    payload = params.except(:controller, :action, :sign, :cryptomus_webhook).to_unsafe_h
+    sign = params[:sign]
+
+    unless Cryptomus::WebhookValidator.validate(payload:, sign:)
+      Rails.logger.info { 'invalid signature' }
+      head 400
+      return
+    end
+
+    unless payload['is_final']
+      Rails.logger.info { "status is not final: #{payload['status']}" }
+      head 204
+      return
+    end
+
+    payment = Payment.find(payload['order_id'])
+    CryptomusPayment::CheckStatus.call(payment:)
+    head 204
+  end
+
+  private
+
+  def handle_exceptions(error)
+    log_error(error)
+    capture_error(error)
+    head 500
+  end
+
+  def capture_extra
+    {
+      payload: params.except(:controller, :action, :sign).to_unsafe_h,
+      sign: params[:sign]
+    }
+  end
+end

--- a/app/decorators/payment_decorator.rb
+++ b/app/decorators/payment_decorator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class PaymentDecorator < BillingDecorator
+  delegate_all
+  decorates Payment
+
+  def status_formatted
+    status_tag(status, class: status_color)
+  end
+
+  private
+
+  def status_color
+    if model.completed?
+      :ok
+    elsif model.pending?
+      :warning
+    elsif model.canceled?
+      :error
+    end
+  end
+end

--- a/app/forms/customer_api/cryptomus_payment_form.rb
+++ b/app/forms/customer_api/cryptomus_payment_form.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module CustomerApi
+  class CryptomusPaymentForm < ApplicationForm
+    EXPIRATION_SEC = 12 * 60 * 60 # expires in 12 hours
+
+    def self.policy_class
+      PaymentPolicy
+    end
+
+    attr_reader :uuid, :url
+
+    attr_accessor :customer_id, :allowed_account_ids
+
+    attribute :amount, :decimal
+    attribute :notes, :string
+    attribute :account_id, :string
+
+    validates :amount, presence: true
+    validates :amount, numericality: { greater_than_or_equal_to: 0.01 }, allow_nil: true
+
+    validates :account, presence: true
+
+    # @!method account
+    define_memoizable :account, apply: lambda {
+      return if account_id.nil?
+
+      scope = Account.where(contractor_id: customer_id)
+      scope = scope.where(id: allowed_account_ids) if allowed_account_ids.present?
+      scope.find_by(uuid: account_id)
+    }
+
+    def persisted?
+      uuid.present?
+    end
+
+    private
+
+    def _save
+      ApplicationRecord.transaction do
+        payment = Payment.create!(
+          account:,
+          amount:,
+          notes:,
+          status_id: Payment::CONST::STATUS_ID_PENDING
+        )
+        crypto_payment = create_cryptomus_payment(payment)
+        @url = crypto_payment[:result][:url]
+        @uuid = payment.reload.uuid
+      end
+    end
+
+    def create_cryptomus_payment(payment)
+      Cryptomus::Client.create_payment(
+        order_id: payment.id.to_s,
+        amount: amount.to_s,
+        currency: 'USD',
+        currencies: available_currencies,
+        url_callback: YetiConfig.cryptomus&.url_callback,
+        lifetime: EXPIRATION_SEC,
+        subtract: 100 # customer will pay 100% of commission
+      )
+    end
+
+    def available_currencies
+      response = Cryptomus::Client.list_services
+      currencies = response[:result].map { |currency| currency[:currency] }.uniq
+      currencies.map { |currency| { currency: } }
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -11,6 +11,7 @@
 #  uuid          :uuid             not null
 #  created_at    :timestamptz      not null
 #  account_id    :integer(4)       not null
+#  status_id     :integer(2)       not null
 #
 # Indexes
 #
@@ -23,19 +24,104 @@
 #
 
 class Payment < ApplicationRecord
-  belongs_to :account
+  module CONST
+    STATUS_ID_CANCELED = 10
+    STATUS_ID_COMPLETED = 20
+    STATUS_ID_PENDING = 30
+    STATUS_IDS = {
+      STATUS_ID_CANCELED => 'canceled',
+      STATUS_ID_COMPLETED => 'completed',
+      STATUS_ID_PENDING => 'pending'
+    }.freeze
+
+    freeze
+  end
 
   include WithPaperTrail
 
-  validates :amount, numericality: true
-  validates :account, presence: true
+  attribute :status_id, :integer, default: CONST::STATUS_ID_COMPLETED
 
-  before_create do
-    account.lock! # will generate SELECT FOR UPDATE SQL statement
-    account.balance += amount
-    throw(:abort) unless account.save
+  belongs_to :account, class_name: 'Account'
+
+  validates :amount, presence: true
+  validates :amount, numericality: { other_than: 0 }, allow_nil: true
+
+  validate :validate_status_id
+
+  before_save :top_up_balance
+
+  # eq not_eq in not_in
+  scope :status_eq, lambda { |value|
+    status_id = CONST::STATUS_IDS.key(value)
+    status_id ? where(status_id:) : none
+  }
+
+  scope :status_not_eq, lambda { |value|
+    status_id = CONST::STATUS_IDS.key(value)
+    status_id ? where.not(status_id:) : all
+  }
+
+  scope :status_in, lambda { |*values|
+    status_ids = values.map { |value| CONST::STATUS_IDS.key(value) }.compact
+    status_ids.present? ? where(status_id: status_ids) : none
+  }
+
+  scope :status_not_in, lambda { |*values|
+    status_ids = values.map { |value| CONST::STATUS_IDS.key(value) }.compact
+    status_ids.present? ? where.not(status_id: status_ids) : all
+  }
+
+  scope :today, lambda {
+    where('created_at >= ? ', Time.now.at_beginning_of_day)
+  }
+
+  scope :yesterday, lambda {
+    where('created_at >= ? and created_at < ?', 1.day.ago.at_beginning_of_day, Time.now.at_beginning_of_day)
+  }
+
+  def status
+    CONST::STATUS_IDS[status_id]
   end
 
-  scope :today, -> { where('created_at >= ? ', Time.now.at_beginning_of_day) }
-  scope :yesterday, -> { where('created_at >= ? and created_at < ?', 1.day.ago.at_beginning_of_day, Time.now.at_beginning_of_day) }
+  def completed?
+    status_id == CONST::STATUS_ID_COMPLETED
+  end
+
+  def canceled?
+    status_id == CONST::STATUS_ID_CANCELED
+  end
+
+  def pending?
+    status_id == CONST::STATUS_ID_PENDING
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[status_eq status_not_eq status_in status_not_in]
+  end
+
+  private
+
+  def top_up_balance
+    if status_id_changed? && completed?
+      account.lock! # will generate SELECT FOR UPDATE SQL statement
+      account.balance += amount
+      throw(:abort) unless account.save
+    end
+  end
+
+  def validate_status_id
+    if status_id.nil?
+      errors.add(:status_id, :blank)
+      return
+    end
+
+    if CONST::STATUS_IDS.keys.exclude?(status_id)
+      errors.add(:status_id, :inclusion, value: status_id)
+      return
+    end
+
+    if status_id_changed? && status_id_was == Payment::CONST::STATUS_ID_COMPLETED
+      errors.add(:status_id, :readonly)
+    end
+  end
 end

--- a/app/policies/payment_policy.rb
+++ b/app/policies/payment_policy.rb
@@ -5,4 +5,6 @@ class PaymentPolicy < ::RolePolicy
 
   class Scope < ::RolePolicy::Scope
   end
+
+  alias_rule :check_cryptomus?, to: :perform?
 end

--- a/app/resources/api/rest/admin/payment_resource.rb
+++ b/app/resources/api/rest/admin/payment_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::Rest::Admin::PaymentResource < BaseResource
-  attributes :amount, :notes
+  attributes :amount, :notes, :status
 
   paginator :paged
 
@@ -9,6 +9,7 @@ class Api::Rest::Admin::PaymentResource < BaseResource
 
   ransack_filter :amount, type: :number
   ransack_filter :notes, type: :string
+  ransack_filter :status, type: :enum, collection: Payment::CONST::STATUS_IDS.values
 
   def self.creatable_fields(_context)
     %i[
@@ -16,5 +17,9 @@ class Api::Rest::Admin::PaymentResource < BaseResource
       amount
       notes
     ]
+  end
+
+  def self.sortable_fields(_context)
+    %i[amount notes]
   end
 end

--- a/app/resources/api/rest/customer/v1/cryptomus_payment_resource.rb
+++ b/app/resources/api/rest/customer/v1/cryptomus_payment_resource.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Api::Rest::Customer::V1::CryptomusPaymentResource < Api::Rest::Customer::V1::BaseResource
+  model_name 'CustomerApi::CryptomusPaymentForm'
+
+  attributes :amount,
+             :notes,
+             :url
+
+  has_one :account, foreign_key_on: :related
+
+  before_create { _model.customer_id = context[:customer_id] }
+  before_create { _model.allowed_account_ids = context[:allowed_account_ids] }
+
+  def self.creatable_fields(_ctx = nil)
+    %i[amount notes account]
+  end
+
+  def fetchable_fields
+    %i[url]
+  end
+end

--- a/app/resources/api/rest/customer/v1/payment_resource.rb
+++ b/app/resources/api/rest/customer/v1/payment_resource.rb
@@ -5,6 +5,7 @@ class Api::Rest::Customer::V1::PaymentResource < Api::Rest::Customer::V1::BaseRe
 
   attributes :amount,
              :notes,
+             :status,
              :created_at
 
   has_one :account, foreign_key_on: :related
@@ -14,11 +15,16 @@ class Api::Rest::Customer::V1::PaymentResource < Api::Rest::Customer::V1::BaseRe
   ransack_filter :amount, type: :number
   ransack_filter :created_at, type: :datetime
   association_uuid_filter :account_id, class_name: 'Account'
+  ransack_filter :status, type: :enum, collection: Payment::CONST::STATUS_IDS.values
 
   def self.apply_allowed_accounts(records, options)
     context = options[:context]
     records = records.ransack(account_contractor_id_eq: context[:customer_id]).result
     records = records.where(account_id: context[:allowed_account_ids]) if context[:allowed_account_ids].present?
     records
+  end
+
+  def self.sortable_fields(_context)
+    %i[amount notes created_at]
   end
 end

--- a/app/services/cryptomus_payment/check_status.rb
+++ b/app/services/cryptomus_payment/check_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CryptomusPayment
+  class CheckStatus < ApplicationService
+    Error = Class.new(StandardError)
+
+    parameter :payment, required: true
+
+    SUCCESS_STATUSES = %w[paid paid_over].freeze
+
+    def call
+      payment.with_lock do
+        raise Error, 'Payment is not pending' unless payment.pending?
+
+        cr_payment = Cryptomus::Client.payment(order_id: payment.id.to_s)
+        unless cr_payment[:result][:is_final]
+          raise Error, "Cryptomus Payment status is not final: #{cr_payment[:result][:status]}"
+        end
+
+        if cr_payment[:result][:status].in?(SUCCESS_STATUSES)
+          amount = cr_payment[:result][:payer_amount].to_d
+          payment.update!(amount:, status_id: Payment::CONST::STATUS_ID_COMPLETED)
+        else
+          payment.update!(status_id: Payment::CONST::STATUS_ID_CANCELED)
+        end
+      end
+    end
+  end
+end

--- a/app/views/payments/cryptomus_info.html.erb
+++ b/app/views/payments/cryptomus_info.html.erb
@@ -1,0 +1,3 @@
+<pre>
+<%= JSON.pretty_generate @cryptomus_info %>
+</pre>

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -68,6 +68,12 @@ Config.setup do |setup_config|
     optional(:keep_expired_destinations_days)
     optional(:keep_expired_dialpeers_days)
     optional(:keep_balance_notifications_days)
+
+    optional(:cryptomus).schema do
+      optional(:api_key).maybe(:string)
+      optional(:merchant_id).maybe(:string)
+      optional(:url_callback).maybe(:string)
+    end
   end
 end
 

--- a/config/initializers/cryptomus.rb
+++ b/config/initializers/cryptomus.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Cryptomus.configure do |config|
+  config.merchant_id = YetiConfig.cryptomus&.merchant_id
+  config.api_key = YetiConfig.cryptomus&.api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   get 'with_contractor_accounts', to: 'accounts#with_contractor'
   ActiveAdmin.routes(self)
 
+  post 'cryptomus_webhooks', to: 'cryptomus_webhooks#create'
+
   resources :active_calls, constraints: { id: %r{[^/]+} }, only: %i[show index destroy]
 
   resources :remote_stats do
@@ -166,6 +168,7 @@ Rails.application.routes.draw do
             jsonapi_resources :chart_active_calls, only: %i[create]
             jsonapi_resources :chart_originated_cps, only: %i[create]
             jsonapi_resources :payments, only: %i[index show]
+            jsonapi_resources :cryptomus_payments, only: %i[create]
             jsonapi_resources :invoices, only: %i[index show] do
               jsonapi_relationships
               member { get :download }

--- a/config/yeti_web.yml.ci
+++ b/config/yeti_web.yml.ci
@@ -40,3 +40,8 @@ versioning_disable_for_models:
 keep_expired_dialpeers_days: 30
 keep_expired_destinations_days:
 keep_balance_notifications_days: 30
+
+cryptomus:
+  api_key: 'your_api_key'
+  merchant_id: 'your_merchant_id'
+  url_callback: 'https://your_domain.com/cryptomus_webhooks'

--- a/config/yeti_web.yml.development
+++ b/config/yeti_web.yml.development
@@ -40,3 +40,8 @@ versioning_disable_for_models:
 keep_expired_dialpeers_days: 30
 keep_expired_destinations_days: 30
 keep_balance_notifications_days: 30
+
+cryptomus:
+  api_key: 'your_api_key'
+  merchant_id: 'your_merchant_id'
+  url_callback: 'https://your_domain.com/cryptomus_webhooks'

--- a/config/yeti_web.yml.distr
+++ b/config/yeti_web.yml.distr
@@ -40,3 +40,8 @@ versioning_disable_for_models:
 keep_expired_dialpeers_days:
 keep_expired_destinations_days:
 keep_expired_destinations_days:
+
+cryptomus:
+  api_key: 'your_api_key'
+  merchant_id: 'your_merchant_id'
+  url_callback: 'https://your_domain.com/cryptomus_webhooks'

--- a/db/migrate/20230702152539_payments_add_status_id.rb
+++ b/db/migrate/20230702152539_payments_add_status_id.rb
@@ -1,0 +1,11 @@
+class PaymentsAddStatusId < ActiveRecord::Migration[7.0]
+  def up
+    # Payment::CONST::STATUS_ID_COMPLETED == 20
+    add_column 'billing.payments', :status_id, :integer, limit: 2, default: 20, null: false
+    change_column_default 'billing.payments', :status_id, nil
+  end
+
+  def down
+    remove_column 'billing.payments', :status_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22325,7 +22325,8 @@ CREATE TABLE billing.payments (
     id bigint NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     uuid uuid DEFAULT public.uuid_generate_v1() NOT NULL,
-    private_notes character varying
+    private_notes character varying,
+    status_id smallint NOT NULL
 );
 
 
@@ -31413,7 +31414,8 @@ ALTER TABLE ONLY sys.sensors
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
+SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import
+;
 
 INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20170822151410'),
@@ -31555,6 +31557,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20230524191752'),
 ('20230602113601'),
 ('20230608134717'),
+('20230702152539'),
 ('20230706164807'),
 ('20230706202154'),
 ('20230708194737');

--- a/spec/config/yeti_web_spec.rb
+++ b/spec/config/yeti_web_spec.rb
@@ -46,7 +46,12 @@ RSpec.describe 'config/yeti_web.yml' do
       versioning_disable_for_models: a_kind_of(Array),
       keep_expired_dialpeers_days: a_kind_of(Integer),
       keep_expired_destinations_days: be_nil,
-      keep_balance_notifications_days: a_kind_of(Integer)
+      keep_balance_notifications_days: a_kind_of(Integer),
+      cryptomus: {
+        api_key: a_kind_of(String),
+        merchant_id: a_kind_of(String),
+        url_callback: a_kind_of(String)
+      }
     }
   end
 

--- a/spec/factories/payment.rb
+++ b/spec/factories/payment.rb
@@ -6,9 +6,18 @@ FactoryBot.define do
     association :account
     notes { 'notes text' }
     private_notes { 'private notes' }
+    status_id { Payment::CONST::STATUS_ID_COMPLETED }
 
     after(:create) do |record|
       record.reload # to populate uuid
+    end
+
+    trait :pending do
+      status_id { Payment::CONST::STATUS_ID_PENDING }
+    end
+
+    trait :canceled do
+      status_id { Payment::CONST::STATUS_ID_CANCELED }
     end
   end
 end

--- a/spec/features/billing/accounts/create_payment_spec.rb
+++ b/spec/features/billing/accounts/create_payment_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Account details Create Payment', type: :feature, js: true do
+  subject do
+    visit account_path(account.id)
+    fill_in_form!
+    submit_form!
+  end
+
+  include_context :login_as_admin
+
+  let!(:account) { create(:account) }
+
+  let(:submit_form!) do
+    within_panel('Create Payment') do
+      click_button 'Create Payment'
+    end
+  end
+  let(:fill_in_form!) do
+    within_panel('Create Payment') do
+      fill_in 'Amount', with: '200.50'
+      fill_in 'Notes', with: 'Some notes'
+    end
+  end
+
+  it 'creates new payment successfully' do
+    expect {
+      subject
+      expect(page).to have_flash_message('Payment created!', type: :notice)
+    }.to change { Payment.count }.by(1)
+                                 .and change { account.reload.balance }.by(200.50)
+
+    expect(page).to have_current_path account_path(account.id)
+    payment = Payment.last!
+    expect(payment).to have_attributes(
+                         status_id: Payment::CONST::STATUS_ID_COMPLETED,
+                         account: account,
+                         amount: 200.50,
+                         notes: 'Some notes',
+                         private_notes: nil
+                       )
+  end
+
+  context 'without Amount' do
+    let(:fill_in_form!) do
+      within_panel('Create Payment') do
+        fill_in 'Notes', with: 'Some notes'
+      end
+    end
+
+    it 'does not create payment' do
+      expect {
+        subject
+        expect(page).to have_flash_message("Payment creation failed: Amount can't be blank", type: :error)
+      }.to change { Payment.count }.by(0)
+                                   .and change { account.reload.balance }.by(0)
+
+      expect(page).to have_current_path account_path(account.id)
+    end
+  end
+
+  context 'with Amount 0' do
+    let(:fill_in_form!) do
+      within_panel('Create Payment') do
+        fill_in 'Amount', with: 0
+        fill_in 'Notes', with: 'Some notes'
+      end
+    end
+
+    it 'does not create payment' do
+      expect {
+        subject
+        expect(page).to have_flash_message('Payment creation failed: Amount must be other than 0', type: :error)
+      }.to change { Payment.count }.by(0)
+                                   .and change { account.reload.balance }.by(0)
+
+      expect(page).to have_current_path account_path(account.id)
+    end
+  end
+end

--- a/spec/features/billing/payments/check_cryptomus_spec.rb
+++ b/spec/features/billing/payments/check_cryptomus_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Payments check cryptomus page', js: true do
+  subject do
+    visit payment_path(payment.id)
+    click_link 'Check Cryptomus'
+  end
+
+  include_context :login_as_admin
+  let!(:payment) { create(:payment, payment_attrs) }
+  let(:payment_attrs) { { status_id: Payment::CONST::STATUS_ID_PENDING } }
+
+  let!(:stub_cryptomus_payment) do
+    WebMock.stub_request(:post, "#{Cryptomus::CONST::URL}/v1/payment/info")
+           .with(
+      headers: { 'Content-Type': 'application/json' },
+      body: { order_id: payment.id.to_s }.to_json
+    )
+           .and_return(
+      headers: { 'Content-Type': 'application/json' },
+      status: cryptomus_response_status,
+      body: cryptomus_response_body.to_json
+    )
+  end
+  let(:cryptomus_response_status) { 200 }
+  let(:cryptomus_response_body) do
+    {
+      "state": 0,
+      "result": {
+        "uuid": 'f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+        "order_id": payment.id.to_s,
+        "amount": '100.00000000',
+        "payment_amount": '110.95000000',
+        "payer_amount": '100.00000000',
+        "payer_currency": 'USDT',
+        "currency": 'USDT',
+        "comments": nil,
+        "network": 'tron_trc20',
+        "address": nil,
+        "from": nil,
+        "txid": nil,
+        "payment_status": 'paid',
+        "url": 'https://pay.cryptomus.com/pay/f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+        "expired_at": 1.hour.from_now.to_i,
+        "status": 'paid',
+        "is_final": true,
+        "additional_data": nil,
+        "currencies": [
+          {
+            "currency": 'USDT',
+            "network": 'tron_trc20'
+          },
+          {
+            "currency": 'USDT',
+            "network": 'eth_erc20'
+          }
+        ]
+      }
+    }
+  end
+
+  let!(:stub_check_status) do
+    allow(CryptomusPayment::CheckStatus).to receive(:call).with(payment:).once
+  end
+
+  it 'calls CryptomusPayment::CheckStatus' do
+    expect(CryptomusPayment::CheckStatus).to receive(:call).with(payment:).once
+    subject
+    expect(page).to have_flash_message('Payment status updated.', type: :notice)
+  end
+
+  context 'when CryptomusPayment::CheckStatus::Error raised' do
+    let!(:stub_check_status) do
+      allow(CryptomusPayment::CheckStatus).to receive(:call).with(payment:).and_raise(
+        CryptomusPayment::CheckStatus::Error, 'test error'
+      )
+    end
+
+    it 'displays error' do
+      subject
+      expect(page).to have_flash_message('test error', type: :error)
+    end
+  end
+
+  context 'when Cryptomus::Errors::ApiError raised' do
+    let!(:stub_check_status) do
+      response = double(status: 404, body: { error: 'not found' })
+      allow(CryptomusPayment::CheckStatus).to receive(:call).with(payment:).and_raise(
+        Cryptomus::Errors::ApiError, response
+      )
+    end
+
+    it 'displays error' do
+      subject
+      expect(page).to have_flash_message('Response status 404', type: :error)
+    end
+  end
+end

--- a/spec/features/billing/payments/export_payments_spec.rb
+++ b/spec/features/billing/payments/export_payments_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Export Payments', type: :feature do
         ['Amount', item.amount.to_s],
         ['Notes', item.notes.to_s],
         ['Private notes', item.private_notes.to_s],
+        ['Status', item.status],
         ['Created at', item.created_at.to_s]
       ]
     )

--- a/spec/features/billing/payments/new_payment_spec.rb
+++ b/spec/features/billing/payments/new_payment_spec.rb
@@ -1,47 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Create new Payment', type: :feature, js: true do
-  include_context :login_as_admin
-
-  before do
-    @account = create(:account)
+  subject do
     visit new_payment_path
+    fill_in_form!
+    submit_form!
   end
 
-  include_context :fill_form, 'new_payment' do
-    let(:attributes) do
-      {
-        account_id: lambda {
-          fill_in_chosen('Account', with: @account.display_name, ajax: true)
-        },
-        amount: 100_500,
-        notes: 'Some notes',
-        private_notes: 'Some private notes'
-      }
+  include_context :login_as_admin
+
+  let!(:account) { create(:account) }
+
+  let(:submit_form!) do
+    click_button 'Create Payment'
+  end
+  let(:fill_in_form!) do
+    fill_in_chosen('Account', with: account.display_name, ajax: true)
+    fill_in 'Amount', with: 100_500
+    fill_in 'Notes', with: 'Some notes'
+    fill_in 'Private notes', with: 'Some private notes'
+  end
+
+  it 'creates new payment successfully' do
+    expect {
+      subject
+      expect(page).to have_flash_message('Payment was successfully created.', type: :notice)
+    }.to change { Payment.count }.by(1)
+                                 .and change { account.reload.balance }.by(100_500)
+
+    payment = Payment.last!
+    expect(page).to have_current_path payment_path(payment.id)
+    expect(payment).to have_attributes(
+      status_id: Payment::CONST::STATUS_ID_COMPLETED,
+      account: account,
+      amount: 100_500,
+      notes: 'Some notes',
+      private_notes: 'Some private notes'
+    )
+  end
+
+  context 'without Amount' do
+    let(:fill_in_form!) do
+      fill_in_chosen('Account', with: account.display_name, ajax: true)
+      fill_in 'Notes', with: 'Some notes'
+      fill_in 'Private notes', with: 'Some private notes'
     end
 
-    it 'creates new payment succesfully' do
-      click_on_submit
-      expect(page).to have_css('.flash_notice', text: 'Payment was successfully created.')
+    it 'does not create payment' do
+      expect {
+        subject
+        expect(page).to have_semantic_error_texts("Amount can't be blank")
+      }.to change { Payment.count }.by(0)
+                                   .and change { account.reload.balance }.by(0)
 
-      expect(Payment.last).to have_attributes(
-        account_id: @account.id,
-        amount: attributes[:amount],
-        notes: attributes[:notes],
-        private_notes: attributes[:private_notes]
-      )
+      expect(page).to have_current_path payments_path
+      expect(page).to have_field_chosen('Account', with: account.display_name)
+    end
+  end
+
+  context 'with Amount 0' do
+    let(:fill_in_form!) do
+      fill_in_chosen('Account', with: account.display_name, ajax: true)
+      fill_in 'Amount', with: 0
+      fill_in 'Notes', with: 'Some notes'
+      fill_in 'Private notes', with: 'Some private notes'
     end
 
-    context 'with validation error' do
-      let(:attributes) { super().except(:amount) }
+    it 'does not create payment' do
+      expect {
+        subject
+        expect(page).to have_semantic_error_texts('Amount must be other than 0')
+      }.to change { Payment.count }.by(0)
+                                   .and change { account.reload.balance }.by(0)
 
-      it 'account should be still' do
-        click_on_submit
-
-        expect(page).to have_semantic_errors(count: 1)
-        expect(page).to have_semantic_error('Amount is not a number')
-        expect(page).to have_field_chosen('Account', with: @account.display_name)
-      end
+      expect(page).to have_current_path payments_path
+      expect(page).to have_field_chosen('Account', with: account.display_name)
     end
   end
 end

--- a/spec/features/billing/payments/show_spec.rb
+++ b/spec/features/billing/payments/show_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Payments show page', js: true do
+  subject do
+    visit payment_path(payment.id)
+  end
+
+  include_context :login_as_admin
+  let!(:payment) { create(:payment, payment_attrs) }
+  let(:payment_attrs) { { status_id: Payment::CONST::STATUS_ID_COMPLETED } }
+
+  it 'displays payment details' do
+    subject
+    expect(page).to have_attribute_row 'ID', exact_text: payment.id.to_s
+    expect(page).to have_attribute_row 'AMOUNT', exact_text: payment.amount.to_s
+    expect(page).to have_attribute_row 'STATUS', exact_text: 'completed'
+    expect(page).to have_attribute_row 'UUID', exact_text: payment.uuid
+    expect(page).not_to have_action_item 'Check Cryptomus'
+  end
+
+  context 'when payment is pending' do
+    let(:payment_attrs) { super().merge status_id: Payment::CONST::STATUS_ID_PENDING }
+
+    let!(:stub_cryptomus_payment) do
+      WebMock.stub_request(:post, "#{Cryptomus::CONST::URL}/v1/payment/info")
+             .with(
+               headers: { 'Content-Type': 'application/json' },
+               body: { order_id: payment.id.to_s }.to_json
+             )
+             .and_return(
+               headers: { 'Content-Type': 'application/json' },
+               status: cryptomus_response_status,
+               body: cryptomus_response_body.to_json
+             )
+    end
+    let(:cryptomus_response_status) { 200 }
+    let(:cryptomus_response_body) do
+      {
+        "state": 0,
+        "result": {
+          "uuid": 'f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+          "order_id": payment.id.to_s,
+          "amount": '100.00000000',
+          "payment_amount": '110.95000000',
+          "payer_amount": '100.00000000',
+          "payer_currency": 'USDT',
+          "currency": 'USDT',
+          "comments": nil,
+          "network": 'tron_trc20',
+          "address": nil,
+          "from": nil,
+          "txid": nil,
+          "payment_status": 'paid',
+          "url": 'https://pay.cryptomus.com/pay/f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+          "expired_at": 1.hour.from_now.to_i,
+          "status": 'paid',
+          "is_final": true,
+          "additional_data": nil,
+          "currencies": [
+            {
+              "currency": 'USDT',
+              "network": 'tron_trc20'
+            },
+            {
+              "currency": 'USDT',
+              "network": 'eth_erc20'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'displays payment details' do
+      subject
+      expect(page).to have_attribute_row 'ID', exact_text: payment.id.to_s
+      expect(page).to have_attribute_row 'AMOUNT', exact_text: payment.amount.to_s
+      expect(page).to have_attribute_row 'STATUS', exact_text: 'pending'
+      expect(page).to have_attribute_row 'UUID', exact_text: payment.uuid
+      expect(page).to have_action_item 'Check Cryptomus'
+
+      switch_tab 'Cryptomus Info'
+      expect(page).to have_text(
+                        JSON.pretty_generate(cryptomus_response_body)
+                      )
+    end
+
+    context 'when cryptomus response with error' do
+      let(:cryptomus_response_status) { 404 }
+      let(:cryptomus_response_body) do
+        { state: 1, message: 'No query results for model [App\\Models\\MerchantPayment].' }
+      end
+
+      it 'displays cryptomus payment' do
+        subject
+        expect(page).to have_attribute_row 'ID', exact_text: payment.id.to_s
+        switch_tab 'Cryptomus Info'
+        expect(page).to have_text(
+                          "Response status 404\n" + JSON.pretty_generate(cryptomus_response_body)
+                        )
+      end
+    end
+  end
+
+  context 'when payment is canceled' do
+    let(:payment_attrs) { super().merge status_id: Payment::CONST::STATUS_ID_CANCELED }
+
+    it 'displays payment details' do
+      subject
+      expect(page).to have_attribute_row 'ID', exact_text: payment.id.to_s
+      expect(page).to have_attribute_row 'AMOUNT', exact_text: payment.amount.to_s
+      expect(page).to have_attribute_row 'STATUS', exact_text: 'canceled'
+      expect(page).to have_attribute_row 'UUID', exact_text: payment.uuid
+      expect(page).not_to have_action_item 'Check Cryptomus'
+    end
+  end
+end

--- a/spec/fixtures/json/cryptomus_payment_services.json
+++ b/spec/fixtures/json/cryptomus_payment_services.json
@@ -1,0 +1,369 @@
+{
+  "state": 0,
+  "result": [
+    {
+      "network": "ETH",
+      "currency": "VERSE",
+      "is_available": true,
+      "limit": {
+        "min_amount": "2500.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "DAI",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "TON",
+      "currency": "TON",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.00100000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "USDT",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "100000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BCH",
+      "currency": "BCH",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.00100000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "XMR",
+      "currency": "XMR",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.00100000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "DASH",
+      "currency": "DASH",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.02000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "BNB",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.00500000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "DAI",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "DOGE",
+      "currency": "DOGE",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "POLYGON",
+      "currency": "USDC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "CGPT",
+      "is_available": true,
+      "limit": {
+        "min_amount": "10.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "TRON",
+      "currency": "USDC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "USDC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "USDT",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.50000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "TRON",
+      "currency": "USDT",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "100000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "TRON",
+      "currency": "TRX",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "BUSD",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BSC",
+      "currency": "USDC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "POLYGON",
+      "currency": "MATIC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.50000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "TRON",
+      "currency": "BUSD",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "POLYGON",
+      "currency": "DAI",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "BTC",
+      "currency": "BTC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.00002000",
+        "max_amount": "100.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "MATIC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "LTC",
+      "currency": "LTC",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.02000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "ETH",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.01000000",
+        "max_amount": "1000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "POLYGON",
+      "currency": "USDT",
+      "is_available": true,
+      "limit": {
+        "min_amount": "0.50000000",
+        "max_amount": "1000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    },
+    {
+      "network": "ETH",
+      "currency": "BUSD",
+      "is_available": true,
+      "limit": {
+        "min_amount": "1.00000000",
+        "max_amount": "10000000.00000000"
+      },
+      "commission": {
+        "fee_amount": "0.00",
+        "percent": "2.00"
+      }
+    }
+  ]
+}

--- a/spec/requests/api/rest/customer/v1/cryptomus_payments_spec.rb
+++ b/spec/requests/api/rest/customer/v1/cryptomus_payments_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::Customer::V1::CryptomusPaymentsController, type: :request do
+  include_context :json_api_customer_v1_helpers, type: :'cryptomus-payments'
+
+  let!(:account) { create(:account, contractor: customer) }
+  let!(:prev_payment) { create(:payment, account:) }
+
+  describe 'POST /api/rest/customer/v1/cryptomus-payments' do
+    subject do
+      post json_api_request_path, params: json_api_request_body.to_json, headers: json_api_request_headers
+    end
+
+    shared_examples :creates_successfully do
+      it 'creates pending payment' do
+        expect { subject }.to change { Payment.count }.by(1)
+        expect(stub_cryptomus_payment_services).to have_been_requested.once
+        expect(stub_create_cryptomus_payment).to have_been_requested.once
+        expect(Payment.last).to have_attributes(
+                                  account_id: account.id,
+                                  amount: json_api_attributes[:amount].to_d,
+                                  notes: json_api_attributes[:notes],
+                                  status_id: Payment::CONST::STATUS_ID_PENDING,
+                                  private_notes: nil
+                                )
+      end
+
+      it 'does not change account balance' do
+        expect { subject }.not_to change { account.reload.balance }
+      end
+
+      include_examples :responds_with_status, 201
+
+      it 'responds with payment uuid' do
+        subject
+        expect(response_json).to match(
+                                   data: {
+                                     id: Payment.last.uuid,
+                                     type: 'cryptomus-payments',
+                                     attributes: {
+                                       url: cryptomus_url
+                                     },
+                                     links: anything
+                                   }
+                                 )
+      end
+    end
+
+    shared_examples :creation_failed do |errors:|
+      include_examples :returns_json_api_errors, errors: errors
+
+      it 'does not create payment' do
+        expect { subject }.not_to change { Payment.count }
+        expect(stub_cryptomus_payment_services).not_to have_been_requested
+        expect(stub_create_cryptomus_payment).not_to have_been_requested
+      end
+
+      it 'does not change account balance' do
+        expect { subject }.not_to change { account.reload.balance }
+      end
+    end
+
+    let(:json_api_request_body) do
+      {
+        data: {
+          type: 'cryptomus-payments',
+          attributes: json_api_attributes,
+          relationships: json_api_relationships
+        }
+      }
+    end
+    let(:json_api_attributes) do
+      { amount: '100' }
+    end
+    let(:json_api_relationships) do
+      {
+        account: { data: { type: 'accounts', id: account.reload.uuid } }
+      }
+    end
+    let(:cryptomus_url) do
+      'https://pay.cryptomus.com/pay/f1386fb5-ecfa-41d4-a85d-b151d98df5e1'
+    end
+
+    let!(:payment_services_body) do
+      File.read Rails.root.join('spec/fixtures/json/cryptomus_payment_services.json')
+    end
+    let!(:stub_cryptomus_payment_services) do
+      WebMock.stub_request(:post, "#{Cryptomus::CONST::URL}/v1/payment/services")
+             .with(headers: { 'Content-Type': 'application/json' }, body: '{}')
+             .and_return(headers: { 'Content-Type': 'application/json' }, status: 201, body: payment_services_body)
+    end
+    let(:cryptomus_currencies) do
+      JSON.parse(payment_services_body, symbolize_names: true)[:result].map { |row| row.slice(:currency) }.uniq
+    end
+
+    let!(:stub_create_cryptomus_payment) do
+      WebMock.stub_request(:post, "#{Cryptomus::CONST::URL}/v1/payment")
+             .with(
+               headers: { 'Content-Type': 'application/json' },
+               body: cryptomus_request_body.to_json
+             )
+             .and_return(
+               headers: { 'Content-Type': 'application/json' },
+               status: cryptomus_response_status,
+               body: cryptomus_response_body.to_json
+             )
+    end
+    let(:cryptomus_request_body) do
+      {
+        order_id: (prev_payment.id + 1).to_s,
+        amount: json_api_attributes[:amount].to_d.to_s,
+        currency: 'USD',
+        currencies: cryptomus_currencies,
+        url_callback: YetiConfig.cryptomus&.url_callback,
+        lifetime: CustomerApi::CryptomusPaymentForm::EXPIRATION_SEC,
+        subtract: 100
+      }
+    end
+    let(:cryptomus_response_status) { 200 }
+    let(:cryptomus_response_body) do
+      {
+        "state": 0,
+        "result": {
+          "uuid": 'f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+          "order_id": (prev_payment.id + 1).to_s,
+          "amount": '100.00000000',
+          "payment_amount": '110.95000000',
+          "payer_amount": '100.00000000',
+          "payer_currency": 'USDT',
+          "currency": 'USDT',
+          "comments": nil,
+          "network": 'tron_trc20',
+          "address": nil,
+          "from": nil,
+          "txid": nil,
+          "payment_status": 'check',
+          "url": cryptomus_url,
+          "expired_at": CustomerApi::CryptomusPaymentForm::EXPIRATION_SEC.seconds.from_now.to_i,
+          "status": 'check',
+          "is_final": false,
+          "additional_data": nil,
+          "currencies": [
+            {
+              "currency": 'USDT',
+              "network": 'tron_trc20'
+            },
+            {
+              "currency": 'USDT',
+              "network": 'eth_erc20'
+            }
+          ]
+        }
+      }
+    end
+
+    include_examples :creates_successfully
+
+    context 'with notes attribute' do
+      let(:json_api_attributes) do
+        super().merge notes: 'qweasd'
+      end
+
+      include_examples :creates_successfully
+    end
+
+    context 'with no attributes and no relationships' do
+      let(:json_api_attributes) { {} }
+      let(:json_api_relationships) { {} }
+
+      include_examples :creation_failed, errors: [
+        { detail: "amount - can't be blank", source: { pointer: '/data/attributes/amount' } },
+        { detail: "account - can't be blank", source: { pointer: '/data/relationships/account' } }
+      ]
+    end
+  end
+end

--- a/spec/requests/cryptomus_webhooks_spec.rb
+++ b/spec/requests/cryptomus_webhooks_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Cryptomus Webhooks', type: :request do
+  describe 'POST /cryptomus_webhooks' do
+    subject do
+      post '/cryptomus_webhooks',
+           params: request_body.to_json,
+           headers: { 'Content-Type': 'application/json' }
+    end
+
+    let(:request_body) { payload.merge(sign:) }
+    let(:sign) { Cryptomus::Signature.generate(payload.to_json) }
+    let!(:payment) { create(:payment) }
+    let(:payload) do
+      {
+        type: 'payment',
+        uuid: '99d3473f-ce0f-43dc-ba25-d42b4802fb0c',
+        order_id: payment.id.to_s,
+        amount: '70.00000000',
+        payment_amount: '70.00000000',
+        payment_amount_usd: '4.30',
+        merchant_amount: '67.90000000',
+        commission: '2.10000000',
+        is_final: true,
+        status: 'paid',
+        from: nil,
+        wallet_address_uuid: nil,
+        network: 'tron',
+        currency: 'TRX',
+        payer_currency: 'TRX',
+        additional_data: 'Some additional info',
+        convert: {
+          "to_currency": 'USDT',
+          "commission": nil,
+          "rate": '0.06193320',
+          "amount": '4.16321164'
+        }
+      }
+    end
+
+    it 'returns 204' do
+      expect(CryptomusPayment::CheckStatus).to receive(:call).with(payment:).once
+      subject
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/spec/services/cryptomus_payment/check_status_spec.rb
+++ b/spec/services/cryptomus_payment/check_status_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+RSpec.describe CryptomusPayment::CheckStatus do
+  describe '.call' do
+    subject do
+      described_class.call(payment:)
+    end
+
+    let!(:payment) { create(:payment, payment_attrs) }
+    let!(:payment_attrs) { { amount: 100, status_id: Payment::CONST::STATUS_ID_PENDING } }
+
+    let!(:stub_cryptomus_payment) do
+      WebMock.stub_request(:post, "#{Cryptomus::CONST::URL}/v1/payment/info")
+             .with(
+        headers: { 'Content-Type': 'application/json' },
+        body: { order_id: payment.id.to_s }.to_json
+      )
+             .and_return(
+        headers: { 'Content-Type': 'application/json' },
+        status: cryptomus_response_status,
+        body: cryptomus_response_body.to_json
+      )
+    end
+    let(:cryptomus_response_status) { 200 }
+    let(:cryptomus_response_body) do
+      {
+        "state": 0,
+        "result": {
+          "uuid": 'f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+          "order_id": payment.id.to_s,
+          "amount": '100.00000000',
+          "payment_amount": '110.95000000',
+          "payer_amount": '100.00000000',
+          "payer_currency": 'USDT',
+          "currency": 'USDT',
+          "comments": nil,
+          "network": 'tron_trc20',
+          "address": nil,
+          "from": nil,
+          "txid": nil,
+          "payment_status": 'paid',
+          "url": 'https://pay.cryptomus.com/pay/f1386fb5-ecfa-41d4-a85d-b151d98df5e1',
+          "expired_at": 1.hour.from_now.to_i,
+          "status": 'paid',
+          "is_final": true,
+          "additional_data": nil,
+          "currencies": [
+            {
+              "currency": 'USDT',
+              "network": 'tron_trc20'
+            },
+            {
+              "currency": 'USDT',
+              "network": 'eth_erc20'
+            }
+          ]
+        }
+      }
+    end
+
+    context 'when cryptomus payment is paid' do
+      it 'updates payment status to completed' do
+        expect { subject }.to change { payment.reload.status_id }.to(Payment::CONST::STATUS_ID_COMPLETED)
+        expect(payment.reload.amount).to eq 100
+      end
+    end
+
+    context 'when cryptomus payment is paid_over' do
+      let(:cryptomus_response_body) do
+        super().deep_merge(
+          result: {
+            "status": 'paid_over',
+            "amount": '105.00000000',
+            "payment_amount": '115.95000000',
+            "payer_amount": '105.00000000'
+          }
+        )
+      end
+
+      it 'updates payment status to completed' do
+        expect { subject }.to change { payment.reload.status_id }.to(Payment::CONST::STATUS_ID_COMPLETED)
+        expect(payment.reload.amount).to eq 105
+      end
+    end
+
+    context 'when cryptomus payment is check' do
+      let(:cryptomus_response_body) do
+        super().deep_merge(
+          result: {
+            "status": 'check',
+            "is_final": false
+          }
+        )
+      end
+
+      it 'raises Error' do
+        expect { subject }.to raise_error(
+                                described_class::Error,
+                                'Cryptomus Payment status is not final: check'
+                              )
+      end
+
+      it 'does not change payment' do
+        expect { safe_subject }.not_to change { payment.reload.attributes }
+      end
+
+      it 'does not change account balance' do
+        expect { safe_subject }.not_to change { payment.account.reload.balance }
+      end
+    end
+
+    context 'when cryptomus payment is cancel' do
+      let(:cryptomus_response_body) do
+        super().deep_merge(
+          result: {
+            "status": 'cancel'
+          }
+        )
+      end
+
+      it 'updates payment status to canceled' do
+        expect { subject }.to change { payment.reload.status_id }.to(Payment::CONST::STATUS_ID_CANCELED)
+      end
+
+      it 'does not change account balance' do
+        expect { subject }.not_to change { payment.account.reload.balance }
+      end
+    end
+
+    context 'with completed payment' do
+      let!(:payment_attrs) { super().merge status_id: Payment::CONST::STATUS_ID_COMPLETED }
+
+      it 'raises Error' do
+        expect { subject }.to raise_error(described_class::Error, 'Payment is not pending')
+      end
+
+      it 'does not change payment' do
+        expect { safe_subject }.not_to change { payment.reload.attributes }
+      end
+
+      it 'does not change account balance' do
+        expect { safe_subject }.not_to change { payment.account.reload.balance }
+      end
+    end
+
+    context 'with canceled payment' do
+      let!(:payment_attrs) { super().merge status_id: Payment::CONST::STATUS_ID_COMPLETED }
+
+      it 'raises Error' do
+        expect { subject }.to raise_error(described_class::Error, 'Payment is not pending')
+      end
+
+      it 'does not change payment' do
+        expect { safe_subject }.not_to change { payment.reload.attributes }
+      end
+
+      it 'does not change account balance' do
+        expect { safe_subject }.not_to change { payment.account.reload.balance }
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://doc.cryptomus.com/payments/getting-started

### User stories

1. I am a client of the Customer API
 Want to create cryptomus payment and receive link to pay it
 In order to top up the balance of an account using crypto.

1. I am a client of Customer API
 Want to see pending payment for not paid cryptomus and completed payment for paid one
 In order to distinguish paid from not paid payments.

1. I am a client of Customer API
 Want pending payments to become canceled after cryptomus payment expires
 In order to distinguish payment that can't be completed.

### API

#### Customer V1 API add POST cryptomus payments
`POST /api/rest/customer/v1/cryptomus-payments`

request attributes:
* amount (required)

request relationships:
* account (required)

response attributes:
* id - id of pending payment that were created
* url

request sample:
```
POST /api/rest/customer/v1/cryptomus-payments
Content-type: application/vnd.api+json
Accept: application/vnd.api+json
Cookie: ...

{
  "data": {
    "type": "cryptomus-payments",
    "attributes": {
      "amount": "100.23"
    },
    "relationships": {
      "account": {
        "data": {
          "type": "accounts",
          "id": "123"
        }
      }
    }
  }
}
```

response sample:
```
Created 201

{
  "data": {
    "type": "cryptomus-payments",
    "id": "1001",
    "attributes": {
      "url": "https://pay.cryptomus.com/pay/f1386fb5-ecfa-41d4-a85d-b151d98df5e1"
    }
  }
}
```

#### Customer V1 API payments add status attribute
`GET /api/rest/customer/v1/payments`
add response attribute:
* status - string (canceled, pending, or completed)
add filters:
* filter[status_eq]
* filter[status_not_eq]
* filter[status_in]
* filter[status_not_in]

`GET /api/rest/customer/v1/payments/:id`
add response attribute:
* status - string (canceled, pending, or completed)

#### Admin API payments add status attribute
`GET /api/rest/admin/payments`
add response attribute:
* status - string (canceled, pending, or completed)
add filters:
* filter[status_eq]
* filter[status_not_eq]
* filter[status_in]
* filter[status_not_in]

`GET /api/rest/admin/payments/:id`
add response attribute:
* status - string (canceled, pending, or completed)

#### Cryptomus webhook
`POST /cryptomus_webhooks`

receives and handles webhooks from cryptomus.
complete or cancel the payment