### PR TITLE
Admin UI: add Network Type filters to dialpeers and destinations index pages

### DIFF
--- a/app/admin/routing/destinations.rb
+++ b/app/admin/routing/destinations.rb
@@ -79,6 +79,12 @@ ActiveAdmin.register Routing::Destination, as: 'Destination' do
                           scope: -> { System::Network.order(:name) },
                           path: '/system_networks/search'
 
+  filter :network_type_id,
+         as: :select,
+         label: 'Network Type',
+         input_html: { class: 'chosen' },
+         collection: -> { System::NetworkType.collection }
+
   filter :external_id_eq, label: 'EXTERNAL_ID'
   filter :valid_from, as: :date_time_range
   filter :valid_till, as: :date_time_range

--- a/app/admin/routing/dialpeers.rb
+++ b/app/admin/routing/dialpeers.rb
@@ -190,6 +190,12 @@ ActiveAdmin.register Dialpeer do
                           scope: -> { System::Network.order(:name) },
                           path: '/system_networks/search'
 
+  filter :network_type_id,
+         as: :select,
+         label: 'Network Type',
+         input_html: { class: 'chosen' },
+         collection: -> { System::NetworkType.collection }
+
   filter :created_at, as: :date_time_range
   filter :external_id
   filter :exclusive_route, as: :select, collection: [['Yes', true], ['No', false]]

--- a/spec/features/routing/destinations/filters_spec.rb
+++ b/spec/features/routing/destinations/filters_spec.rb
@@ -277,4 +277,31 @@ RSpec.describe 'Filter Destination records', :js do
       expect(page).to have_table_cell column: 'Id', exact_text: record.id.to_s
     end
   end
+
+  describe 'filter by network type' do
+    let(:filter_records) do
+      within_filters do
+        fill_in_chosen 'Network Type', with: network_type.name
+      end
+    end
+
+    let!(:network_prefix) { FactoryBot.create(:network_prefix, prefix: '892715892') }
+    let!(:record) { FactoryBot.create(:destination, prefix: '892715892') }
+    let(:network_type) { record.network.network_type }
+
+    before do
+      FactoryBot.create_list(:destination, 3)
+    end
+
+    it 'should be return filtered record' do
+      subject
+
+      expect(page).to have_table_row(count: 1)
+      expect(page).to have_table_row(id: record.id)
+
+      within_filters do
+        expect(page).to have_field_chosen('Network Type', with: network_type.name)
+      end
+    end
+  end
 end

--- a/spec/features/routing/dialpeers/filters_spec.rb
+++ b/spec/features/routing/dialpeers/filters_spec.rb
@@ -225,4 +225,27 @@ RSpec.describe 'Filter dialpeer records', :js do
       expect(page).to have_table_cell column: 'Id', text: dialpeer_one.id
     end
   end
+
+  describe 'filter by network type' do
+    let(:filter_records) do
+      within_filters do
+        fill_in_chosen 'Network Type', with: network_type.name
+      end
+    end
+
+    let!(:network_prefix) { FactoryBot.create(:network_prefix, prefix: '892715892') }
+    let!(:record) { FactoryBot.create(:dialpeer, prefix: '892715892') }
+    let(:network_type) { record.network.network_type }
+
+    it 'should be return filtered record' do
+      subject
+
+      expect(page).to have_table_row(count: 1)
+      expect(page).to have_table_row(id: record.id)
+
+      within_filters do
+        expect(page).to have_field_chosen('Network Type', with: network_type.name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Admin UI: add Network Type filters to dialpeers and destinations index pages