### PR TITLE
Add new filters to the CDR Exports

### DIFF
--- a/app/admin/cdr/cdr_exports.rb
+++ b/app/admin/cdr/cdr_exports.rb
@@ -108,7 +108,53 @@ ActiveAdmin.register CdrExport, as: 'CDR Export' do
   end
 
   permit_params :callback_url,
-                filters: CdrExport::FiltersModel.attribute_types.keys.map(&:to_sym),
+                filters: [
+                  :time_start_gteq,
+                  :time_start_lteq,
+                  :time_start_lt,
+                  :customer_id_eq,
+                  :customer_external_id_eq,
+                  :customer_acc_id_eq,
+                  :customer_acc_external_id_eq,
+                  :vendor_id_eq,
+                  :vendor_external_id_eq,
+                  :vendor_acc_id_eq,
+                  :vendor_acc_external_id_eq,
+                  :is_last_cdr_eq,
+                  :success_eq,
+                  :customer_auth_id_eq,
+                  :customer_auth_external_id_eq,
+                  :failed_resource_type_id_eq,
+                  :src_prefix_in_contains,
+                  :src_prefix_in_eq,
+                  :dst_prefix_in_contains,
+                  :dst_prefix_in_eq,
+                  :src_prefix_routing_contains,
+                  :src_prefix_routing_eq,
+                  :dst_prefix_routing_contains,
+                  :dst_prefix_routing_eq,
+                  :src_prefix_out_contains,
+                  :src_prefix_out_eq,
+                  :dst_prefix_out_contains,
+                  :dst_prefix_out_eq,
+                  :src_country_id_eq,
+                  :dst_country_id_eq,
+                  :routing_tag_ids_include,
+                  :routing_tag_ids_exclude,
+                  :routing_tag_ids_empty,
+                  :orig_gw_id_eq,
+                  :orig_gw_external_id_eq,
+                  :term_gw_id_eq,
+                  :term_gw_external_id_eq,
+                  :duration_eq,
+                  :duration_gteq,
+                  :duration_lteq,
+                  :customer_auth_external_type_eq,
+                  :customer_auth_external_type_not_eq,
+                  customer_auth_external_id_in: [],
+                  dst_country_iso_in: [],
+                  src_country_iso_in: []
+                ],
                 fields: []
 
   form do |f|
@@ -225,6 +271,35 @@ ActiveAdmin.register CdrExport, as: 'CDR Export' do
                input_html: { class: 'chosen' },
                required: false
       ff.input :term_gw_external_id_eq, required: false
+      ff.input :customer_auth_external_type_eq, required: false
+      ff.input :customer_auth_external_type_not_eq, required: false
+      ff.input :customer_auth_external_id_in,
+               as: :select,
+               multiple: true,
+               required: false,
+               input_html: {
+                 class: 'chosen-ajax',
+                 data: {
+                   path: '/customers_auths/search_with_return_external_id?q[ordered_by]=name'
+                 }
+               },
+               collection: if params.dig(:q, :customer_auth_external_id_in)
+                             CustomersAuth.where(external_id: params.dig(:q, :customer_auth_external_id_in)).order(:name).pluck(:name, :external_id)
+                           else
+                             CustomersAuth.none
+                           end
+      ff.input :src_country_iso_in,
+               as: :select,
+               multiple: true,
+               collection: System::Country.pluck(:name, :iso2),
+               input_html: { class: 'chosen' },
+               required: false
+      ff.input :dst_country_iso_in,
+               as: :select,
+               multiple: true,
+               collection: System::Country.pluck(:name, :iso2),
+               input_html: { class: 'chosen' },
+               required: false
     end
     f.actions
   end

--- a/app/admin/routing/customers_auths.rb
+++ b/app/admin/routing/customers_auths.rb
@@ -12,6 +12,8 @@ ActiveAdmin.register CustomersAuth do
 
   acts_as_delayed_job_lock
 
+  search_support!(search_name: :search_with_return_external_id, id_column: :external_id)
+
   decorate_with CustomersAuthDecorator
 
   acts_as_export :id, :enabled, :reject_calls, :name,

--- a/app/models/customers_auth.rb
+++ b/app/models/customers_auth.rb
@@ -239,6 +239,8 @@ class CustomersAuth < ApplicationRecord
   scope :from_domain_array_contains, ->(f_dom) { where.contains from_domain: Array(f_dom) }
   scope :to_domain_array_contains, ->(to_dom) { where.contains to_domain: Array(to_dom) }
   scope :x_yeti_auth_array_contains, ->(auth) { where.contains x_yeti_auth: Array(auth) }
+  scope :search_for, ->(term) { where("class4.customers_auth.name || ' | ' || class4.customers_auth.id::varchar ILIKE ?", "%#{term}%") }
+  scope :ordered_by, ->(term) { order(term) }
 
   include Yeti::ResourceStatus
 
