### PR TITLE
#1200, Add request IP and meta to API log model

### DIFF
--- a/app/admin/logs/api_logs.rb
+++ b/app/admin/logs/api_logs.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
 
   controller do
     def scoped_collection
-      super.select('id, created_at, status, method, path, db_duration, page_duration')
+      super.select('id, created_at, status, method, path, db_duration, page_duration, remote_ip')
     end
 
     def find_resource
@@ -37,6 +37,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
   filter :response_body
   filter :request_headers
   filter :response_headers
+  filter :remote_ip_eq_inet, as: :string, label: 'Remote IP'
 
   index do
     id_column
@@ -46,6 +47,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
     column :path
     column :db_duration
     column :page_duration
+    column :remote_ip
   end
 
   show do
@@ -84,6 +86,12 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
           l.response_body
         end
       end
+      row :meta do |l|
+        pre do
+          l.meta
+        end
+      end
+      row :remote_ip
     end
     active_admin_comments
   end

--- a/app/controllers/api/cryptomus_callbacks_controller.rb
+++ b/app/controllers/api/cryptomus_callbacks_controller.rb
@@ -22,6 +22,10 @@ class Api::CryptomusCallbacksController < ActionController::API
     head 200
   end
 
+  def meta
+    nil
+  end
+
   private
 
   def server_error(error)

--- a/app/controllers/api/rest/admin/auth_controller.rb
+++ b/app/controllers/api/rest/admin/auth_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Api::Rest::Admin::AuthController < Knock::AuthTokenController
+  def meta
+    nil
+  end
+
   private
 
   def entity_name

--- a/app/controllers/api/rest/customer/v1/auth_controller.rb
+++ b/app/controllers/api/rest/customer/v1/auth_controller.rb
@@ -36,6 +36,10 @@ class Api::Rest::Customer::V1::AuthController < ApplicationController
     head 204
   end
 
+  def meta
+    nil
+  end
+
   private
 
   def authenticate!

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -35,6 +35,10 @@ class ApiController < ActionController::API
 
   rescue_from StandardError, with: :capture_error!
 
+  def meta
+    nil
+  end
+
   protected
 
   def current_db_connection

--- a/app/models/log/api_log.rb
+++ b/app/models/log/api_log.rb
@@ -8,10 +8,12 @@
 #  action           :string
 #  controller       :string
 #  db_duration      :float
+#  meta             :jsonb
 #  method           :string
 #  page_duration    :float
 #  params           :text
 #  path             :string
+#  remote_ip        :inet
 #  request_body     :text
 #  request_headers  :text
 #  response_body    :text
@@ -36,8 +38,13 @@ class Log::ApiLog < ApplicationRecord
   self.pg_partition_depth_future = 3
 
   scope :failed, -> { where('status >= ?', 400) }
+  scope :remote_ip_eq_inet, ->(value) { where('remote_ip >>= ?', value) }
 
   def display_name
     id.to_s
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[remote_ip_eq_inet]
   end
 end

--- a/config/initializers/instrumentation_notification.rb
+++ b/config/initializers/instrumentation_notification.rb
@@ -12,6 +12,8 @@ module ActionController
     end
 
     def process_action(*args)
