### PR TITLE
1592, Customer API: specify service_type attribute for Service API resource

### DIFF
--- a/app/admin/billing/service_types.rb
+++ b/app/admin/billing/service_types.rb
@@ -16,6 +16,7 @@ ActiveAdmin.register Billing::ServiceType, as: 'ServiceType' do
   filter :name
   filter :provisioning_class
   filter :force_renew
+  filter :ui_type
 
   index do
     selectable_column
@@ -25,6 +26,7 @@ ActiveAdmin.register Billing::ServiceType, as: 'ServiceType' do
     column :force_renew
     column :provisioning_class
     column :variables, :variables_json
+    column :ui_type
   end
 
   show do
@@ -39,6 +41,7 @@ ActiveAdmin.register Billing::ServiceType, as: 'ServiceType' do
             link_to resource.services.count,
                     services_path(q: { type_id_eq: resource.id })
           end
+          row :ui_type
         end
       end
 
@@ -58,6 +61,7 @@ ActiveAdmin.register Billing::ServiceType, as: 'ServiceType' do
       f.input :name
       f.input :force_renew
       f.input :provisioning_class, as: :select, collection: Billing::ServiceType.available_provisioning_classes, input_html: { class: :chosen }
+      f.input :ui_type
       f.input :variables_json, label: 'Variables', as: :text
     end
     f.actions

--- a/app/models/billing/service_type.rb
+++ b/app/models/billing/service_type.rb
@@ -8,6 +8,7 @@
 #  force_renew        :boolean          default(FALSE), not null
 #  name               :string           not null
 #  provisioning_class :string
+#  ui_type            :string
 #  variables          :jsonb
 #
 # Indexes

--- a/app/resources/api/rest/customer/v1/service_resource.rb
+++ b/app/resources/api/rest/customer/v1/service_resource.rb
@@ -12,6 +12,7 @@ class Api::Rest::Customer::V1::ServiceResource < Api::Rest::Customer::V1::BaseRe
   attribute :renew_at
   attribute :renew_period
   attribute :service_type
+  attribute :ui_type
 
   has_one :account, class_name: 'Account', foreign_key_on: :related
   has_many :transactions, class_name: 'Transaction', foreign_key_on: :related
@@ -29,6 +30,10 @@ class Api::Rest::Customer::V1::ServiceResource < Api::Rest::Customer::V1::BaseRe
 
   def service_type
     _model.type.name
+  end
+
+  def ui_type
+    _model.type.ui_type
   end
 
   def self.sortable_fields(_ctx = nil)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,8 @@ en:
       lnp_routing_plan_lnp_rule:
         drop_call_on_error: "Drop call if LNP resolve failed. When disabled routing will fallback to use destination number"
         rewrite_call_destination: "use LRN as new call destination"
+      billing_service_type:
+        ui_type: "This field will be used in Service Resource of Customer API"
 
 
   attributes:

--- a/db/migrate/20241107212537_migration_add_ui_type_field.rb
+++ b/db/migrate/20241107212537_migration_add_ui_type_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MigrationAddUiTypeField < ActiveRecord::Migration[7.0]
+  def change
+    add_column 'billing.service_types', :ui_type, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31489,7 +31489,8 @@ CREATE TABLE billing.service_types (
     name character varying NOT NULL,
     provisioning_class character varying,
     variables jsonb,
-    force_renew boolean DEFAULT false NOT NULL
+    force_renew boolean DEFAULT false NOT NULL,
+    ui_type character varying
 );
 
 
@@ -41244,6 +41245,7 @@ INSERT INTO "public"."schema_migrations" (version) VALUES
 ('20241012124910'),
 ('20241015092015'),
 ('20241016075439'),
-('20241017124729');
+('20241017124729'),
+('20241107212537');
 
 

--- a/spec/factories/billing/service_types.rb
+++ b/spec/factories/billing/service_types.rb
@@ -8,6 +8,7 @@
 #  force_renew        :boolean          default(FALSE), not null
 #  name               :string           not null
 #  provisioning_class :string
+#  ui_type            :string
 #  variables          :jsonb
 #
 # Indexes
@@ -19,5 +20,6 @@ FactoryBot.define do
     sequence(:name) { |n| "Service Type #{n}" }
     provisioning_class { 'Billing::Provisioning::Logging' }
     variables { { 'foo' => 'bar' } }
+    ui_type { 'phone_systems' }
   end
 end

--- a/spec/models/billing/service_type_spec.rb
+++ b/spec/models/billing/service_type_spec.rb
@@ -8,6 +8,7 @@
 #  force_renew        :boolean          default(FALSE), not null
 #  name               :string           not null
 #  provisioning_class :string
+#  ui_type            :string
 #  variables          :jsonb
 #
 # Indexes


### PR DESCRIPTION
# Description

specify the `ui_type` attribute for Service API resource of Customer API

added filter for Service Customer API resource
filter[ui-type-eq]


### example of response from service customer API

```
{
  "data": {
    "id": "fe81c806-40ad-40e9-ba33-757b43607b60",
    "type": "services",
    "links": {
      "self": "http://example.org/api/rest/customer/v1/services/fe81c806-40ad-40e9-ba33-757b43607b60"
    },
    "attributes": {
      "name": "Service_10",
      "state": "Active",
      "initial-price": "84.56",
      "renew-price": "93.26",
      "created-at": "2024-11-07T20:31:23.300Z",
      "renew-at": null,
      "renew-period": "Disabled",
      "service-type": "Service Type 16",
      "ui-type": "phone_systems"
    },
    "relationships": {
      "account": {
        "links": {
          "self": "http://example.org/api/rest/customer/v1/services/fe81c806-40ad-40e9-ba33-757b43607b60/relationships/account",
          "related": "http://example.org/api/rest/customer/v1/services/fe81c806-40ad-40e9-ba33-757b43607b60/account"
        }
      },
      "transactions": {
        "links": {
          "self": "http://example.org/api/rest/customer/v1/services/fe81c806-40ad-40e9-ba33-757b43607b60/relationships/transactions",
          "related": "http://example.org/api/rest/customer/v1/services/fe81c806-40ad-40e9-ba33-757b43607b60/transactions"
        }
      }
    }
  }
}
```


## Additional links

related to #1592 
https://github.com/yeti-switch/yeti-client/pull/178

