### PR TITLE
bump puma gem from v6.3.1 to v6.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,7 +659,7 @@ GEM
     pgq_prometheus (0.2.3)
       prometheus_exporter
     public_suffix (4.0.6)
-    puma (6.3.1)
+    puma (6.4.2)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
There is vulnerability inside puma gem

### Description
Invalid parsing of chunked encoding in HTTP/1.1 allows DoS attacks

### Additional info
```
Name: puma
Version: 6.3.1
CVE: CVE-2024-21647
GHSA: GHSA-c2f4-cvqm-65w2
Criticality: Medium
URL: https://github.com/puma/puma/security/advisories/GHSA-c2f4-cvqm-65w2
Title: Puma HTTP Request/Response Smuggling vulnerability
Solution: upgrade to '~> 5.6.8', '>= 6.4.2'
```

notice: the new tag `1.12.127` is required

### Additional links
closes #1406 