### PR TITLE
fix customer auth active calls metrics price, send metric when empty CustomerAuthStats for the last 24 hours

### DIFF
--- a/app/jobs/jobs/prometheus_customer_auth_stats.rb
+++ b/app/jobs/jobs/prometheus_customer_auth_stats.rb
@@ -8,8 +8,10 @@ module Jobs
 
     def execute
       client = PrometheusExporter::Client.default
+      metrics = []
+      metrics << CustomerAuthProcessor.collect(alive: 1)
       Stats::CustomerAuthStats.last24_hour.each do |stat|
-        metric = CustomerAuthProcessor.collect(
+        metrics << CustomerAuthProcessor.collect(
           last24h_customer_price: stat.customer_price.to_f,
           labels: {
             account_id: stat.account_id,
@@ -19,8 +21,8 @@ module Jobs
             customer_auth_external_type: stat.customer_auth_external_type
           }
         )
-        client.send_json(metric)
       end
+      metrics.each { |metric| client.send_json(metric) }
     end
   end
 end

--- a/lib/prometheus/customer_auth_collector.rb
+++ b/lib/prometheus/customer_auth_collector.rb
@@ -3,6 +3,7 @@
 class CustomerAuthCollector < PrometheusExporter::Server::TypeCollector
   MAX_METRIC_AGE = 30
   GAUGES = {
+    alive: '1 if PrometheusCustomerAuthStats job is alive, otherwise missing',
     last24h_customer_price: 'total customer price originated by customer auth in last 24 hours'
   }.freeze
 

--- a/spec/jobs/jobs/calls_monitoring_spec.rb
+++ b/spec/jobs/jobs/calls_monitoring_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Jobs::CallsMonitoring, '#call' do
           .with(
             type: 'yeti_ac',
             ca: 1,
-            ca_price_originated: 1.04, # +1.04 normal call -5 reverse call
+            ca_price_originated: 1.02, # +1.02 normal call
             metric_labels: {
               id: customers_auth.id,
               external_id: customers_auth.external_id,
@@ -353,7 +353,7 @@ RSpec.describe Jobs::CallsMonitoring, '#call' do
           .with(
             type: 'yeti_ac',
             ca: 1,
-            ca_price_originated: -5,
+            ca_price_originated: -5, # -5 reverse call
             metric_labels: {
               id: customers_auth2.id,
               external_id: customers_auth2.external_id,
@@ -402,7 +402,7 @@ RSpec.describe Jobs::CallsMonitoring, '#call' do
             .with(
               type: 'yeti_ac',
               ca: 2,
-              ca_price_originated: -3.96, # +1.04 normal call -5 reverse call
+              ca_price_originated: -3.98, # +1.02 normal call -5 reverse call
               metric_labels: {
                 id: customers_auth.id,
                 external_id: customers_auth.external_id,

--- a/spec/jobs/jobs/prometheus_customer_auth_stats_spec.rb
+++ b/spec/jobs/jobs/prometheus_customer_auth_stats_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Jobs::PrometheusCustomerAuthStats do
 
   it 'sends prometheus metrics' do
     expect { subject }.to send_prometheus_metrics
-      .exactly(3)
+      .exactly(4)
+      .with(type: 'yeti_ca', alive: 1, metric_labels: {})
       .with(type: 'yeti_ca',
             last24h_customer_price: 0.3,
             metric_labels: {


### PR DESCRIPTION
- fix customer auth active calls metrics price (estimated price must be counted only for current call duration)
- send metric when empty CustomerAuthStats for the last 24 hours (to prevent invalid data caching on prometheus exporter)side