### PR TITLE
1590, fix bug when request /api/rest/admin/active-calls?filter[orig-gw-id-eq]=1

### DIFF
--- a/app/models/yeti/cdrs_filter.rb
+++ b/app/models/yeti/cdrs_filter.rb
@@ -57,7 +57,12 @@ module Yeti
 
       EQ_FILTERABLE.each do |k|
         %i[eq equals].each do |suff|
-          filter.add_filter { |cdr| cdr[:"#{k}"].to_i == search_param(k, suff).to_i } if searchable?(k, suff)
+          search_values = search_param(k, suff)
+          next unless searchable?(k, suff)
+
+          search_values.each do |value|
+            filter.add_filter { |cdr| cdr[:"#{k}"].to_i == value.to_i }
+          end
         end
       end
       STARTS_WITH_FILTERABLE.each do |k|


### PR DESCRIPTION
## description

exception when request `/api/rest/admin/active-calls?filter[orig-gw-id-eq]=1`

logs
```
Oct 9 14:47:16 250012 yeti-web[141163]: [f980a4a5-e1c5-4f68-ac5c-2d5304ad8ba3] Started GET “/api/rest/admin/active-calls?filter%5Borig-gw-id-eq% 5D=17” for 127.0.0.1 at 2024-10-09 14:47:16 +0200
Oct 9 14:47:16 250012 yeti-web[141163]: [f980a4a5-e1c5-4f68-ac5c-2d5304ad8ba3] Processing by Api::Rest::Admin::ActiveCallsController#index as API_JSON
Oct 9 14:47:16 250012 yeti-web[141163]: [f980a4a5-e1c5-4f68-ac5c-2d5304ad8ba3] Parameters: {“filter”=>{“orig-gw-id-eq”=>“17”} }
Oct 9 14:47:17 250012 yeti-web[141163]: request to node 1
Oct 9 14:47:17 250012 yeti-web[141163]: loading 1 active calls
Oct 9 14:47:17 250012 yeti-web[141163]: [f980a4a5-e1c5-4f68-ac5c-2d5304ad8ba3] Internal Server Error: undefined method to_i' for ["17"]:Array /opt/yeti-web/ app/models/yeti/cdrs_filter.rb:60:in block (3 levels) in generate_filter’#012>
Oct 9 14:47:17 250012 yeti-web[141163]: [f980a4a5-e1c5-4f68-ac5c-2d5304ad8ba3] Completed 500 Internal Server Error in 51ms (Views: 0.4ms | ActiveRecord: 5.9ms | Allocations: 10444)


```