### PR TITLE
bump rack gem from v3.1.11 to v3.1.12 to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,7 +691,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.11)
+    rack (3.1.12)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
## Description

bump rack gem from v3.1.11 to v3.1.12 to fix Vulnerability

## Additional details

```
Name: rack
Version: 3.1.11
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: upgrade to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'

Vulnerabilities found!
```

## Additional links

CVE-2025-27610