### PR TITLE
#1698, bug fix when /dashboard page is loaded, html layout is floated

### DIFF
--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -140,9 +140,8 @@ body.active_admin.index #active_admin_content {
   clear: both;
 }
 
-#main_content_wrapper:has() {
+#main_content_wrapper {
   float: inherit;
-  margin-left: 288px;
   width: auto;
 }
 


### PR DESCRIPTION
## Description

fix regression that was made within #1698 

## Related links

https://github.com/yeti-switch/yeti-web/pull/1709/commits/216a804383ea6d214bc3425cff2ea26844370076

### Screenshots to view how it looks like the problem page

<img width="1688" alt="Screenshot 2025-03-12 at 17 37 39" src="https://github.com/user-attachments/assets/d2784a0c-8b61-419b-94f5-74b022a8326b" />

<img width="1698" alt="Screenshot 2025-03-12 at 17 37 57" src="https://github.com/user-attachments/assets/14ea00d5-62f3-4b0d-99a0-d427dbdfa04f" />
