### PR TITLE
bug fix: for cdrs page, failed request when submit visible columns

### DIFF
--- a/app/admin/cdr/cdrs.rb
+++ b/app/admin/cdr/cdrs.rb
@@ -607,7 +607,7 @@ ActiveAdmin.register Cdr::Cdr, as: 'CDR' do
     end
   end
 
-  index do
+  index download_links: %i[csv json] do
     column :id do |cdr|
       if cdr.has_dump?
         if cdr.has_recording?

--- a/app/assets/javascripts/index_as_table_visible_columns.js
+++ b/app/assets/javascripts/index_as_table_visible_columns.js
@@ -9,10 +9,7 @@ $(document).ready(function(){
                     var $select = $(this).closest('#block_available_columns').find('select'),
                         selected_fields = $select.val();
                     $(this).parent().find('.ui-dialog-buttonset').text('Loading...');
-                    $.getJSON(
-                        this.href,
-                        {index_table_visible_columns: selected_fields}
-                    ).success(function(){
+                    $.getJSON(this.href, {index_table_visible_columns: selected_fields}, function() {
                         window.location.reload();
                     });
                 },
@@ -27,7 +24,7 @@ $(document).ready(function(){
         });
 
         $('#reset_visible_columns').click(function(){
-            $.getJSON(this.href, {index_table_visible_columns: ''}).success(function(){
+            $.getJSON(this.href, {index_table_visible_columns: ''}, function () {
                 window.location.reload();
             });
         });

--- a/spec/features/cdr/cdr_history/cdrs_index_spec.rb
+++ b/spec/features/cdr/cdr_history/cdrs_index_spec.rb
@@ -98,4 +98,35 @@ RSpec.describe 'CDRs index', type: :feature do
       expect(page).to have_table_cell(column: 'ID', exact_text: cdr.id)
     end
   end
+
+  describe 'Visible columns feature' do
+    context 'when click to "Reset" link' do
+      subject { click_link :Reset }
+
+      let!(:admin_user) { create :admin_user, visible_columns: { cdrs: %w[id] } }
+
+      before { visit cdrs_path }
+
+      it 'should click to "Reset" link', js: true do
+        expect { subject }.to change { admin_user.reload.visible_columns['cdrs'] }.from(%w[id]).to('')
+      end
+    end
+
+    context 'when select the several columns and submit form' do
+      subject { click_button 'Show' }
+
+      let!(:admin_user) { create :admin_user, visible_columns: { cdrs: %w[id] } }
+
+      before do
+        visit cdrs_path
+        click_link 'Visible columns'
+        select 'time_start', from: 'select_available_columns'
+        select 'time_end', from: 'select_available_columns'
+      end
+
+      it 'should reload index page and then render only selected columns', js: true do
+        expect { subject }.to change { admin_user.reload.visible_columns }.from({ 'cdrs' => %w[id] }).to({ 'cdrs' => %w[id time_start time_end] })
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

added the `json` download links for CDR admin index page because the ActiveAdmin has build in
condition see below:

```
def restrict_format_access!
  unless request.format.html?
    presenter = active_admin_config.get_page_presenter(:index)
    download_formats = (presenter || {}).fetch(:download_links, active_admin_config.namespace.download_links)
    unless build_download_formats(download_formats).include?(request.format.symbol)
      raise ActiveAdmin::AccessDenied.new(current_active_admin_user, :index)
    end
  end
end
```

so download_formats it is actually download_links from index page

## Additional links

closes #1363