### PR TITLE
1516, do not raise error when Node return not found

### DIFF
--- a/app/jobs/jobs/calls_monitoring.rb
+++ b/app/jobs/jobs/calls_monitoring.rb
@@ -406,6 +406,8 @@ module Jobs
         begin
           node_id = call[:node_id].to_i
           nodes[node_id].drop_call(local_tag)
+        rescue NodeApi::Error => e
+          logger.error "#{e.class} #{e.message}"
         rescue StandardError => e
           node_id = call.is_a?(Hash) ? call[:node_id] : nil
           capture_error(e, extra: { local_tag: local_tag, node_id: node_id })


### PR DESCRIPTION
Within Jobs::CallsMonitoring job we execute the terminate_calls! method and within this method sometime Node returns "not found" response and in this case do not raise error NodeApi::Error and no not send exception in Sentry.

closes #1516