### PR TITLE
bump rexml from v3.2.8 to v3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -715,8 +715,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)


### PR DESCRIPTION
### Description

fix vulnerability
```
Name: rexml
Version: 3.2.8
CVE: CVE-2024-39908
Criticality: Unknown
URL: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8
Title: DoS in REXML
Solution: upgrade to '>= 3.3.2'
```