### PR TITLE
allow to ContactEmailSender to create email log even when there is SMTP setting

### DIFF
--- a/app/domain/contact_email_sender.rb
+++ b/app/domain/contact_email_sender.rb
@@ -24,6 +24,8 @@ class ContactEmailSender
   # @param message [String,nil]
   # @param attachments [Array<Notification::Attachment,nil]
   def send_email(subject:, message: nil, attachments: nil)
+    return if contact.smtp_connection.nil?
+
     ApplicationRecord.transaction do
       email_log = create_email_log(
         subject: subject,


### PR DESCRIPTION
### Description

when we perform `ContactEmailSender.batch_send_emails(contacts, subject: 'text', message: 'message')`

the Email log is not created due there is no any SMTP configs even global

To imptove this logic I suggest to remove `not null` constraint from `mail_from` column of `notifications.email_logs` table and do not fill in this column when we perform `batch_send_emails` method.
As result we will able to view Email Log (Logs->Email Log) and determinate that curently there is no any SMTP config and it should be created for specific contact or Global one.

### Additional links

closes #1395