### PR TITLE
admin UI: cdr exports fix

### DIFF
--- a/app/models/cdr_export.rb
+++ b/app/models/cdr_export.rb
@@ -80,6 +80,18 @@ class CdrExport < ApplicationRecord
     attribute :customer_auth_external_id_in, :integer, array: { reject_blank: true }
     attribute :dst_country_iso_in, :string, array: { reject_blank: true }
     attribute :src_country_iso_in, :string, array: { reject_blank: true }
+
+    def customer_auth_external_id_in=(v)
+      super(v.presence)
+    end
+
+    def dst_country_iso_in=(v)
+      super(v.presence)
+    end
+
+    def src_country_iso_in=(v)
+      super(v.presence)
+    end
   end
 
   STATUS_PENDING = 'Pending'

--- a/spec/features/cdr/cdr_exports/copy_cdr_export_spec.rb
+++ b/spec/features/cdr/cdr_exports/copy_cdr_export_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Copy CDR Export', js: :true do
       term_gw_external_id_eq: gateway.external_id,
       customer_auth_external_type_eq: customer_auth.external_type,
       customer_auth_external_type_not_eq: customer_auth.external_type,
-      customer_auth_external_id_in: [],
       src_country_iso_in: [country.iso2, country.iso2],
       dst_country_iso_in: [country.iso2, country.iso2]
     }
@@ -126,9 +125,6 @@ RSpec.describe 'Copy CDR Export', js: :true do
                               filters_json: {
                                 time_start_gteq: '2018-01-01T00:00:00.000Z',
                                 time_start_lteq: '2018-03-01T00:00:00.000Z',
-                                customer_auth_external_id_in: [],
-                                src_country_iso_in: [],
-                                dst_country_iso_in: [],
                                 customer_external_id_eq: 9998
                               }
                             )

--- a/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
+++ b/spec/features/cdr/cdr_exports/new_cdr_export_spec.rb
@@ -39,10 +39,7 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(cdr_export.filters_json).to match(
         time_start_gteq: '2018-01-01T00:00:00.000Z',
         time_start_lteq: '2018-03-01T00:00:00.000Z',
-        customer_acc_id_eq: account.id,
-        customer_auth_external_id_in: [],
-        dst_country_iso_in: [],
-        src_country_iso_in: []
+        customer_acc_id_eq: account.id
       )
     end
   end
@@ -74,10 +71,7 @@ RSpec.describe 'Create new CDR export', js: true do
       expect(cdr_export.filters_json).to match(
         time_start_gteq: '2018-01-01T00:00:00.000Z',
         time_start_lteq: '2018-03-01T00:00:00.000Z',
-        customer_acc_id_eq: account.id,
-        customer_auth_external_id_in: [],
-        dst_country_iso_in: [],
-        src_country_iso_in: []
+        customer_acc_id_eq: account.id
       )
     end
   end
@@ -241,10 +235,7 @@ RSpec.describe 'Create new CDR export', js: true do
                             )
       expect(cdr_export.filters_json).to match(
         time_start_gteq: '2018-01-01T00:00:00.000Z',
-        time_start_lteq: '2018-03-01T00:00:00.000Z',
-        customer_auth_external_id_in: [],
-        dst_country_iso_in: [],
-        src_country_iso_in: []
+        time_start_lteq: '2018-03-01T00:00:00.000Z'
       )
     end
   end
@@ -272,10 +263,7 @@ RSpec.describe 'Create new CDR export', js: true do
                             )
       expect(cdr_export.filters_json).to match(
         time_start_gteq: '2018-01-01T00:00:00.000Z',
-        time_start_lt: '2018-03-01T00:00:00.000Z',
-        customer_auth_external_id_in: [],
-        dst_country_iso_in: [],
-        src_country_iso_in: []
+        time_start_lt: '2018-03-01T00:00:00.000Z'
       )
     end
   end


### PR DESCRIPTION
prevent the creation of empty customer_auth_external_id_in/dst_country_iso_in/src_country_iso_in filters by default cause generated SQL will exclude all records (empty CSV file)

regression here - https://github.com/yeti-switch/yeti-web/pull/1345