### PR TITLE
#1728, Refactor CdrDecorator to use constant for phone number masking

### DIFF
--- a/app/decorators/cdr_decorator.rb
+++ b/app/decorators/cdr_decorator.rb
@@ -38,7 +38,7 @@ class CdrDecorator < Draper::Decorator
   def decorated_legb_ruri
     return nil if model.legb_ruri.nil?
 
-    h.authorized?(:allow_full_dst_number) ? model.legb_ruri : model.legb_ruri.gsub(/([0-9]{3})(?=@)/, '***')
+    h.authorized?(:allow_full_dst_number) ? model.legb_ruri : model.legb_ruri.gsub(Cdr::Cdr::MASK_PHONE_NUMBER_REGEXP, '***')
   end
 
   def decorated_phone_field(field_name)

--- a/app/forms/routing/simulation_form.rb
+++ b/app/forms/routing/simulation_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Routing::SimulationForm < ApplicationForm
+  with_policy_class 'Routing::SimulationFormPolicy'
+
   def self.model_name
     ActiveModel::Name.new(self, nil, 'Routing::Simulation')
   end

--- a/app/models/cdr/cdr.rb
+++ b/app/models/cdr/cdr.rb
@@ -213,6 +213,8 @@ class Cdr::Cdr < Cdr::Base
     node sign_term_transport_protocol package_counter
   ].freeze
 
+  MASK_PHONE_NUMBER_REGEXP = /([0-9]{3})(?=@)/
+
   # Used to adjust their format while create CDR Export.
   TIME_SPECIFIC_FIELDS = %w[time_start time_end time_connect].freeze
 

--- a/app/policies/cdr/cdr_policy.rb
+++ b/app/policies/cdr/cdr_policy.rb
@@ -4,8 +4,11 @@ module Cdr
   class CdrPolicy < ::RolePolicy
     section 'Cdr/Cdr'
     self.allowed_actions += %i[allow_full_dst_number recording pcap]
-    alias_rule :dump?, :routing_simulation?, to: :perform?
     Scope = Class.new(RolePolicy::Scope)
+
+    def routing_simulation?
+      Routing::SimulationFormPolicy.new(user, nil).read?
+    end
 
     def download_call_record?
       allowed_for_role?(:recording)

--- a/app/policies/routing/simulation_form_policy.rb
+++ b/app/policies/routing/simulation_form_policy.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Routing
+  class SimulationFormPolicy < RolePolicy
+    section 'Routing/RoutingSimulation'
+
+    def read?
+      allowed_for_role?(:read)
+    end
+
+    Scope = Class.new(RolePolicy::Scope)
+  end
+end


### PR DESCRIPTION
- Introduced MASK_PHONE_NUMBER_REGEXP in Cdr model for consistent phone number masking.
- Updated decorated_legb_ruri method in CdrDecorator to utilize the new constant.