### PR TITLE
#1699, add relationshop to routing plan/group/rateplan and rate_group

### DIFF
--- a/app/resources/api/rest/admin/rate_group_resource.rb
+++ b/app/resources/api/rest/admin/rate_group_resource.rb
@@ -5,12 +5,18 @@ class Api::Rest::Admin::RateGroupResource < BaseResource
 
   attributes :name, :external_id
 
+  has_many :rateplans, class_name: 'Rateplan',
+                       exclude_links: %i[default self],
+                       relation_name: :rateplans,
+                       foreign_key_on: :related
+
   ransack_filter :name, type: :string
 
   def self.updatable_fields(_context)
     %i[
       name
       external_id
+      rateplans
     ]
   end
 

--- a/app/resources/api/rest/admin/rateplan_resource.rb
+++ b/app/resources/api/rest/admin/rateplan_resource.rb
@@ -9,6 +9,12 @@ class Api::Rest::Admin::RateplanResource < BaseResource
 
   filter :name # DEPRECATED
 
+  has_many :rate_groups,
+           class_name: 'RateGroup',
+           exclude_links: %i[default self],
+           relation_name: :rate_groups,
+           foreign_key_on: :related
+
   ransack_filter :name, type: :string
   ransack_filter :profit_control_mode_id, type: :number
 
@@ -16,6 +22,7 @@ class Api::Rest::Admin::RateplanResource < BaseResource
     %i[
       name
       profit_control_mode_id
+      rate_groups
     ]
   end
 

--- a/app/resources/api/rest/admin/routing_group_resource.rb
+++ b/app/resources/api/rest/admin/routing_group_resource.rb
@@ -6,12 +6,17 @@ class Api::Rest::Admin::RoutingGroupResource < ::BaseResource
 
   paginator :paged
 
+  has_many :routing_plans, class_name: 'RoutingPlan',
+                           exclude_links: %i[default self],
+                           relation_name: :routing_plans,
+                           foreign_key_on: :related
+
   filter :name # DEPRECATED
 
   ransack_filter :name, type: :string
 
   def self.updatable_fields(_context)
-    [:name]
+    %i[name routing_plans]
   end
 
   def self.creatable_fields(context)

--- a/app/resources/api/rest/admin/routing_plan_resource.rb
+++ b/app/resources/api/rest/admin/routing_plan_resource.rb
@@ -7,6 +7,11 @@ class Api::Rest::Admin::RoutingPlanResource < BaseResource
 
   attributes :name, :rate_delta_max, :use_lnp, :max_rerouting_attempts, :sorting_id
 
+  has_many :routing_groups, class_name: 'RoutingGroup',
+                            exclude_links: %i[default self],
+                            relation_name: :routing_groups,
+                            foreign_key_on: :related
+
   filter :name # DEPRECATED in favor of name_eq
 
   ransack_filter :name, type: :string
@@ -28,6 +33,7 @@ class Api::Rest::Admin::RoutingPlanResource < BaseResource
       validate_dst_number_format
       validate_dst_number_network
       external_id
+      routing_groups
     ]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
           jsonapi_resources :contacts
           jsonapi_resources :api_accesses
           jsonapi_resources :customers_auths
+          jsonapi_resources :rate_groups
 
           jsonapi_resources :dialpeers
           jsonapi_resources :dialpeer_next_rates

--- a/spec/acceptance/rest/admin/api/rate_groups_spec.rb
+++ b/spec/acceptance/rest/admin/api/rate_groups_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rspec_api_documentation/dsl'
+
+RSpec.resource 'Routing Rate Groups' do
+  include_context :acceptance_admin_user
+
+  let(:type) { 'rate-groups' }
+
+  get '/api/rest/admin/rate-groups' do
+    jsonapi_filters Api::Rest::Admin::RateGroupResource._allowed_filters
+
+    before { create_list(:rate_group, 2) }
+
+    example_request 'get listing' do
+      expect(status).to eq(200)
+    end
+  end
+
+  get '/api/rest/admin/rate-groups/:id' do
+    let(:id) { create(:rate_group).id }
+
+    example_request 'get specific entry' do
+      expect(status).to eq(200)
+    end
+  end
+
+  post '/api/rest/admin/rate-groups/456329901/relationships/rateplans' do
+    parameter :data, 'The rate plans to be associated with the rate group', required: true
+
+    let!(:record) { FactoryBot.create(:rate_group, id: 456_329_901) }
+    let!(:rateplan) { create(:rateplan) }
+    let(:data) { [{ type: 'rateplans', id: rateplan.id.to_s }] }
+
+    example_request 'associate rateplans with rate group' do
+      expect(status).to eq(204)
+      expect(record.reload).to have_attributes(rateplan_ids: [rateplan.id])
+    end
+  end
+end

