### PR TITLE
bump devise from v4.9.1 to v4.9.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
     delayed_job_active_record (4.1.7)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
-    devise (4.9.1)
+    devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)


### PR DESCRIPTION
devise release note

```
4.9.4 - 2024-04-10
enhancements

Add support for Ruby 3.3. (no changes needed)
bug fixes
```