### PR TITLE
fix float test when render routing tags

### DIFF
--- a/spec/features/cdr/cdr_history/cdr_show_spec.rb
+++ b/spec/features/cdr/cdr_history/cdr_show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'CDR show', type: :feature do
     subject
     expect(page).to have_table_row(count: 1)
     expect(page).to have_attribute_row('ID', exact_text: cdr.id)
-    expect(page).to have_attribute_row('Routing Tags', exact_text: "#{tag_ua.name} #{tag_us.name}")
+    expect(find(attributes_row_selector('Routing Tags')).text.split).to match_array([tag_ua.name, tag_us.name])
     within_attribute_row('Routing Tags') do
       expect(page).to have_selector('.status_tag.ok', text: tag_ua.name)
       expect(page).to have_selector('.status_tag.ok', text: tag_us.name)
@@ -33,7 +33,7 @@ RSpec.describe 'CDR show', type: :feature do
     subject
     expect(page).to have_table_row(count: 1)
     expect(page).to have_table_cell(column: 'Id', exact_text: cdr.id)
-    expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{tag_ua.name} #{tag_us.name}")
+    expect(find(table_cell_selector('Routing Tags')).text.split).to match_array([tag_ua.name, tag_us.name])
     within_table_cell('Routing Tags') do
       expect(page).to have_selector('.status_tag.ok', exact_text: tag_ua.name)
       expect(page).to have_selector('.status_tag.ok', exact_text: tag_us.name)
@@ -78,7 +78,7 @@ RSpec.describe 'CDR show', type: :feature do
       subject
       expect(page).to have_table_row(count: 1)
       expect(page).to have_attribute_row('ID', exact_text: cdr.id)
-      expect(page).to have_attribute_row('Routing Tags', exact_text: "#{tag_ua.name} 9454 #{tag_us.name}")
+      expect(find(attributes_row_selector('Routing Tags')).text.split).to match_array([tag_ua.name, '9454', tag_us.name])
       within_attribute_row('Routing Tags') do
         expect(page).to have_selector('.status_tag.ok', exact_text: tag_ua.name)
         expect(page).to have_selector('.status_tag.no', exact_text: '9454')
@@ -90,7 +90,7 @@ RSpec.describe 'CDR show', type: :feature do
       subject
       expect(page).to have_table_row(count: 1)
       expect(page).to have_table_cell(column: 'Id', exact_text: cdr.id)
-      expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{tag_ua.name} 9454 #{tag_us.name}")
+      expect(find(table_cell_selector('Routing Tags')).text.split).to match_array([tag_ua.name, '9454', tag_us.name])
       within_table_cell('Routing Tags') do
         expect(page).to have_selector('.status_tag.ok', exact_text: tag_ua.name)
         expect(page).to have_selector('.status_tag.no', exact_text: '9454')

--- a/spec/features/cdr/cdr_history/cdrs_index_spec.rb
+++ b/spec/features/cdr/cdr_history/cdrs_index_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'CDRs index', type: :feature do
 
     within_table_row(id: cdrs.first.id) do
       expect(page).to have_table_cell(column: 'Id', exact_text: cdr_no_tags.id)
-      expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{tag_ua.name} 321 #{tag_us.name}")
+      expect(find(table_cell_selector('Routing Tags')).text.split).to match_array([tag_ua.name, '321', tag_us.name])
       within_table_cell('Routing Tags') do
         expect(page).to have_selector('.status_tag.ok', exact_text: tag_ua.name)
         expect(page).to have_selector('.status_tag.no', exact_text: '321')
@@ -51,7 +51,7 @@ RSpec.describe 'CDRs index', type: :feature do
 
     within_table_row(id: cdrs.second.id) do
       expect(page).to have_table_cell(column: 'Id', exact_text: cdr_no_tags.id)
-      expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{tag_ua.name} 321 #{tag_us.name}")
+      expect(find(table_cell_selector('Routing Tags')).text.split).to match_array([tag_ua.name, '321', tag_us.name])
       within_table_cell('Routing Tags') do
         expect(page).to have_selector('.status_tag.ok', exact_text: tag_ua.name)
         expect(page).to have_selector('.status_tag.no', exact_text: '321')
