### PR TITLE
YETIWEB-1398, Feature: Introduce API Log tags

### DIFF
--- a/app/admin/logs/api_logs.rb
+++ b/app/admin/logs/api_logs.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
 
   controller do
     def scoped_collection
-      super.select('id, created_at, status, method, path, db_duration, page_duration, remote_ip')
+      super.select('id, created_at, status, method, path, db_duration, page_duration, remote_ip, tags')
     end
 
     def find_resource
@@ -27,6 +27,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
   filter :created_at, as: :date_time_range
   filter :path
   filter :method
+  filter :tag_eq, label: 'Tag Equals'
   filter :status
   filter :controller, as: :select, collection: proc { ApiControllers.list }, input_html: { class: :chosen }
   filter :action
@@ -44,6 +45,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
     column :created_at
     column :status
     column :method
+    column :tags, &:tags_separated_by_comma
     column :path
     column :db_duration
     column :page_duration
@@ -56,6 +58,7 @@ ActiveAdmin.register Log::ApiLog, as: 'ApiLog' do
       row :created_at
       row :status
       row :method
+      row :tags, &:tags_separated_by_comma
       row :path
       row :controller
       row :action

--- a/app/decorators/api_log_decorator.rb
+++ b/app/decorators/api_log_decorator.rb
@@ -35,4 +35,10 @@ class ApiLogDecorator < Draper::Decorator
       ''
     end
   end
+
+  def tags_separated_by_comma
+    return if model.tags.empty?
+
+    model.tags.join(', ')
+  end
 end

--- a/app/models/log/api_log.rb
+++ b/app/models/log/api_log.rb
@@ -19,6 +19,7 @@
 #  response_body    :text
 #  response_headers :text
 #  status           :integer(4)
+#  tags             :string           default([]), is an Array
 #  created_at       :timestamptz      not null
 #
 # Indexes
@@ -38,6 +39,7 @@ class Log::ApiLog < ApplicationRecord
   self.pg_partition_depth_future = 3
 
   scope :failed, -> { where('status >= ?', 400) }
