### PR TITLE
1528, Customer API: improve transactions API resource

### DIFF
--- a/app/resources/api/rest/customer/v1/transaction_resource.rb
+++ b/app/resources/api/rest/customer/v1/transaction_resource.rb
@@ -13,7 +13,7 @@ class Api::Rest::Customer::V1::TransactionResource < Api::Rest::Customer::V1::Ba
 
   ransack_filter :created_at, type: :datetime
   association_uuid_filter :account_id, class_name: 'Account'
-  ransack_filter :service_id, type: :foreign_key
+  association_uuid_filter :service_id, class_name: 'Billing::Service'
   ransack_filter :amount, type: :number
   ransack_filter :description, type: :string
 

--- a/app/resources/api/rest/customer/v1/transaction_resource.rb
+++ b/app/resources/api/rest/customer/v1/transaction_resource.rb
@@ -9,7 +9,7 @@ class Api::Rest::Customer::V1::TransactionResource < Api::Rest::Customer::V1::Ba
   attribute :created_at
 
   has_one :account, class_name: 'Account', foreign_key_on: :related
-  has_one :service, class_name: 'Service', relation_name: :type, foreign_key_on: :related
+  has_one :service, class_name: 'Service', foreign_key_on: :related
 
   ransack_filter :created_at, type: :datetime
   association_uuid_filter :account_id, class_name: 'Account'

--- a/spec/requests/api/rest/customer/v1/services_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/services_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::Customer::V1::ServicesController, type: :request do
+  include_context :json_api_customer_v1_helpers, type: :services
+
+  let!(:service) { FactoryBot.create(:service, uuid: SecureRandom.uuid) }
+  let(:json_api_request_query) { { include: :transactions } }
+
+  describe 'GET /api/rest/customer/v1/services?include=transactions' do
+    subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
+
+    it 'should render records with included service' do
+      subject
+
+      expect(response_json[:errors]).to eq nil
+      expect(response_json[:data].pluck(:id)).to match_array [service.uuid]
+      expect(response_json[:included]).to contain_exactly(
+        hash_including(
+          id: service.transactions.first.uuid,
+          type: 'transactions'
+        )
+      )
+    end
+  end
+
+  describe 'GET /api/rest/customer/v1/services/{id}?include=transactions' do
+    subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
+
+    let(:json_api_request_path) { "#{super()}/#{service.uuid}" }
+
+    it 'should return record with included service' do
+      subject
+
+      expect(response_json.dig(:data, :id)).to eq service.uuid
+      expect(response_json.dig(:included)).to contain_exactly hash_including id: service.transactions.first.uuid, type: 'transactions'
+    end
+  end
+end

--- a/spec/requests/api/rest/customer/v1/transactions_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/transactions_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::Customer::V1::TransactionsController, type: :request do
+  include_context :json_api_customer_v1_helpers, type: :transactions
+
+  let!(:service) { FactoryBot.create(:service, uuid: SecureRandom.uuid) }
+  let(:json_api_request_query) { { include: :service } }
+
+  describe 'GET /api/rest/customer/v1/transactions?include=service' do
+    subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
+
+    it 'should render records with included service' do
+      subject
+
+      expect(response_json[:errors]).to eq nil
+      expect(response_json[:data].pluck(:id)).to match_array [service.transactions.first.uuid]
+      expect(response_json[:included]).to contain_exactly(
+        hash_including(
+          id: service.uuid,
+          type: 'services',
+          attributes: hash_including(name: service.name)
+        )
+      )
+    end
+  end
+
+  describe 'GET /api/rest/customer/v1/transactions/{id}?include=service' do
+    subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
+
+    let(:json_api_request_path) { "#{super()}/#{service.transactions.first.uuid}" }
+
+    it 'should return record with included service' do
+      subject
+
+      expect(response_json.dig(:data, :id)).to eq service.transactions.first.uuid
+      expect(response_json.dig(:included)).to contain_exactly hash_including id: service.uuid, type: 'services'
+    end
+  end
+end

--- a/spec/requests/api/rest/customer/v1/transactions_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/transactions_controller_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Api::Rest::Customer::V1::TransactionsController, type: :request d
     end
   end
 
+  describe 'GET /api/rest/customer/v1/transactions?filter[service-id-eq]=uuid' do
+    subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
+
+    let(:json_api_request_query) { { filter: { 'service-id-eq' => service.uuid } } }
+
+    it 'should filter records by UUID of service' do
+      subject
+
+      expect(response_json[:data].pluck(:id)).to contain_exactly service.transactions.first.uuid
+    end
+  end
+
   describe 'GET /api/rest/customer/v1/transactions/{id}?include=service' do
     subject { get json_api_request_path, params: json_api_request_query, headers: json_api_request_headers }
 


### PR DESCRIPTION
### Description

Allow to include `service` from transaction API resource

example of request:
```
GET /api/rest/customer/v1/transactions?include=service
```

### Additional links

closes #1528 