### PR TITLE
Use multiple transactions to load custom network prefixes

### DIFF
--- a/db/custom_seeds/network_prefixes.rb
+++ b/db/custom_seeds/network_prefixes.rb
@@ -20,25 +20,25 @@ System::NetworkPrefix.transaction do
   System::NetworkPrefix.insert_all!(network_prefixes) if network_prefixes.any?
 end
 
-  Dir.glob('db/network_data/**/*.yml') do |f|
-    System::NetworkPrefix.transaction do
-      puts "processing file #{f}:" # rubocop:disable Rails/Output
-      data = YAML.load_file(f, aliases: true)
-      n = data['networks']
+Dir.glob('db/network_data/**/*.yml') do |f|
+  System::NetworkPrefix.transaction do
+    puts "processing file #{f}:" # rubocop:disable Rails/Output
+    data = YAML.load_file(f, aliases: true)
+    n = data['networks']
 
-      System::Network.insert_all!(n) if n.any?
-      puts "  loaded #{n.length} networks" # rubocop:disable Rails/Output
-      n_ids = n.map { |ni| ni['id'] }.uniq
+    System::Network.insert_all!(n) if n.any?
+    puts "  loaded #{n.length} networks" # rubocop:disable Rails/Output
+    n_ids = n.map { |ni| ni['id'] }.uniq
 
-      np = data['network_prefixes']
-      System::NetworkPrefix.insert_all!(np) if np.any?
-      puts "  loaded #{np.length} network prefixes" # rubocop:disable Rails/Output
-      np_ids = np.map { |npi| npi['network_id'] }.uniq
-      
-      no_prefixes = n_ids - np_ids
-      puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any? # rubocop:disable Rails/Output
-    end
+    np = data['network_prefixes']
+    System::NetworkPrefix.insert_all!(np) if np.any?
+    puts "  loaded #{np.length} network prefixes" # rubocop:disable Rails/Output
+    np_ids = np.map { |npi| npi['network_id'] }.uniq
+
+    no_prefixes = n_ids - np_ids
+    puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any? # rubocop:disable Rails/Output
   end
+end
 
 System::NetworkPrefix.transaction do
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.network_types_id_seq', MAX(id), true) FROM sys.network_types"

--- a/db/custom_seeds/network_prefixes.rb
+++ b/db/custom_seeds/network_prefixes.rb
@@ -18,24 +18,29 @@ System::NetworkPrefix.transaction do
   System::Network.insert_all!(networks) if networks.any?
   System::Country.insert_all!(countries) if countries.any?
   System::NetworkPrefix.insert_all!(network_prefixes) if network_prefixes.any?
+end
 
   Dir.glob('db/network_data/**/*.yml') do |f|
-    puts "processing file #{f}:" # rubocop:disable Rails/Output
-    data = YAML.load_file(f, aliases: true)
-    n = data['networks']
-    System::Network.insert_all!(n) if n.any?
-    puts "  loaded #{n.length} networks" # rubocop:disable Rails/Output
-    n_ids = n.map { |ni| ni['id'] }.uniq
+    System::NetworkPrefix.transaction do
+      puts "processing file #{f}:" # rubocop:disable Rails/Output
+      data = YAML.load_file(f, aliases: true)
+      n = data['networks']
 
-    np = data['network_prefixes']
-    System::NetworkPrefix.insert_all!(np) if np.any?
-    puts "  loaded #{np.length} network prefixes" # rubocop:disable Rails/Output
-    np_ids = np.map { |npi| npi['network_id'] }.uniq
+      System::Network.insert_all!(n) if n.any?
+      puts "  loaded #{n.length} networks" # rubocop:disable Rails/Output
+      n_ids = n.map { |ni| ni['id'] }.uniq
 
-    no_prefixes = n_ids - np_ids
-    puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any? # rubocop:disable Rails/Output
+      np = data['network_prefixes']
+      System::NetworkPrefix.insert_all!(np) if np.any?
+      puts "  loaded #{np.length} network prefixes" # rubocop:disable Rails/Output
+      np_ids = np.map { |npi| npi['network_id'] }.uniq
+      
+      no_prefixes = n_ids - np_ids
+      puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any? # rubocop:disable Rails/Output
+    end
   end
 
+System::NetworkPrefix.transaction do
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.network_types_id_seq', MAX(id), true) FROM sys.network_types"
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.networks_id_seq', MAX(id), true) FROM sys.networks"
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.countries_id_seq', MAX(id), true) FROM sys.countries"


### PR DESCRIPTION
## Description

This update addresses a memory issue encountered during the loading of large network prefixes. When attempting to load all network data in a single transaction, the process would run out of memory and terminate with an error. To mitigate this, we now process the loading in smaller transactions, ensuring that memory consumption remains manageable