+  scope :tag_eq, ->(value) { where.any(tags: value) }
   scope :remote_ip_eq_inet, lambda { |value|
     begin
       remote_ip = IPAddr.new(value).to_s
@@ -52,6 +54,6 @@ class Log::ApiLog < ApplicationRecord
   end
 
   def self.ransackable_scopes(_auth_object = nil)
-    %i[remote_ip_eq_inet]
+    %i[remote_ip_eq_inet tag_eq]
   end
 end

--- a/config/initializers/instrumentation_notification.rb
+++ b/config/initializers/instrumentation_notification.rb
@@ -21,6 +21,7 @@ module ActionController
         params: request.filtered_parameters,
         format: request.format.try(:ref),
         method: request.method,
+        tags: YetiConfig.api_log_tags || [],
         path: (begin
                       request.fullpath
                rescue StandardError
@@ -59,6 +60,7 @@ ActiveSupport::Notifications.subscribe 'process_action.action_controller' do |_n
         api_request.page_duration = (finish - start) * 1000
         api_request.db_duration = payload[:db_runtime]
         api_request.method = payload[:method]
+        api_request.tags = payload[:tags]
         api_request.status = payload[:status]
         api_request.controller = payload[:controller]
         api_request.action = payload[:action]

--- a/config/yeti_web.yml.development
+++ b/config/yeti_web.yml.development
@@ -40,3 +40,6 @@ versioning_disable_for_models:
 keep_expired_dialpeers_days: 30
 keep_expired_destinations_days: 30
 keep_balance_notifications_days: 30
+
+api_log_tags:
+  - SOME_TAG_FOR_API_LOG

--- a/config/yeti_web.yml.distr
+++ b/config/yeti_web.yml.distr
@@ -40,3 +40,6 @@ versioning_disable_for_models:
 keep_expired_dialpeers_days:
 keep_expired_destinations_days:
 keep_expired_destinations_days:
+
+api_log_tags:
+  - SOME_TAG_FOR_API_LOG

--- a/db/migrate/20231227093950_add_column_to_api_log_table.rb
+++ b/db/migrate/20231227093950_add_column_to_api_log_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddColumnToApiLogTable < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'logs.api_requests', :tags, :string, array: true, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25426,7 +25426,8 @@ CREATE TABLE logs.api_requests (
     request_headers text,
     response_headers text,
     meta jsonb,
-    remote_ip inet
+    remote_ip inet,
+    tags character varying[] DEFAULT '{}'::character varying[]
 )
 PARTITION BY RANGE (created_at);
 
@@ -31578,6 +31579,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20231106095901'),
 ('20231106100113'),
 ('20231107100745'),
-('20231206200530');
+('20231206200530'),
+('20231227093950');
 
 

--- a/spec/factories/log/api_logs.rb
+++ b/spec/factories/log/api_logs.rb
@@ -2,22 +2,30 @@
 
 # == Schema Information
 #
-# Table name: api_requests
+# Table name: logs.api_requests
 #
-#  id               :integer          not null, primary key
-#  created_at       :datetime         not null
-#  path             :string
-#  method           :string
-#  status           :integer
-#  controller       :string
+#  id               :bigint(8)        not null, primary key
 #  action           :string
-#  page_duration    :float
+#  controller       :string
 #  db_duration      :float
+#  meta             :jsonb
+#  method           :string
+#  page_duration    :float
 #  params           :text
+#  path             :string
+#  remote_ip        :inet
 #  request_body     :text
-#  response_body    :text
 #  request_headers  :text
+#  response_body    :text
 #  response_headers :text
+#  status           :integer(4)
+#  tags             :string           default([]), is an Array
+#  created_at       :timestamptz      not null
+#
+# Indexes
+#
+#  api_requests_created_at_idx  (created_at)
+#  api_requests_id_idx          (id)
 #
 
 FactoryBot.define do
@@ -34,6 +42,7 @@ FactoryBot.define do
     response_body { nil }
     request_headers { nil }
     response_headers { nil }
+    tags { [] }
 
     before(:create) do |record, _evaluator|
       Log::ApiLog.add_partition_for(record.created_at || Time.now.utc)

--- a/spec/features/log/api_logs/index_api_logs_spec.rb
+++ b/spec/features/log/api_logs/index_api_logs_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Index Log Api Logs', type: :feature do
       expect(page).to have_table_row count: 2
       expect(page).to have_table_cell column: 'Id', exact_text: api_log_first.id
       expect(page).to have_table_cell column: 'Id', exact_text: api_log_second.id
+      expect(page).to have_table_cell column: 'Tags', exact_text: ''
       expect(page).not_to have_link 'CSV'
     end
   end
@@ -57,6 +58,37 @@ RSpec.describe 'Index Log Api Logs', type: :feature do
 
         expect(page).to have_table_row count: 1
         expect(page).to have_table_cell column: 'Id', exact_text: record.id
+      end
+    end
+
+    describe 'by "Tag Equals"' do
+      context 'when filter by tag1' do
+        let(:record_attrs) { super().merge tags: %w[tag1 tag2] }
+
+        before do
+          FactoryBot.create(:api_log, tags: %w[tag5])
+          allow(YetiConfig).to receive(:api_log_tags).and_return(%w[tag1 tag2])
+          visit api_logs_path
+          fill_in 'Tag Equals', with: 'tag1'
+        end
+
+        it 'should render filtered records only' do
+          subject
+
+          expect(page).to have_table_row count: 1
+          expect(page).to have_table_cell column: 'Id', exact_text: record.id
+        end
+      end
+
+      context 'when there is NO any "api_log_tags" configuration' do
+        before do
+          allow(YetiConfig).to receive(:api_log_tags).and_return(nil)
+          visit api_logs_path
+        end
+
+        it 'should render index page properly' do
+          expect(page).to have_page_title 'Api Logs'
+        end
       end
     end
   end

--- a/spec/features/log/api_logs/show_api_logs_spec.rb
+++ b/spec/features/log/api_logs/show_api_logs_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Show Log Api Logs' do
+  include_context :login_as_admin
+
+  let(:record_attrs) { {} }
+  let!(:record) { FactoryBot.create(:api_log, record_attrs) }
+
+  context 'when visit valid API Log' do
+    let(:record_attrs) { super().merge tags: %w[tag1 tag2] }
+
+    before { visit api_log_path(record) }
+
+    it 'should render show page properly' do
+      expect(page).to have_page_title record.id
+      expect(page).to have_attribute_row('Controller', exact_text: record.controller)
+      expect(page).to have_attribute_row('Tags', exact_text: 'tag1, tag2')
+    end
+  end
+end

--- a/spec/models/log/api_log_spec.rb
+++ b/spec/models/log/api_log_spec.rb
@@ -19,6 +19,7 @@
 #  response_body    :text
 #  response_headers :text
 #  status           :integer(4)
+#  tags             :string           default([]), is an Array
 #  created_at       :timestamptz      not null
 #
 # Indexes

--- a/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
+++ b/spec/requests/api/rest/admin/routing/area_prefixes_spec.rb
@@ -48,5 +48,29 @@ RSpec.describe Api::Rest::Admin::Routing::AreaPrefixesController, type: :request
         expect(Log::ApiLog.last).to have_attributes(meta: nil, remote_ip: '127.0.0.1')
       end
     end
+
+    context 'when YETI WEB is configured with API Log tag USA' do
+      before do
+        allow(Thread).to receive(:new).and_yield
+        allow(YetiConfig).to receive(:api_log_tags).and_return(%w[USA])
+      end
+
+      it 'creates Log::ApiLog with USA tag' do
+        expect { subject }.to change { Log::ApiLog.count }.by(1)
+        expect(Log::ApiLog.last).to have_attributes(tags: %w[USA])
+      end
+    end
+
+    context 'when there is NO API Log Tags configuration' do
+      before do
+        allow(Thread).to receive(:new).and_yield
+        allow(YetiConfig).to receive(:api_log_tags).and_return(nil)
+      end
+
+      it 'creates Log::ApiLog without tags' do
+        expect { subject }.to change { Log::ApiLog.count }.by(1)
+        expect(Log::ApiLog.last).to have_attributes(tags: [])
+      end
+    end
   end
 end


### PR DESCRIPTION
Introduce API Log tags. So you can add tag/tags "api_log_tags" config to the "yeti_web.yml" configuration file, and this value will be added to each API log record.

Admin UI changes:
- added column tags for the index page of the API Log
- added column tags for show page of API Log
- added filter Tag Contains for the index page of API Log

closes #1398

## Screenshot:

<img width="1913" alt="Screenshot 2023-12-27 at 12 17 51" src="https://github.com/yeti-switch/yeti-web/assets/10907664/13d01b95-57ae-4029-81e0-dc1666ad5f5c">