@@ -313,6 +315,8 @@ class CustomersAuth < ApplicationRecord
       to_domain_array_contains
       x_yeti_auth_array_contains
       ip_covers
+      search_for
+      ordered_by
     ]
   end
 

--- a/lib/resource_dsl/active_search.rb
+++ b/lib/resource_dsl/active_search.rb
@@ -2,11 +2,11 @@
 
 module ResourceDSL
   module ActiveSearch
-    def search_support!
-      collection_action :search, method: :get do
+    def search_support!(search_name: :search, id_column: :id)
+      collection_action search_name, method: :get do
         data = resource_class.ransack(params[:q]).result
         result = data.map do |item|
-          { id: item.id, value: item.display_name }
+          { id: item[id_column], value: item.display_name }
         end
         render json: result
       end

--- a/spec/acceptance/rest/admin/api/cdr/cdr_exports_spec.rb
+++ b/spec/acceptance/rest/admin/api/cdr/cdr_exports_spec.rb
@@ -63,7 +63,12 @@ RSpec.resource 'Cdr Exports' do
         term_gw_external_id_eq: 1245,
         duration_eq: 60,
         duration_gteq: 0,
-        duration_lteq: 100
+        duration_lteq: 100,
+        customer_auth_external_type_eq: 'term',
+        customer_auth_external_type_not_eq: 'em',
+        customer_auth_external_id_in: [1, 2, 3],
+        dst_country_iso_in: [country.iso2],
+        src_country_iso_in: [country.iso2]
       }
     end
     let(:'callback-url') { 'test.url.com' }

--- a/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
+++ b/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe 'Create new CDR export', js: true do
         status: 'Pending',
         filters: a_kind_of(CdrExport::FiltersModel)
       )
-      filters = cdr_export.filters.as_json.symbolize_keys
-      expect(filters).to match(
-          time_start_gteq: '2018-01-01T00:00:00.000Z',
-          time_start_lteq: '2018-03-01T00:00:00.000Z',
-          customer_acc_id_eq: account.id
-        )
+      expect(cdr_export.filters_json).to match(
+        time_start_gteq: '2018-01-01T00:00:00.000Z',
+        time_start_lteq: '2018-03-01T00:00:00.000Z',
+        customer_acc_id_eq: account.id,
+        customer_auth_external_id_in: [],
+        dst_country_iso_in: [],
+        src_country_iso_in: []
+      )
     end
   end
 
@@ -69,12 +71,14 @@ RSpec.describe 'Create new CDR export', js: true do
         status: 'Pending',
         filters: a_kind_of(CdrExport::FiltersModel)
       )
-      filters = cdr_export.filters.as_json.symbolize_keys
-      expect(filters).to match(
-          time_start_gteq: '2018-01-01T00:00:00.000Z',
-          time_start_lteq: '2018-03-01T00:00:00.000Z',
-          customer_acc_id_eq: account.id
-        )
+      expect(cdr_export.filters_json).to match(
+        time_start_gteq: '2018-01-01T00:00:00.000Z',
+        time_start_lteq: '2018-03-01T00:00:00.000Z',
+        customer_acc_id_eq: account.id,
+        customer_auth_external_id_in: [],
+        dst_country_iso_in: [],
+        src_country_iso_in: []
+      )
     end
   end
 
@@ -82,7 +86,7 @@ RSpec.describe 'Create new CDR export', js: true do
     let!(:countries) { create_list(:country, 2, :uniq_name) }
     let!(:vendor) { create(:vendor) }
     let!(:vendor_acc) { create(:account, name: 'test', contractor: vendor) }
-    let!(:customer_auth) { create(:customers_auth) }
+    let!(:customer_auth) { create(:customers_auth, external_id: 1235, external_type: 'term') }
     let!(:gateway1) { create(:gateway) }
     let!(:gateway2) { create(:gateway) }
 
@@ -132,10 +136,15 @@ RSpec.describe 'Create new CDR export', js: true do
         fill_in 'Time start gteq', with: '2018-01-01'
         fill_in 'Time start lteq', with: '2018-03-01'
         fill_in 'Time start lt', with: '2018-03-01', exact: true
+        fill_in 'Customer auth external type eq', with: 'term'
+        fill_in 'Customer auth external type not eq', with: 'em'
+        fill_in_chosen 'Customer auth external id in', with: customer_auth.name, multiple: true, ajax: true
+        fill_in_chosen 'Src country iso in', with: countries.first.name, multiple: true
+        fill_in_chosen 'Dst country iso in', with: countries.first.name, multiple: true
 
         # all allowed filters must be filled in this test.
         CdrExport::FiltersModel.attribute_types.each_key do |filter_key|
