### PR TITLE
change type of numberlist_id for import_numberlist_items table from smallint to integer

### DIFF
--- a/app/models/importing/numberlist_item.rb
+++ b/app/models/importing/numberlist_item.rb
@@ -23,7 +23,7 @@
 #  tag_action_value_names :string
 #  action_id              :integer(4)
 #  lua_script_id          :integer(2)
-#  numberlist_id          :integer(2)
+#  numberlist_id          :integer(4)
 #  o_id                   :integer(4)
 #  rewrite_ss_status_id   :integer(2)
 #  tag_action_id          :integer(4)

--- a/db/migrate/20250729072451_change_type_for_numberlist_id_on_import_numberlist_items.rb
+++ b/db/migrate/20250729072451_change_type_for_numberlist_id_on_import_numberlist_items.rb
@@ -1,0 +1,9 @@
+class ChangeTypeForNumberlistIdOnImportNumberlistItems < ActiveRecord::Migration[7.2]
+  def up
+    change_column :import_numberlist_items, :numberlist_id, :integer
+  end
+
+  def down
+    change_column :import_numberlist_items, :numberlist_id, :integer, limit: 2
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -43149,7 +43149,7 @@ CREATE TABLE data_import.import_numberlist_items (
     id integer NOT NULL,
     o_id integer,
     error_string character varying,
-    numberlist_id smallint,
+    numberlist_id integer,
     numberlist_name character varying,
     key character varying,
     action_id integer,
@@ -50143,6 +50143,7 @@ ALTER TABLE ONLY sys.sensors
 SET search_path TO gui, public, switch, billing, class4, runtime_stats, sys, logs, data_import;
 
 INSERT INTO "public"."schema_migrations" (version) VALUES
+('20250729072451'),
 ('20250714084517'),
 ('20250713123436'),
 ('20250712180031'),

--- a/spec/factories/importing/numberlist_items.rb
+++ b/spec/factories/importing/numberlist_items.rb
@@ -23,7 +23,7 @@
 #  tag_action_value_names :string
 #  action_id              :integer(4)
 #  lua_script_id          :integer(2)
-#  numberlist_id          :integer(2)
+#  numberlist_id          :integer(4)
 #  o_id                   :integer(4)
 #  rewrite_ss_status_id   :integer(2)
 #  tag_action_id          :integer(4)


### PR DESCRIPTION
To sync with numberlists primary key:

```
# Table name: class4.numberlists
#
#  id                         :integer(4)       not null, primary key
```