@@ -76,7 +76,7 @@ RSpec.describe 'CDRs index', type: :feature do
       subject
       expect(page).to have_table_row(count: 1)
       expect(page).to have_table_cell(column: 'ID', exact_text: cdr_with_one_tag.id)
-      expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{routing_tag.name.upcase} #{tag_ua.name.upcase}")
+      expect(find(table_cell_selector('Routing Tags')).text.split).to match_array([routing_tag.name.upcase, tag_ua.name.upcase])
     end
   end
 

--- a/spec/features/rate_management/pricelist_item/index_spec.rb
+++ b/spec/features/rate_management/pricelist_item/index_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
           expect(page).to have_table_cell(column: 'ID', exact_text: item.id.to_s)
           expect(page).to have_table_cell(column: 'Prefix', exact_text: item.prefix)
           expect(page).to have_table_cell(column: 'Connect Fee', exact_text: item.connect_fee.to_s)
-          expect(page).to have_table_cell(column: 'Routing Tags', exact_text: item.routing_tags.map(&:name).map(&:upcase).join(' | '))
+          expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array item.routing_tags.map(&:name).map(&:upcase)
           expect(page).to have_table_cell(column: 'Initial Rate', exact_text: item.initial_rate.to_s)
           expect(page).to have_table_cell(column: 'Next Rate', exact_text: item.next_rate.to_s)
           expect(page).to have_table_cell(column: 'Vendor', exact_text: item.vendor.display_name)
@@ -116,7 +116,7 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
             expect(page).to have_table_cell(column: 'ID', exact_text: item.id.to_s)
             expect(page).to have_table_cell(column: 'Prefix', exact_text: item.prefix)
             expect(page).to have_table_cell(column: 'Connect Fee', exact_text: item.connect_fee.to_s)
-            expect(page).to have_table_cell(column: 'Routing Tags', exact_text: item.routing_tags.map(&:name).map(&:upcase).join(' | '))
+            expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array(item.routing_tags.map(&:name).map(&:upcase))
             expect(page).to have_table_cell(column: 'Initial Rate', exact_text: item.initial_rate.to_s)
             expect(page).to have_table_cell(column: 'Next Rate', exact_text: item.next_rate.to_s)
             expect(page).to have_table_cell(column: 'Vendor', exact_text: item.vendor.display_name)
@@ -879,7 +879,7 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
               expect(page).to have_table_cell(column: 'Dialpeer', exact_text: 'EMPTY')
               expect(page).to have_table_cell(column: 'Prefix', exact_text: item.prefix)
               expect(page).to have_table_cell(column: 'Connect Fee', exact_text: item.connect_fee.to_s)
-              expect(page).to have_table_cell(column: 'Routing Tags', exact_text: item.routing_tags.map(&:name).map(&:upcase).join(' | '))
+              expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array(item.routing_tags.map(&:name).map(&:upcase))
               expect(page).to have_table_cell(column: 'Initial Rate', exact_text: item.initial_rate.to_s)
               expect(page).to have_table_cell(column: 'Next Rate', exact_text: item.next_rate.to_s)
               expect(page).to have_table_cell(column: 'Vendor', exact_text: item.vendor.display_name)
@@ -931,7 +931,7 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
               expect(page).to have_table_cell(column: 'Dialpeer', exact_text: item.detected_dialpeer_ids.first.to_s)
               expect(page).to have_table_cell(column: 'Prefix', exact_text: item.prefix)
               expect(page).to have_table_cell(column: 'Connect Fee', exact_text: item.connect_fee.to_s)
-              expect(page).to have_table_cell(column: 'Routing Tags', exact_text: item.routing_tags.map(&:name).map(&:upcase).join(' | '))
+              expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array(item.routing_tags.map(&:name).map(&:upcase))
               expect(page).to have_table_cell(column: 'Initial Rate', exact_text: item.initial_rate.to_s)
               expect(page).to have_table_cell(column: 'Next Rate', exact_text: item.next_rate.to_s)
               expect(page).to have_table_cell(column: 'Vendor', exact_text: item.vendor.display_name)
@@ -983,7 +983,7 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
               expect(page).to have_table_cell(column: 'Dialpeer', exact_text: item.detected_dialpeer_ids.first.to_s)
               expect(page).to have_table_cell(column: 'Prefix', exact_text: item.prefix)
               expect(page).to have_table_cell(column: 'Connect Fee', exact_text: item.connect_fee.to_s)