-          selector = "[name=\"cdr_export[filters][#{filter_key}]\"]"
+          selector = "#cdr_export_filters_#{filter_key}"
           field_node = page.find("input#{selector}, select#{selector}", visible: :all)
           expect(field_node.value).to(
             be_present,
@@ -158,8 +167,7 @@ RSpec.describe 'Create new CDR export', js: true do
                               status: 'Pending',
                               filters: a_kind_of(CdrExport::FiltersModel)
                             )
-      filters = cdr_export.filters.as_json.symbolize_keys
-      expect(filters).to match(
+      expect(cdr_export.filters_json).to match(
                            time_start_gteq: '2018-01-01T00:00:00.000Z',
                            time_start_lteq: '2018-03-01T00:00:00.000Z',
                            time_start_lt: '2018-03-01T00:00:00.000Z',
@@ -199,7 +207,12 @@ RSpec.describe 'Create new CDR export', js: true do
                            term_gw_id_eq: gateway2.id,
                            duration_eq: 30,
                            duration_gteq: 0,
-                           duration_lteq: 60
+                           duration_lteq: 60,
+                           customer_auth_external_type_eq: 'term',
+                           customer_auth_external_type_not_eq: 'em',
+                           customer_auth_external_id_in: [customer_auth.external_id],
+                           dst_country_iso_in: [countries.first.iso2],
+                           src_country_iso_in: [countries.first.iso2]
                          )
     end
   end
@@ -226,11 +239,13 @@ RSpec.describe 'Create new CDR export', js: true do
                               status: 'Pending',
                               filters: a_kind_of(CdrExport::FiltersModel)
                             )
-      filters = cdr_export.filters.as_json.symbolize_keys
-      expect(filters).to match(
-                           time_start_gteq: '2018-01-01T00:00:00.000Z',
-                           time_start_lteq: '2018-03-01T00:00:00.000Z'
-                         )
+      expect(cdr_export.filters_json).to match(
+        time_start_gteq: '2018-01-01T00:00:00.000Z',
+        time_start_lteq: '2018-03-01T00:00:00.000Z',
+        customer_auth_external_id_in: [],
+        dst_country_iso_in: [],
+        src_country_iso_in: []
+      )
     end
   end
 
@@ -255,11 +270,13 @@ RSpec.describe 'Create new CDR export', js: true do
                               status: 'Pending',
                               filters: a_kind_of(CdrExport::FiltersModel)
                             )
-      filters = cdr_export.filters.as_json.symbolize_keys
-      expect(filters).to match(
-                           time_start_gteq: '2018-01-01T00:00:00.000Z',
-                           time_start_lt: '2018-03-01T00:00:00.000Z'
-                         )
+      expect(cdr_export.filters_json).to match(
+        time_start_gteq: '2018-01-01T00:00:00.000Z',
+        time_start_lt: '2018-03-01T00:00:00.000Z',
+        customer_auth_external_id_in: [],
+        dst_country_iso_in: [],
+        src_country_iso_in: []
+      )
     end
   end
 

--- a/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
+++ b/spec/requests/api/rest/admin/cdr/cdr_exports_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrExportsController, type: :request do
           'export-type': cdr_export.export_type,
           status: cdr_export.status,
           fields: cdr_export.fields,
-          filters: cdr_export.filters.as_json.symbolize_keys
+          filters: cdr_export.filters_json
         }
       end
     end
@@ -127,8 +127,7 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrExportsController, type: :request do
       it 'creates cdr_export' do
         expect { subject }.to change { CdrExport.count }.by(1)
         expect(last_record).to have_attributes(expected_cdr_export_attrs)
-        filters = last_record.filters.as_json.symbolize_keys
-        expect(filters).to match(expected_cdr_export_filters)
+        expect(last_record.filters_json).to match(expected_cdr_export_filters)
       end
 
       it 'enqueues Worker::CdrExportJob' do

--- a/spec/requests/api/rest/customer/v1/cdr_exports_spec.rb
+++ b/spec/requests/api/rest/customer/v1/cdr_exports_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::Rest::Customer::V1::CdrExportsController, type: :request do
       it 'creates cdr_export' do
         expect { subject }.to change { CdrExport.count }.by(1)
         expect(cdr_export).to have_attributes(expected_cdr_export_attrs)
-        expect(cdr_export.filters.as_json.symbolize_keys).to match(expected_cdr_export_filters)
+        expect(cdr_export.filters_json).to match(expected_cdr_export_filters)
       end
     end
 


### PR DESCRIPTION
Add additional CDR export filters: customer_auth_external_type_eq, customer_auth_external_type_not_eq, customer_auth_external_id_in (supports array), src_country_iso_in (supports array), dst_country_iso_in (supports array)

![filters](https://github.com/yeti-switch/yeti-web/assets/22831505/4f6e50fc-f734-4026-9ab6-0a93d40cdb91)
![cdr_export_show](https://github.com/yeti-switch/yeti-web/assets/22831505/e15dfeff-89ca-4c75-8ed2-07fa49cb9dbf)