### PR TITLE
#1698, update rack gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'activerecord-import'
 gem 'pg'
 gem 'pg_advisory_lock', git: 'https://github.com/didww/pg_advisory_lock.git'
 gem 'pg_sql_caller', git: 'https://github.com/didww/pg_sql_caller.git'
-gem 'rack', ' ~> 2.2.6'
+gem 'rack'
 gem 'rails', '~> 7.2.0'
 gem 'responders'
 
@@ -45,7 +45,10 @@ gem 'active_admin_sidebar', '1.1.0'
 gem 'excelinator', github: 'senid231/excelinator', branch: 'ruby3-fix'
 
 # REST API
-gem 'jsonapi-resources', '~> 0.9.12'
+# TODO: switch to the official gem from rubygems.org after the 0.9.13 release
+# https://github.com/cerebris/jsonapi-resources/issues/1456#issuecomment-2710742154
+# https://github.com/cerebris/jsonapi-resources/pull/1463
+gem 'jsonapi-resources', github: 'cerebris/jsonapi-resources', branch: 'release-0-9'
 
 # gem 'activeadmin_async_export'
 
@@ -69,7 +72,6 @@ gem 'jquery-tablesorter'
 gem 'jquery-ui-rails', github: 'jquery-ui-rails/jquery-ui-rails', tag: 'v7.0.0'
 gem 'mini_racer'
 gem 'rails-html-sanitizer', '>= 1.6.1'
-gem 'sass-globbing'
 gem 'uglifier', '>= 1.3'
 
 # Server Tools
@@ -104,17 +106,13 @@ group :development, :test do
   gem 'awesome_print'
   gem 'bullet'
   gem 'byebug'
-  gem 'thin'
 
   gem 'brakeman'
   gem 'bundler-audit', require: false
   gem 'factory_bot_rails'
   gem 'parallel_tests'
+  gem 'rspec_api_documentation', github: 'stitchfix/rspec_api_documentation'
   gem 'rspec-rails'
-  # https://github.com/zipmark/rspec_api_documentation/pull/458
-  # present only on master
-  # Temporary solution. Waiting for merge https://github.com/zipmark/rspec_api_documentation/pull/507
-  gem 'rspec_api_documentation', github: 'BigG1947/rspec_api_documentation'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,20 @@
 GIT
-  remote: https://github.com/BigG1947/rspec_api_documentation.git
-  revision: 269213b950082d5a055f9ab020fcdace90605165
-  specs:
-    rspec_api_documentation (6.1.0)
-      activesupport (>= 3.0.0)
-      mustache (~> 1.0, >= 0.99.4)
-      rspec (~> 3.0)
-
-GIT
   remote: https://github.com/activeadmin-plugins/capybara_active_admin.git
   revision: d2cdc2c0a5478d4ee1afb30f3465c7be3b760a86
   specs:
     capybara_active_admin (0.3.3)
       activeadmin
       rspec (~> 3.0)
+
+GIT
+  remote: https://github.com/cerebris/jsonapi-resources.git
+  revision: 17772cefd8a90fc1b54744871de1050a6040a691
+  branch: release-0-9
+  specs:
+    jsonapi-resources (0.9.12)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
 
 GIT
   remote: https://github.com/cschiewek/devise_ldap_authenticatable.git
@@ -71,6 +72,15 @@ GIT
   specs:
     excelinator (1.3.1)
       spreadsheet
+
+GIT
+  remote: https://github.com/stitchfix/rspec_api_documentation.git
+  revision: f4e5508473a6aae6aba3ba915365a8c5c72f32ba
+  specs:
+    rspec_api_documentation (6.1.0)
+      activesupport (>= 3.0.0)
+      mustache (~> 1.0, >= 0.99.4)
+      rspec (~> 3.0)
 
 GIT
   remote: https://github.com/workgena/active_admin_date_range_preset.git
@@ -258,7 +268,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
@@ -335,10 +345,9 @@ GEM
       dry-initializer (~> 3.0)
       dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
-    erubi (1.13.0)
+    erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
-    eventmachine (1.2.5)
     execjs (2.7.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
@@ -383,7 +392,7 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.14.0)
       actionpack (>= 6.0)
@@ -391,7 +400,8 @@ GEM
       railties (>= 6.0)
       responders (>= 2)
     io-console (0.8.0)
-    irb (1.14.3)
+    irb (1.15.1)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jquery-rails (4.4.0)
@@ -401,10 +411,6 @@ GEM
     jquery-tablesorter (1.27.2)
       railties (>= 3.2)
     json (2.7.3)
-    jsonapi-resources (0.9.12)
-      activerecord (>= 4.1)
-      concurrent-ruby
-      railties (>= 4.1)
     jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -426,8 +432,8 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     locale (2.1.2)
-    logger (1.6.5)
-    loofah (2.23.1)
+    logger (1.6.6)
+    loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -669,6 +675,9 @@ GEM
     pg (1.4.6)
     pgq_prometheus (0.2.3)
       prometheus_exporter
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     psych (5.2.3)
       date
       stringio
@@ -682,14 +691,14 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.12)
-    rack-session (1.0.2)
-      rack (< 3)
-    rack-test (2.1.0)
+    rack (3.1.11)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.2.1)
+      rack (>= 3)
     rails (7.2.2.1)
       actioncable (= 7.2.2.1)
       actionmailbox (= 7.2.2.1)