+      return super unless request.path.start_with?('/api/')
+
       raw_payload = {
         controller: self.class.name,
         action: action_name,

--- a/config/initializers/instrumentation_notification.rb
+++ b/config/initializers/instrumentation_notification.rb
@@ -15,6 +15,7 @@ module ActionController
       raw_payload = {
         controller: self.class.name,
         action: action_name,
+        meta: meta,
         params: request.filtered_parameters,
         format: request.format.try(:ref),
         method: request.method,
@@ -43,6 +44,9 @@ ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |_n
 
     Log::ApiLog.create do |api_request|
       debug_mode = payload[:debug_mode]
+
+      api_request.meta = payload[:meta]
+      api_request.remote_ip = payload[:remote_ip]
 
       if payload[:status].nil? && payload[:exception].present?
         payload[:status] = ActionDispatch::ExceptionWrapper.status_code_for_exception(payload[:exception].class)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,9 @@ en:
         x_yeti_auth: 'X-Yeti-Auth'
       cdr:
         auth_orig_ip: 'Auth Orig IP'
+      log/api_log:
+        remote_ip: 'Remote IP'
+
     errors:
       models:
         billing\contact:

--- a/db/migrate/20230928100513_add_meta_attribute_to_api_log.rb
+++ b/db/migrate/20230928100513_add_meta_attribute_to_api_log.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetaAttributeToApiLog < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'logs.api_requests', :meta, :jsonb
+  end
+end

--- a/db/migrate/20230928134637_add_remote_ip_to_api_log_table.rb
+++ b/db/migrate/20230928134637_add_remote_ip_to_api_log_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRemoteIpToApiLogTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'logs.api_requests', :remote_ip, :inet
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25446,7 +25446,9 @@ CREATE TABLE logs.api_requests (
     request_body text,
     response_body text,
     request_headers text,
-    response_headers text
+    response_headers text,
+    meta jsonb,
+    remote_ip inet
 )
 PARTITION BY RANGE (created_at);
 
@@ -31614,6 +31616,8 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20230708194737'),
 ('20230717103315'),
 ('20230808192245'),
-('20230909093914');
+('20230909093914'),
+('20230928100513'),
+('20230928134637');
 
 

--- a/spec/features/log/api_logs/index_api_logs_spec.rb
+++ b/spec/features/log/api_logs/index_api_logs_spec.rb
@@ -10,4 +10,30 @@ RSpec.describe 'Index Log Api Logs', type: :feature do
       expect(page).to have_css('.resource_id_link', text: api_log.id)
     end
   end
+
+  describe 'filter' do
+    subject { click_button :Filter }
+
+    let(:record_attrs) { {} }
+    let!(:record) { FactoryBot.create(:api_log, record_attrs) }
+
+    describe 'by Remote IP' do
+      context 'when valid data' do
+        let(:record_attrs) { super().merge remote_ip: '127.0.0.1' }
+
+        before do
+          visit api_logs_path
+          fill_in 'Remote IP', with: '127.0.0.1'
+        end
+
+        it 'should render filtered records only' do
+          subject
+
+          expect(page).to have_table_row count: 1
+          expect(page).to have_table_cell column: 'Id', exact_text: record.id
+          expect(page).to have_field 'Remote IP', with: '127.0.0.1'
+        end
+      end
+    end
+  end
 end

--- a/spec/models/log/api_log_spec.rb
+++ b/spec/models/log/api_log_spec.rb
@@ -8,10 +8,12 @@
 #  action           :string
 #  controller       :string
 #  db_duration      :float
+#  meta             :jsonb
 #  method           :string
 #  page_duration    :float
 #  params           :text
 #  path             :string
+#  remote_ip        :inet
 #  request_body     :text
 #  request_headers  :text
 #  response_body    :text

--- a/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
+++ b/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
@@ -21,4 +21,26 @@ RSpec.describe Api::Rest::Admin::Routing::AreaPrefixesController, type: :request
 
     it_behaves_like :json_api_admin_check_authorization
   end
+
+  describe 'API Log recording' do
+    subject { get json_api_request_path, params: nil, headers: json_api_request_headers }
+
+    context 'when controller contains meta info' do
+      before { allow_any_instance_of(described_class).to receive(:meta).and_return({ foo: :bar }) }
+
+      it 'creates Log::ApiLog with meta and remote IP' do
+        expect { subject }.to change { Log::ApiLog.count }.by(1)
+        expect(Log::ApiLog.last).to have_attributes(meta: { 'foo' => 'bar' }, remote_ip: '127.0.0.1')
+      end
+    end
+
+    context 'when controller DO NOT contains meta info' do
+      before { allow_any_instance_of(described_class).to receive(:meta).and_return(nil) }
+
+      it 'creates Log::ApiLog with meta and remote IP' do
+        expect { subject }.to change { Log::ApiLog.count }.by(1)
+        expect(Log::ApiLog.last).to have_attributes(meta: nil, remote_ip: '127.0.0.1')
+      end
+    end
+  end
 end

--- a/spec/services/rate_management/apply_pricelist_spec.rb
+++ b/spec/services/rate_management/apply_pricelist_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe RateManagement::ApplyPricelist do
 
     shared_examples :should_delete_dialpeers do
       it 'should delete dialpeers' do
-        expect(DeleteDialpeers).to receive(:call).with(dialpeer_ids: to_delete_dialpeers.map(&:id)).and_call_original
+        expect(DeleteDialpeers).to receive(:call).with(dialpeer_ids: match_array(to_delete_dialpeers.map(&:id))).and_call_original
         expect { subject }.to change(Dialpeer, :count).by(-to_delete_dialpeers.size)
       end
     end


### PR DESCRIPTION
add meta column with `jsonb` type to logs.api_requests table
add remote_ip column with `string` type to logs.api_requests table

Added this filter on the API Log index page:
- "Remote IP" string by remote_ip column

#### store remote IP when API/meta info is used (any endpoint that starts with '/api/')

closed #1200


