### PR TITLE
#1592, fix warning for PhoneSystemsSessions controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,7 +191,7 @@ Rails.application.routes.draw do
             jsonapi_resources :countries, only: %i[index show]
             jsonapi_resources :services, only: %i[index show]
             jsonapi_resources :transactions, only: %i[index show]
-            jsonapi_resource :phone_systems_sessions, only: %i[create]
+            jsonapi_resources :phone_systems_sessions, only: %i[create]
           end
         end
 


### PR DESCRIPTION
## Description

example of warning:
```
Singleton routes created for non singleton resource Api::Rest::Customer::V1::PhoneSystemsSessionResource. Links may not be generated correctly.
```

### related links

#1592