### PR TITLE
when create service type use predefined values for "provisioning_class" field

### DIFF
--- a/app/admin/billing/service_types.rb
+++ b/app/admin/billing/service_types.rb
@@ -57,7 +57,7 @@ ActiveAdmin.register Billing::ServiceType, as: 'ServiceType' do
     f.inputs do
       f.input :name
       f.input :force_renew
-      f.input :provisioning_class
+      f.input :provisioning_class, as: :select, collection: Billing::ServiceType.available_provisioning_classes, input_html: { class: :chosen }
       f.input :variables_json, label: 'Variables', as: :text
     end
     f.actions

--- a/app/models/billing/service_type.rb
+++ b/app/models/billing/service_type.rb
@@ -52,6 +52,12 @@ class Billing::ServiceType < ApplicationRecord
     self.variables = value
   end
 
+  def self.available_provisioning_classes
+    Dir[Rails.root.join('app/models/billing/provisioning/*.rb')].map do |file|
+      "Billing::Provisioning::#{File.basename(file, '.rb').camelize}"
+    end
+  end
+
   private
 
   def validate_provisioning_class

--- a/spec/features/billing/service_types/new_spec.rb
+++ b/spec/features/billing/service_types/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Billing Service Types New', js: true, bullet: [:n] do
 
   let(:fill_form!) do
     fill_in 'Name', with: attributes[:name]
-    fill_in 'Provisioning class', with: attributes[:provisioning_class]
+    fill_in_chosen 'Provisioning class', with: attributes[:provisioning_class]
     fill_in 'Variables', with: attributes[:variables_json]
     check 'Force renew' if attributes[:force_renew]
   end
@@ -73,23 +73,6 @@ RSpec.describe 'Billing Service Types New', js: true, bullet: [:n] do
         expect(page).to have_semantic_error_texts(
                         'Variables must be a JSON object or empty'
                       )
-      }.not_to change { Billing::ServiceType.count }
-      expect(page).to have_current_path service_types_path
-      expect(page).to have_field 'Name', with: attributes[:name]
-    end
-  end
-
-  context 'with non-existing provisioning class' do
-    let(:attributes) do
-      super().merge provisioning_class: 'Billing::Provisioning::NonExisting'
-    end
-
-    it 'does not create service type' do
-      expect {
-        subject
-        expect(page).to have_semantic_error_texts(
-                          'Provisioning class is invalid'
-                        )
       }.not_to change { Billing::ServiceType.count }
       expect(page).to have_current_path service_types_path
       expect(page).to have_field 'Name', with: attributes[:name]


### PR DESCRIPTION
## Description

changed a field type from plain input to select