### PR TITLE
#1421 vulnerability inside nokogiri gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,7 +448,7 @@ GEM
       net-protocol
     netstring (0.0.3)
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (3.11.2)


### PR DESCRIPTION
```
Name: nokogiri
Version: 1.15.2
GHSA: GHSA-xc9x-jj77-9p9j
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j
Title: Improper Handling of Unexpected Data Type in Nokogiri
Solution: upgrade to '>= 1.16.2'
```