### PR TITLE
bump json from v2.6.3 to v2.7.3 [no issue]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-tablesorter (1.27.2)
       railties (>= 3.2)
-    json (2.6.3)
+    json (2.7.3)
     jsonapi-resources (0.9.12)
       activerecord (>= 4.1)
       concurrent-ruby


### PR DESCRIPTION
## Description

bump json gem from v2.6.3 to v2.7.3 to prepare to update rails to v7.2 