### PR TITLE
Fix reading the metadata from replica DB for API Log

### DIFF
--- a/config/initializers/instrumentation_notification.rb
+++ b/config/initializers/instrumentation_notification.rb
@@ -17,7 +17,6 @@ module ActionController
       raw_payload = {
         controller: self.class.name,
         action: action_name,
-        meta: try(:meta),
         params: request.filtered_parameters,
         format: request.format.try(:ref),
         method: request.method,
@@ -35,6 +34,7 @@ module ActionController
       ActiveSupport::Notifications.instrument('process_action.action_controller', raw_payload) do |payload|
         result = super
         payload[:status] = response.status
+        payload[:meta] = try(:meta)
         append_info_to_payload(payload)
         result
       end


### PR DESCRIPTION
Related issue https://github.com/yeti-switch/yeti-web/pull/1403/files