### PR TITLE
#1276, Refactor AsyncBatchDestroyJob to increase efficiency

### DIFF
--- a/app/jobs/async_batch_destroy_job.rb
+++ b/app/jobs/async_batch_destroy_job.rb
@@ -5,24 +5,40 @@ class AsyncBatchDestroyJob < ApplicationJob
   BATCH_SIZE = 1000
   queue_as 'batch_actions'
 
-  attr_reader :model_class, :who_is
+  attr_reader :model_class, :who_is, :sql_query
 
   def perform(model_class, sql_query, who_is)
     @model_class = model_class.constantize
+    @sql_query = sql_query
     @who_is = who_is
     set_audit_log_data
-    begin
-      scoped_records = @model_class.find_by_sql(sql_query + " LIMIT #{BATCH_SIZE}")
-      @model_class.transaction do
-        scoped_records.each do |record|
-          raise ActiveRecord::RecordNotDestroyed.new(error_message_for(record), record) unless record.destroy
+    @model_class.transaction do
+      relation.find_in_batches(batch_size: BATCH_SIZE) do |records|
+        records.each do |record|
+          unless record.destroy
+            logger.warn { error_message_for(record) }
+            next
+          end
         end
       end
-    end until scoped_records.empty?
+    end
+  end
+
+  def relation
+    if @sql_query.present? && extract_where_clause(@sql_query).present?
+      @model_class.where(extract_where_clause(sql_query))
+    else
+      @model_class.all
+    end
   end
 
   def error_message_for(record)
     "#{model_class} ##{record.id} can't be deleted: #{record.errors.full_messages.to_sentence}"
+  end
+
+  def extract_where_clause(sql_query)
+    where_clause_match = sql_query.match(/WHERE\s+(.+)\z/i)
+    where_clause_match ? where_clause_match[1].strip : nil
   end
 
   def reschedule_at(_time, _attempts)

--- a/lib/resource_dsl/acts_as_async_destroy.rb
+++ b/lib/resource_dsl/acts_as_async_destroy.rb
@@ -10,7 +10,7 @@ module ResourceDSL
       scoped_collection_action :async_destroy,
                                title: 'Delete batch',
                                if: proc { authorized?(:batch_destroy, resource_klass) } do
-        AsyncBatchDestroyJob.perform_later(model_class, scoped_collection_records.except(:eager_load).to_sql, @paper_trail_info)
+        AsyncBatchDestroyJob.perform_later(model_class, scoped_collection_records.except(:eager_load, :preload).to_sql, @paper_trail_info)
         flash[:notice] = I18n.t('flash.actions.batch_actions.batch_destroy.job_scheduled')
         head 200
       end


### PR DESCRIPTION
## Description

Update AsyncBatchDestroyJob to handle destroy failures

The AsyncBatchDestroyJob has been refactored to handle destroy failures, instead of raising errors. A warning is logged if a destroy operation fails, improving the robustness of the job. Corresponding changes have also been made to the related test cases.

## Additional links

closes #1276
