### PR TITLE
vulnerabilities: bump nokogiri from v1.18.3 to v1.18.6 [no issue]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
       net-protocol
     netstring (0.0.3)
     nio4r (2.5.9)
-    nokogiri (1.18.3)
+    nokogiri (1.18.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (3.11.2)


### PR DESCRIPTION
## Description

bump nokogiri from v1.18.3 to v1.18.6