--- a/spec/controllers/api/rest/admin/rate_groups_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/rate_groups_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::Rest::Admin::RateGroupsController, type: :controller do
+  include_context :jsonapi_admin_headers
+
+  describe 'GET index' do
+    subject { get :index }
+
+    let!(:first_rateplan) { FactoryBot.create(:rateplan) }
+    let!(:second_rateplan) { FactoryBot.create(:rateplan) }
+    let!(:records) do
+      [
+        FactoryBot.create(:rate_group, rateplans: [first_rateplan]),
+        FactoryBot.create(:rate_group, rateplans: [second_rateplan])
+      ]
+    end
+
+    context 'when valid data' do
+      it 'returns the list of rate groups' do
+        subject
+
+        expect(response_body[:errors]).to be_nil
+        expect(response.status).to eq(200)
+        expect(response_body.fetch(:data).size).to eq(records.size)
+        expect(response_body.fetch(:data).pluck(:id)).to match_array(records.pluck(:id).map(&:to_s))
+        expect(response_body.dig(:data, 0, :relationships)).to match rateplans: { links: { related: be_present } }
+      end
+    end
+
+    context 'when include rateplans' do
+      subject { get :index, params: { include: 'rateplans' } }
+
+      it 'returns the list of rate groups with rateplans' do
+        subject
+
+        expect(response_body[:errors]).to be_nil
+        expect(response.status).to eq(200)
+        expect(response_body.fetch(:data).size).to eq(records.size)
+        expect(response_body.fetch(:data).pluck(:id)).to match_array(records.pluck(:id).map(&:to_s))
+        expect(response_body.dig(:data, 0, :relationships)).to match rateplans: { links: be_present, data: be_present }
+      end
+    end
+  end
+
+  describe 'GET show' do
+    before { get :show, params: { id: record.to_param } }
+
+    context 'when valid data' do
+      let!(:record) { FactoryBot.create(:rate_group) }
+
+      it 'returns the requested rate group' do
+        subject
+
+        expect(response_body[:errors]).to be_nil
+        expect(response.status).to eq(200)
+        expect(response_body.dig(:data, :id)).to eq(record.id.to_s)
+        expect(response_body.dig(:data, :relationships)).to match rateplans: { links: { related: be_present } }
+      end
+    end
+  end
+end

--- a/spec/controllers/api/rest/admin/routing_plans_controller_spec.rb
+++ b/spec/controllers/api/rest/admin/routing_plans_controller_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe Api::Rest::Admin::RoutingPlansController, type: :controller do
       it { expect(response.status).to eq(404) }
       it { expect(response_data).to eq(nil) }
     end
+
+    context 'when include=routing_groups' do
+      subject { get :show, params: { id: routing_plan.to_param, include: 'routing-groups' } }
+
+      it 'response body should be valid' do
+        subject
+
+        expect(response_data['id']).to eq(routing_plan.id.to_s)
+        expect(response_data.dig('relationships', 'routing-groups', 'data')).to eq([])
+      end
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
## Description

add has_many relationships between two API resources (routing_plan and routing_group)
add has_many relationships between two API resources (rateplan - rate_group)

### Examples

how to add rate_group for a specific rate-plan

POST {{host}}/api/rest/admin/rateplans/{{last_created_rateplan_id}}/relationships/rate-groups
```json
{
  "data": [
    { "type": "rate-groups", "id": "1" }
  ]
}
```

how to remove all rate-groups from rate-plan

PATCH {{host}}/api/rest/admin/rateplans/:id?include=rate-groups
```json
{
    "data": {
        "type": "rateplans",
        "id": {{last_created_rateplan_id}},
        "relationships": {
            "rate-groups": {
                "data": []
            }
        }
    }
}
```

how to add a group to rate-plan (through PATCH request) when rate-plan already contains one group

PATCH {{host}}/api/rest/admin/rateplans/33?include=rate-groups

```json
{
  "data": {
    "type": "rateplans",
    "id": "33",
    "relationships": {
      "rate-groups": {
        "data": [
          {"type": "rate-groups", "id": "1"}, // Existing group
          {"type": "rate-groups", "id": "2"}  // New group
        ]
      }
    }
  }
}
```

## Additional links

closes #1699