### PR TITLE
#1780, Admin API resource for Billing::PackageCounter

### DIFF
--- a/app/controllers/api/rest/admin/package_counters_controller.rb
+++ b/app/controllers/api/rest/admin/package_counters_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Api::Rest::Admin::PackageCountersController < Api::Rest::Admin::BaseController
+end

--- a/app/resources/api/rest/admin/package_counter_resource.rb
+++ b/app/resources/api/rest/admin/package_counter_resource.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Api::Rest::Admin::PackageCounterResource < ::BaseResource
+  model_name 'Billing::PackageCounter'
+
+  attribute :duration
+  attribute :exclude
+  attribute :prefix
+  attribute :service_id
+
+  paginator :paged
+
+  has_one :account, class_name: 'Account', exclude_links: %i[self]
+  has_one :service, class_name: 'Service', exclude_links: %i[self]
+
+  relationship_filter :service
+  relationship_filter :account
+end

--- a/app/resources/api/rest/admin/service_resource.rb
+++ b/app/resources/api/rest/admin/service_resource.rb
@@ -17,6 +17,7 @@ class Api::Rest::Admin::ServiceResource < ::BaseResource
   has_one :account, class_name: 'Account', always_include_linkage_data: true
   has_one :service_type, class_name: 'ServiceType', foreign_key: :type_id, relation_name: :type
   has_many :transactions, class_name: 'Transaction', foreign_key_on: :related
+  has_many :package_counters, class_name: 'PackageCounter', foreign_key_on: :related
 
   ransack_filter :account_id, type: :foreign_key
   ransack_filter :type_id, type: :foreign_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ Rails.application.routes.draw do
           jsonapi_resources :routeset_discriminators
           jsonapi_resources :destinations
           jsonapi_resources :destination_next_rates
+          jsonapi_resources :package_counters, only: %i[index show]
         end
 
         namespace :customer do

--- a/spec/acceptance/rest/admin/api/package_counters_spec.rb
+++ b/spec/acceptance/rest/admin/api/package_counters_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rspec_api_documentation/dsl'
+
+RSpec.resource 'Package Counters' do
+  include_context :acceptance_admin_user
+  let(:type) { 'package-counters' }
+
+  get '/api/rest/admin/package-counters' do
+    jsonapi_filters Api::Rest::Admin::PackageCounterResource._allowed_filters
+
+    before do
+      create_list(:billing_package_counter, 2)
+    end
+
+    example_request 'get listing' do
+      expect(status).to eq(200)
+    end
+  end
+
+  get '/api/rest/admin/package-counters/:id' do
+    let(:id) { create(:billing_package_counter).id }
+
+    example_request 'get specific entry' do
+      expect(status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/api/rest/admin/services_spec.rb
+++ b/spec/requests/api/rest/admin/services_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::Rest::Admin::ServicesController, type: :request, bullet: [:n
   include_context :json_api_admin_helpers, type: :services
 
   shared_examples :responds_with_service_data_single do |status: 200|
-    include_examples :returns_json_api_record, status:, relationships: %i[account service-type transactions] do
+    include_examples :returns_json_api_record, status:, relationships: %i[account service-type transactions package-counters] do
       let(:json_api_record_id) { record_id }
       let(:json_api_record_attributes) do
         record.reload
@@ -60,6 +60,7 @@ RSpec.describe Api::Rest::Admin::ServicesController, type: :request, bullet: [:n
     let!(:service_type) { create(:service_type) }
     let!(:record) { create(:service, record_attrs) }
     let(:record_attrs) { { type: service_type, account: } }
+    let!(:package_counter) { FactoryBot.create(:billing_package_counter, account:, service: record) }
 
     include_examples :responds_with_service_data_single
 


### PR DESCRIPTION
## Description

- Implemented endpoints for listing and fetching Package Counters in `PackageCountersController`.
- Added `PackageCounterResource` for defining attributes, relationships, and filters.
- Updated `ServiceResource` to include a relationship with Package Counters.
- Adjusted routes to include JSON:API resources for Package Counters.
- Extended service request specs to test Package Counters integration.

## Additional links

closes #1780 

https://github.com/yeti-switch/yeti-switch-api-python/pull/11

## Examples of usage

GET http://127.0.0.1:3000/api/rest/admin/services/1/package-counters
```
{
    "data": [
        {
            "id": "1",
            "type": "package-counters",
            "links": {
                "self": "http://127.0.0.1:3000/api/rest/admin/package-counters/1"
            },
            "attributes": {
                "duration": 0,
                "exclude": false,
                "prefix": "123",
                "service-id": 1
            },
            "relationships": {
                "account": {
                    "links": {
                        "related": "http://127.0.0.1:3000/api/rest/admin/package-counters/1/account"
                    }
                },
                "service": {
                    "links": {
                        "related": "http://127.0.0.1:3000/api/rest/admin/package-counters/1/service"
                    }
                }
            }
        }
    ],
    "meta": {
        "total-count": 1
    },
    "links": {
        "first": "http://127.0.0.1:3000/api/rest/admin/services/1/package-counters?page%5Bnumber%5D=1&page%5Bsize%5D=50",
        "last": "http://127.0.0.1:3000/api/rest/admin/services/1/package-counters?page%5Bnumber%5D=1&page%5Bsize%5D=50"
    }
}
```