@@ -708,7 +717,7 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.1)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.2.1)
@@ -720,7 +729,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.2.1)
     ransack (4.2.1)
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
@@ -729,7 +738,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rchardet (1.8.0)
-    rdoc (6.11.0)
+    rdoc (6.12.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
     reline (0.6.0)
@@ -789,15 +798,16 @@ GEM
     rubyzip (1.3.0)
     rufus-scheduler (3.7.0)
       fugit (~> 1.1, >= 1.1.6)
-    sass (3.4.25)
-    sass-globbing (1.1.5)
-      sass (>= 3.1)
-    sass-rails (5.0.8)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     securerandom (0.4.1)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
@@ -825,22 +835,18 @@ GEM
     simplecov_json_formatter (0.1.4)
     spreadsheet (1.3.0)
       ruby-ole
-    sprockets (3.7.2)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    stringio (3.1.2)
+    stringio (3.1.5)
     syslog (0.2.0)
     syslog-logger (1.6.8)
     text (1.3.1)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    thor (1.2.2)
+    thor (1.3.2)
     tilt (2.0.9)
     timeliness (0.4.5)
     timeout (0.4.3)
@@ -871,7 +877,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.8)
+    zeitwerk (2.7.2)
     zip-zip (0.3)
       rubyzip (>= 1.0.0)
 
@@ -923,7 +929,7 @@ DEPENDENCIES
   jquery-tablesorter
   jquery-ui-rails!
   jrpc!
-  jsonapi-resources (~> 0.9.12)
+  jsonapi-resources!
   jwt
   listen
   matrix (~> 0.4.2)
@@ -947,7 +953,7 @@ DEPENDENCIES
   puma (~> 6.1)
   puma_worker_killer
   pundit
-  rack (~> 2.2.6)
+  rack
   rails (~> 7.2.0)
   rails-html-sanitizer (>= 1.6.1)
   ransack
@@ -959,7 +965,6 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rufus-scheduler
-  sass-globbing
   sass-rails
   selenium-webdriver
   sentry-delayed_job
@@ -971,7 +976,6 @@ DEPENDENCIES
   sprockets
   syslog (~> 0.2.0)
   syslog-logger
-  thin
   uglifier (>= 1.3)
   validates_timeliness (~> 7.0.0.beta1)
   webdrivers (~> 4.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,4 @@
+//= link active_admin
+//= link_tree ../images
+//= link_tree ../stylesheets
+//= link_tree ../javascripts

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.version = '1.0'
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w[yeti/*]
-Rails.application.config.assets.precompile << /\.(?:svg|eot|woff|ttf)\z/
+Rails.application.config.assets.precompile += %w[.svg .eot .woff .ttf]

--- a/spec/support/contexts/customer_v1_cookie_helpers.rb
+++ b/spec/support/contexts/customer_v1_cookie_helpers.rb
@@ -4,10 +4,10 @@ RSpec.shared_context :customer_v1_cookie_helpers do
   def build_raw_cookie(token, expiration:)
     cookie_name = Authentication::CustomerV1Auth::COOKIE_NAME
     if expiration.nil?
-      "#{cookie_name}=#{token}; path=/; HttpOnly; SameSite=Lax"
+      "#{cookie_name}=#{token}; path=/; httponly; samesite=lax"
     else
       expires = expiration.utc.strftime('%a, %d %b %Y %H:%M:%S GMT')
-      "#{cookie_name}=#{token}; path=/; expires=#{expires}; HttpOnly; SameSite=Lax"
+      "#{cookie_name}=#{token}; path=/; expires=#{expires}; httponly; samesite=lax"
     end
   end
 


### PR DESCRIPTION
## Description

update rack gem from v2.2.12 to v3.1.10

### Background

The `sprockets` gem (v3.7.2), which was previously installed, explicitly required rack to be greater than version 1 and less than version 3. To support the update to `rack` v3, the decision was made to upgrade `sprockets` to v4.2.1

## Summary of changes

## Updated gems
`rack` gem from v2.2.12 to v3.1.10
`rackup` gem from v1.0.1 to 2.2.1
`sass-rails` gem from v5.0.8 to v6.0.0
`sassc` gem from v3.4.25 to v2.4.0
`sprockets` gem from v3.7.2 to v4.2.1
`rspec_api_documentation` gem
  - from repo `BigG1947/rspec_api_documentation` revision: `269213b` 

  - to `zipmark/rspec_api_documentation` `v6.1.0`
  - because [this patch is added](https://github.com/stitchfix/rspec_api_documentation/pull/3)

`jsonapi-resources` gem
  - from v0.9.12 to branch `release-0-9`

  - because this patch is added ([issue](https://github.com/cerebris/jsonapi-resources/issues/1456), [pull request](https://github.com/cerebris/jsonapi-resources/pull/1463))

## Downgraded gems:

`thin` gem from v1.8.2 to v1.6.2

  - This downgrade was necessary because thin v1.8.2 depends on rack (>= 1, < 3), whereas v1.6.2 is compatible with rack (>= 1.0.0).

## Removed gems:

`sass-globbing`

  - This gem provided an easy way to import multiple Sass or SCSS files in a single import statement. However, since Rails 3.1 and later versions include this functionality by default, the gem is no longer needed.

## Additional links

1. https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md
2. https://github.com/rails/sprockets/blob/main/UPGRADING.md
3. https://github.com/yeti-switch/yeti-web/issues/1698

