### PR TITLE
resolve GHSA-r95h-9x8f-r3f7 vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,7 +447,7 @@ GEM
       net-protocol
     netstring (0.0.3)
     nio4r (2.5.9)
-    nokogiri (1.16.2)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (3.11.2)


### PR DESCRIPTION
update nokogiri for resolve GHSA-r95h-9x8f-r3f7 vulnerability