### PR TITLE
#1302, add missing filters for Report->Custom Cdrs index page

### DIFF
--- a/app/admin/reports/custom_cdrs.rb
+++ b/app/admin/reports/custom_cdrs.rb
@@ -21,11 +21,16 @@ ActiveAdmin.register Report::CustomCdr, as: 'CustomCdr' do
 
   report_scheduler Report::CustomCdrScheduler
 
-  filter :id
+  filter :id_eq, label: 'ID'
   boolean_filter :completed
   filter :date_start, as: :date_time_range
   filter :date_end, as: :date_time_range
   filter :created_at, as: :date_time_range
+  filter :group_by_any, as: :select,
+                        label: 'Group By',
+                        collection: Report::CustomCdr::CDR_COLUMNS,
+                        input_html: { multiple: true, class: :chosen }
+  filter :filter_eq, as: :string, label: 'Filter'
   contractor_filter :customer_id_eq, label: 'Customer', path_params: { q: { customer_eq: true } }
 
   index do

--- a/app/models/report/custom_cdr.rb
+++ b/app/models/report/custom_cdr.rb
@@ -118,9 +118,15 @@ class Report::CustomCdr < Cdr::Base
     id.to_s
   end
 
+  scope :group_by_any, ->(*values) { where.contains(group_by: values) }
+
   private
 
   def auto_column_constants
     CDR_COLUMNS_CONSTANTS
+  end
+
+  def self.ransackable_scopes(_auth_object = nil)
+    %i[group_by_any]
   end
 end

--- a/spec/features/reports/custom_cdrs/index_custom_cdr_spec.rb
+++ b/spec/features/reports/custom_cdrs/index_custom_cdr_spec.rb
@@ -10,4 +10,23 @@ RSpec.describe 'Index Reports Custom Cdrs', type: :feature do
       expect(page).to have_css('.col-id', text: custom_cdr.id)
     end
   end
+
+  describe 'filter' do
+    subject { click_button :Filter }
+
+    context 'by all filters', js: false do
+      before do
+        visit custom_cdrs_path
+        fill_in 'ID', with: '123'
+        select 'customer_id', from: 'Group By'
+        fill_in 'Filter', with: 'filter'
+      end
+
+      it 'should reload page without error' do
+        subject
+
+        expect(page).to have_page_title 'Custom Cdrs'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes

  * changed ID filter to use eq ransack search suffix
  * added multiple "Group By" filter (will search within group_by array column)
  * added string "Filter" filter to search by "filter" column
 

## Additional links

closes #1302

## Screenshots

<img width="190" alt="Screenshot 2023-10-20 at 22 50 13" src="https://github.com/yeti-switch/yeti-web/assets/10907664/652cb27b-cd10-414b-9e59-c1fccb82d8ab">

