### PR TITLE
#1328, fix vulnerability, bump puma from v6.2.1 to v6.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ GEM
     pgq_prometheus (0.2.3)
       prometheus_exporter
     public_suffix (4.0.6)
-    puma (6.2.1)
+    puma (6.3.1)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
```
CVE-2023-40175
```
https://github.com/advisories/GHSA-68xg-gqqm-vgj8

[compare](https://github.com/puma/puma/compare/v6.2.1...v6.3.1)

closes #1328 