### PR TITLE
Vulnerabilities: Bump puma gem from v6.4.2 to v6.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -660,7 +660,7 @@ GEM
     pgq_prometheus (0.2.3)
       prometheus_exporter
     public_suffix (4.0.6)
-    puma (6.4.2)
+    puma (6.4.3)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
### Description 

```
Name: puma
Version: 6.4.2
CVE: https://github.com/advisories/GHSA-9hf4-67fc-4vf4
GHSA: https://github.com/advisories/GHSA-9hf4-67fc-4vf4
Criticality: Medium
URL: [GHSA-9hf4-67fc-4vf4](https://github.com/puma/puma/security/advisories/GHSA-9hf4-67fc-4vf4)
Title: Puma's header normalization allows for client to clobber proxy set headers
Solution: upgrade to '~> 5.6.9', '>= 6.4.3'
```