### PR TITLE
config to control the behavior of the CallsMonitoring job

### DIFF
--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -25,6 +25,9 @@ Config.setup do |setup_config|
     required(:calls_monitoring).schema do
       required(:write_account_stats).value(:bool?)
       required(:write_gateway_stats).value(:bool?)
+      required(:teardown_on_disabled_customer_auth).value(:bool?)
+      required(:teardown_on_disabled_term_gw).value(:bool?)
+      required(:teardown_on_disabled_orig_gw).value(:bool?)
     end
 
     required(:api).schema do

--- a/config/yeti_web.yml.ci
+++ b/config/yeti_web.yml.ci
@@ -3,6 +3,9 @@ site_title_image: "yeti.png"
 calls_monitoring:
   write_account_stats: true
   write_gateway_stats: true
+  teardown_on_disabled_customer_auth: false # Teardown calls if customer authentication is disabled
+  teardown_on_disabled_term_gw: false # Teardown calls if termination gateway is disabled
+  teardown_on_disabled_orig_gw: false # Teardown calls if origination gateway is disabled
 api:
   token_lifetime: 600 # jwt token lifetime in seconds, empty string means permanent tokens
 cdr_export:

--- a/config/yeti_web.yml.development
+++ b/config/yeti_web.yml.development
@@ -3,6 +3,9 @@ site_title_image: "yeti.png"
 calls_monitoring:
   write_account_stats: true
   write_gateway_stats: true
+  teardown_on_disabled_customer_auth: false # Teardown calls if customer authentication is disabled
+  teardown_on_disabled_term_gw: false # Teardown calls if termination gateway is disabled
+  teardown_on_disabled_orig_gw: false # Teardown calls if origination gateway is disabled
 api:
   token_lifetime: 600 # jwt token lifetime in seconds, empty string means permanent tokens
 cdr_export:

--- a/config/yeti_web.yml.distr
+++ b/config/yeti_web.yml.distr
@@ -3,6 +3,9 @@ site_title_image: "yeti.png"
 calls_monitoring:
   write_account_stats: true
   write_gateway_stats: true
+  teardown_on_disabled_customer_auth: false # Teardown calls if customer authentication is disabled
+  teardown_on_disabled_term_gw: false # Teardown calls if termination gateway is disabled
+  teardown_on_disabled_orig_gw: false # Teardown calls if origination gateway is disabled
 api:
   token_lifetime: 600 # jwt token lifetime in seconds, empty string means permanent tokens
 cdr_export:

--- a/spec/config/yeti_web_spec.rb
+++ b/spec/config/yeti_web_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe 'config/yeti_web.yml' do
       site_title_image: be_kind_of(String),
       calls_monitoring: {
         write_account_stats: be_one_of(true, false),
-        write_gateway_stats: be_one_of(true, false)
+        write_gateway_stats: be_one_of(true, false),
+        teardown_on_disabled_customer_auth: be_one_of(true, false),
+        teardown_on_disabled_term_gw: be_one_of(true, false),
+        teardown_on_disabled_orig_gw: be_one_of(true, false)
       },
       api: {
         token_lifetime: be_kind_of(Integer)

--- a/spec/jobs/jobs/calls_monitoring_spec.rb
+++ b/spec/jobs/jobs/calls_monitoring_spec.rb
@@ -419,29 +419,97 @@ RSpec.describe Jobs::CallsMonitoring, '#call' do
   context 'when origin gw disabled for origination' do
     before do
       origin_gateway.update!(allow_origination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(nil)
     end
     include_examples :drop_calls
+  end
+
+  context 'when origin gw disabled for origination and teardown_on_disabled_orig_gw is true' do
+    before do
+      origin_gateway.update!(allow_origination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(true)
+    end
+    include_examples :drop_calls
+  end
+
+  context 'when origin gw disabled for origination and teardown_on_disabled_orig_gw is false' do
+    before do
+      origin_gateway.update!(allow_origination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(false)
+    end
+    include_examples :keep_calls
   end
 
   context 'when term gw disabled' do
     before do
       term_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(nil)
     end
     include_examples :drop_calls
+  end
+
+  context 'when term gw disabled and teardown_on_disabled_term_gw is true' do
+    before do
+      term_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(true)
+    end
+    include_examples :drop_calls
+  end
+
+  context 'when term gw disabled teardown_on_disabled_term_gw is false' do
+    before do
+      term_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(false)
+    end
+    include_examples :keep_calls
   end
 
   context 'when term gw disabled for termination' do
     before do
       term_gateway.update!(allow_termination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(nil)
     end
     include_examples :drop_calls
+  end
+
+  context 'when term gw disabled for termination and teardown_on_disabled_term_gw is true' do
+    before do
+      term_gateway.update!(allow_termination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(true)
+    end
+    include_examples :drop_calls
+  end
+
+  context 'when term gw disabled for termination and teardown_on_disabled_term_gw is false' do
+    before do
+      term_gateway.update!(allow_termination: false)
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_term_gw).and_return(false)
+    end
+    include_examples :keep_calls
   end
 
   context 'when origin gw disabled' do
     before do
       origin_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(nil)
     end
     include_examples :drop_calls
+  end
+
+  context 'when origin gw disabled and teardown_on_disabled_orig_gw is true' do
+    before do
+      origin_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(true)
+    end
+    include_examples :drop_calls
+  end
+
+  context 'when origin gw disabled and teardown_on_disabled_orig_gw is false' do
+    before do
+      origin_gateway.disable!
+      allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_orig_gw).and_return(false)
+    end
+    include_examples :keep_calls
   end
 
   context 'when Customer has zero balance' do
@@ -630,6 +698,28 @@ RSpec.describe Jobs::CallsMonitoring, '#call' do
 
     context 'when CustomersAuth#reject_calls = TRUE' do
       let(:customers_auth_reject_calls) { true }
+
+      before { allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_customer_auth).and_return(nil) }
+
+      it 'drop first call(with customer_auth_id)' do
+        expect_any_instance_of(Node).to receive(:drop_call).with('normal-call')
+        expect_any_instance_of(Node).not_to receive(:drop_call).with('reverse-call')
+        subject
+      end
+    end
+
+    context 'when CustomersAuth#reject_calls = TRUE and teardown_on_disabled_customer_auth is false' do
+      let(:customers_auth_reject_calls) { true }
+
+      before { allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_customer_auth).and_return(false) }
+
+      include_examples :keep_calls
+    end
+
+    context 'when CustomersAuth#reject_calls = TRUE and teardown_on_disabled_customer_auth is true' do
+      let(:customers_auth_reject_calls) { true }
+
+      before { allow(YetiConfig.calls_monitoring).to receive(:teardown_on_disabled_customer_auth).and_return(true) }
 
       it 'drop first call(with customer_auth_id)' do
         expect_any_instance_of(Node).to receive(:drop_call).with('normal-call')


### PR DESCRIPTION
## Description

add config to control the behavior of the CallsMonitoring job

introduces new configuration options in yeti_web.yml to control
the behavior of the CallsMonitoring job when dealing with
disabled customer authentication and both origination/termination gateways:

```
- calls_monitoring.teardown_on_disabled_customer_auth
- calls_monitoring.teardown_on_disabled_term_gw
- calls_monitoring.teardown_on_disabled_orig_gw
```

The CallsMonitoring class has been updated to use these
configurations in the relevant methods. If the configs
are not present, the current flow should not be changed.

## Additional links

closes #1526 