-              expect(page).to have_table_cell(column: 'Routing Tags', exact_text: item.routing_tags.map(&:name).map(&:upcase).join(' | '))
+              expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array(item.routing_tags.map(&:name).map(&:upcase))
               expect(page).to have_table_cell(column: 'Initial Rate', exact_text: item.initial_rate.to_s)
               expect(page).to have_table_cell(column: 'Next Rate', exact_text: item.next_rate.to_s)
               expect(page).to have_table_cell(column: 'Vendor', exact_text: item.vendor.display_name)
@@ -1021,25 +1021,22 @@ RSpec.describe 'Rate Management Pricelist Items table', bullet: [:n], js: true d
     end
 
     context('when pricelist item include deleted rotuing tag id') do
-      let(:pricelist_items) do
-        [FactoryBot.create(:rate_management_pricelist_item,
-                           :filed_from_project,
-                           pricelist: pricelist,
-                           routing_tag_ids: project.routing_tag_ids + [523])]
+      let(:pricelist_items) { nil }
+      let!(:routing_tag) { FactoryBot.create(:routing_tag) }
+      let!(:pricelist_item) do
+        FactoryBot.create(:rate_management_pricelist_item,
+                          :filed_from_project,
+                          pricelist: pricelist,
+                          routing_tag_ids: [routing_tag.id, 523])
       end
 
-      it 'should render correct' do
+      it 'should render correct', js: false do
         subject
 
         within_main_content do
-          expect(page).to have_table_row(count: pricelist_items.size)
-          pricelist_items.each do |item|
-            within_table_row(id: item.id) do
-              expect(page).to have_table_cell(column: 'ID', exact_text: item.id.to_s)
-              routing_tags = project.routing_tags.map(&:name).join(' | ').upcase
-              expect(page).to have_table_cell(column: 'Routing Tags', exact_text: "#{routing_tags} | 523")
-            end
-          end
+          expect(page).to have_table_row(count: 1)
+          expect(page).to have_table_cell(column: 'ID', exact_text: pricelist_item.id.to_s)
+          expect(find(table_cell_selector('Routing Tags')).text.split(' | ')).to match_array [routing_tag.name, '523']
         end
       end
     end

--- a/spec/features/rate_management/project/show_spec.rb
+++ b/spec/features/rate_management/project/show_spec.rb
@@ -77,10 +77,10 @@ RSpec.describe 'Rate Management Project Show', js: true, bullet: [:n] do
       FactoryBot.create(:routing_tag)
     end
 
-    it 'shows all routing tags' do
+    it 'shows all routing tags', js: false do
       subject
-      routing_tag_names = record.routing_tags.map { |r| r.name.upcase }
-      expect(page).to have_attribute_row 'Routing Tags', exact_text: routing_tag_names.join(' | ')
+
+      expect(find(attributes_row_selector('Routing Tags')).text.split(' | ')).to match_array record.routing_tags.pluck(:name)
       expect(page).to have_attribute_row('Routing Tag Mode', exact_text: 'OR')
     end
   end

--- a/spec/features/routing/dialpeers/show_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/show_dialpeer_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe 'Show Dialpeer', type: :feature, js: true do
     expect(page).to have_attribute_row('ENABLED', exact_text: 'YES')
     expect(page).to have_attribute_row('LOCKED', exact_text: 'NO')
     expect(page).to have_attribute_row('ROUTING GROUP', exact_text: dialpeer.routing_group.display_name)
-    tags_line = "#{routing_tags.first.name.upcase} | #{routing_tags.third.name.upcase} | ANY TAG"
-    expect(page).to have_attribute_row('ROUTING TAGS', exact_text: tags_line)
+    expect(find(attributes_row_selector('ROUTING TAGS')).text.split(' | ')).to match_array [routing_tags.first.name.upcase, routing_tags.third.name.upcase, 'ANY TAG']
     expect(page).to have_attribute_row('ROUTING TAG MODE', exact_text: 'OR')
     expect(page).to have_attribute_row('VENDOR', exact_text: dialpeer.vendor.display_name)
     expect(page).to have_attribute_row('ACCOUNT', exact_text: dialpeer.account.display_name)


### PR DESCRIPTION
## Description

Refactored routing tag display in the test suite to use `match_array` matching instead of exact string comparison