### PR TITLE
Vulnerabilities: Bump webrick gem from v1.8.1 to v1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -837,7 +837,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
### Description

Bump webrick gem from v1.8.1 to v1.8.2 to fix CVE-2024-47220 vulnerability
