### PR TITLE
Customer API: create API Log even when an invalid request format

### DIFF
--- a/config/initializers/instrumentation_notification.rb
+++ b/config/initializers/instrumentation_notification.rb
@@ -17,7 +17,7 @@ module ActionController
       raw_payload = {
         controller: self.class.name,
         action: action_name,
-        meta: meta,
+        meta: try(:meta),
         params: request.filtered_parameters,
         format: request.format.try(:ref),
         method: request.method,

--- a/spec/config/initializers/instrumentation_notification_spec.rb
+++ b/spec/config/initializers/instrumentation_notification_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe 'instrumentation_notification.rb', type: :request do
+  describe 'creation API Logs' do
+    context 'when perform invalid request format' do
+      subject { get '/api/rest/invalid_request/1/format' }
+
+      before { allow(Thread).to receive(:new).and_yield }
+
+      it 'should create Log::ApiLog with properly attributes' do
+        expect { subject }.to change(Log::ApiLog, :count).by(1)
+
+        expect(Log::ApiLog.last!).to have_attributes(
+          path: '/api/rest/invalid_request/1/format',
+          controller: 'ApplicationController',
+          action: 'render_404',
+          method: 'GET',
+          request_body: nil,
+          request_headers: nil,
+          response_body: nil,
+          response_headers: nil,
+          status: 404,
+          remote_ip: nil
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

When an invalid request is performed, the application crashes with error:
```
undefined local variable or method `meta' for #<ApplicationController:0x000000001d1960
```
and instead of the 404 response, the YETI app returns a 500 response, so I fixed this wrong behaviour and instead of the 500 error app will create the API Log and then return a 404 response.

### Additional info:
there is app logs when invalid request is received.
```
Started GET "/api/rest/invalid_request/1/format" for 127.0.0.1 at 2024-01-08 18:32:08 +0200
Processing by ApplicationController#render_404 as HTML
  Parameters: {"a"=>"api/rest/invalid_request/1/format"}
  Rendering layout layouts/application.html.erb
  Rendering 404.html.erb within layouts/application
  Rendered 404.html.erb within layouts/application (Duration: 1.7ms | Allocations: 1048)
  Rendered layout layouts/application.html.erb (Duration: 490.4ms | Allocations: 405928)
Completed 404 Not Found in 500ms (Views: 496.2ms | ActiveRecord: 0.0ms | Allocations: 408208)
  TRANSACTION (0.6ms)  SAVEPOINT active_record_1
  ↳ config/initializers/instrumentation_notification.rb:49:in `block (2 levels) in <main>'
  Log::ApiLog Create (1.1ms)  INSERT INTO "logs"."api_requests" ("created_at", "path", "method", "status", "controller", "action", "page_duration", "db_duration", "params", "request_body", "response_body", "request_headers", "response_headers", "meta", "remote_ip", "tags") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING "id"  [["created_at", "2024-01-08 16:32:09.136451"], ["path", "/api/rest/invalid_request/1/format"], ["method", "GET"], ["status", 404], ["controller", "ApplicationController"], ["action", "render_404"], ["page_duration", 499.808], ["db_duration", 0.0], ["params", "--- !ruby/hash:ActiveSupport::HashWithIndifferentAccess\ncontroller: application\naction: render_404\na: api/rest/invalid_request/1/format\n"], ["request_body", nil], ["response_body", nil], ["request_headers", nil], ["response_headers", nil], ["meta", nil], ["remote_ip", nil], ["tags", "{}"]]
  ↳ config/initializers/instrumentation_notification.rb:49:in `block (2 levels) in <main>'
  TRANSACTION (0.5ms)  RELEASE SAVEPOINT active_record_1
  ↳ config/initializers/instrumentation_notification.rb:49:in `block (2 levels) in <main>'
  Log::ApiLog Count (0.9ms)  SELECT COUNT(*) FROM "logs"."api_requests"
  Log::ApiLog Load (0.6ms)  SELECT "logs"."api_requests".* FROM "logs"."api_requests" ORDER BY "logs"."api_requests"."id" DESC LIMIT $1  [["LIMIT", 1]]
  TRANSACTION (1.3ms)  ROLLBACK
  TRANSACTION (0.8ms)  ROLLBACK
Shutting down background worker
Killing session flusher
```

### Additional links:
closes #1402 