### PR TITLE
#1573, add update action for CDR API resource

### DIFF
--- a/app/resources/api/rest/admin/cdr/cdr_resource.rb
+++ b/app/resources/api/rest/admin/cdr/cdr_resource.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Api::Rest::Admin::Cdr::CdrResource < BaseResource
-  immutable
   model_name 'Cdr::Cdr'
   paginator :paged
 
@@ -16,6 +15,10 @@ class Api::Rest::Admin::Cdr::CdrResource < BaseResource
 
   def self.default_sort
     [{ field: 'time_start', direction: :desc }]
+  end
+
+  def self.updatable_fields(_context)
+    [:metadata]
   end
 
   attributes :time_start,
@@ -127,7 +130,8 @@ class Api::Rest::Admin::Cdr::CdrResource < BaseResource
              :customer_price_no_vat,
              :customer_duration,
              :vendor_duration,
-             :destination_rate_policy_id
+             :destination_rate_policy_id,
+             :metadata
 
   has_one :rateplan, class_name: 'Rateplan', force_routed: true
   has_one :dialpeer, force_routed: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,7 @@ Rails.application.routes.draw do
           jsonapi_resources :incoming_registrations, only: %i[index]
 
           namespace :cdr do
-            jsonapi_resources :cdrs, only: %i[index show] do
+            jsonapi_resources :cdrs, only: %i[index show update] do
               member { get :recording }
               # jsonapi_relationships
               patched_jsonapi_relationships

--- a/spec/acceptance/rest/admin/api/cdr/cdrs_spec.rb
+++ b/spec/acceptance/rest/admin/api/cdr/cdrs_spec.rb
@@ -38,4 +38,35 @@ RSpec.resource 'Cdrs' do
       expect(status).to eq(200)
     end
   end
+
+  patch '/api/rest/admin/cdr/cdrs/:id' do
+    with_options scope: :data, with_example: true do
+      parameter :type, 'Resource type (cdrs)', required: true
+      parameter :id, 'CDR ID', required: true
+      parameter :attributes, 'list of fields/values to update', required: true
+    end
+
+    jsonapi_attribute :metadata
+
+    context '200' do
+      let(:id) { create(:cdr).id }
+
+      example 'Update an CDR' do
+        request = {
+          data: {
+            id: id,
+            type: 'cdrs',
+            attributes: {
+              metadata: { some_json: 'some value' }
+            }
+          }
+        }
+
+        do_request(request)
+
+        expect(status).to eq(200)
+        expect(JSON.parse(response_body).dig('data', 'attributes', 'metadata')).to eq 'some_json' => 'some value'
+      end
+    end
+  end
 end

--- a/spec/controllers/api/rest/admin/cdr/cdrs_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/cdr/cdrs_controller_spec.rb
@@ -690,7 +690,8 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrsController, type: :controller do
             'customer-price-no-vat' => cdr.customer_price_no_vat,
             'customer-duration' => cdr.customer_duration,
             'vendor-duration' => cdr.vendor_duration,
-            'destination-rate-policy-id' => cdr.destination_rate_policy_id
+            'destination-rate-policy-id' => cdr.destination_rate_policy_id,
+            'metadata' => nil
           },
           'relationships' => hash_including(
             'rateplan' => hash_including(
@@ -769,8 +770,8 @@ RSpec.describe Api::Rest::Admin::Cdr::CdrsController, type: :controller do
   end
 
   describe 'PATCH update' do
-    it 'PATCH should not be routable', type: :routing do
-      expect(patch: '/api/rest/admin/cdr/cdrs/123').to_not be_routable
+    it 'PATCH should be routable', type: :routing do
+      expect(patch: '/api/rest/admin/cdr/cdrs/123').to be_routable
     end
   end
 


### PR DESCRIPTION
## Description

allow to update the "metadata" field only for CDR API resource

example:

`PATCH /api/rest/admin/cdr/cdrs/:id`

```json
{
    "data": {
        "type": "cdrs",
        "id": 852,
        "attributes": {
            "metadata": "sdad"
        }
    }
}
```