### PR TITLE
#1844 changed value for send_balance_notifications_to field of webhook payload

### DIFF
--- a/app/domain/notification_event.rb
+++ b/app/domain/notification_event.rb
@@ -136,7 +136,7 @@ class NotificationEvent
     data = account.attributes.merge(
       balance_low_threshold: account.balance_notification_setting.low_threshold,
       balance_high_threshold: account.balance_notification_setting.high_threshold,
-      send_balance_notifications_to: account.balance_notification_setting.send_to
+      send_balance_notifications_to: account_contacts(account).map(&:email).compact
     )
     data.to_json
   end
@@ -145,7 +145,7 @@ class NotificationEvent
     account.attributes.merge(
       balance_low_threshold: account.balance_notification_setting.low_threshold,
       balance_high_threshold: account.balance_notification_setting.high_threshold,
-      send_balance_notifications_to: account.balance_notification_setting.send_to
+      send_balance_notifications_to: account_contacts(account).map(&:email).compact
     )
   end
 

--- a/spec/domain/notification_event_spec.rb
+++ b/spec/domain/notification_event_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe NotificationEvent do
       data = account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
       data.to_json
     end
@@ -273,11 +273,26 @@ RSpec.describe NotificationEvent do
       account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
     end
 
     include_examples :sends_account_threshold_event_emails
+
+    context 'when account send_balance_notifications_to contains non-existing id' do
+      let(:account_attrs) { { send_balance_notifications_to: contacts.map(&:id) + [999_999] } }
+
+      it 'skips missing contacts when building event payload' do
+        event_subscription.update! url: 'http://example.com/cb'
+        allow(NotificationEvent).to receive(:event_time).and_return('stub')
+        expect { subject }.to have_enqueued_job(Worker::SendHttpJob)
+
+        job = enqueued_jobs.find { |j| j[:job] == Worker::SendHttpJob }
+        body = job[:args][2]
+        parsed = JSON.parse(body)
+        expect(parsed['event_data']['send_balance_notifications_to']).to match_array(contacts.map(&:email))
+      end
+    end
   end
 
   describe '.high_threshold_reached' do
@@ -320,7 +335,7 @@ RSpec.describe NotificationEvent do
       data = account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
       data.to_json
     end
@@ -328,7 +343,7 @@ RSpec.describe NotificationEvent do
       account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
     end
 
@@ -375,7 +390,7 @@ RSpec.describe NotificationEvent do
       data = account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
       data.to_json
     end
@@ -383,7 +398,7 @@ RSpec.describe NotificationEvent do
       account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
     end
 
@@ -430,7 +445,7 @@ RSpec.describe NotificationEvent do
       data = account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
       data.to_json
     end
@@ -438,7 +453,7 @@ RSpec.describe NotificationEvent do
       account.attributes.merge(
         balance_low_threshold: account.balance_notification_setting.low_threshold,
         balance_high_threshold: account.balance_notification_setting.high_threshold,
-        send_balance_notifications_to: account.balance_notification_setting.send_to
+        send_balance_notifications_to: account.balance_notification_setting.contacts.map(&:email).compact
       )
     end
 


### PR DESCRIPTION
## Description
We have a NotificationEvent model and a Worker::SendHttpJob that sends a POST request to the customer's URL.  
In this commit, we updated the payload of this HTTP request.

Specifically, we changed the value of the `event_data.send_balance_notifications_to` field in the webhook payload for the "Account high threshold reached" and similar events.

### before:
POST https://example.com/callback
```json
{
  "event_type": "AccountLowThesholdReached",
  "event_data": {
    "id": 1858,
    "contractor_id": 3757,
    "balance": "0.0",
    "min_balance": "0.0",
    "max_balance": "0.0",
    "name": "account2",
    "origination_capacity": null,
    "termination_capacity": null,
    "invoice_period_id": null,
    "invoice_template_id": null,
    "next_invoice_at": null,
    "send_invoices_to": null,
    "timezone_id": 1,
    "next_invoice_type_id": null,
    "uuid": "48c96742-ac23-11f0-a8c3-4e1f71c596a5",
    "external_id": 2,
    "vat": "23.1",
    "total_capacity": null,
    "destination_rate_limit": "0.3444",
    "max_call_duration": 36000,
    "invoice_ref_template": "$id",
    "balance_low_threshold": null,
    "balance_high_threshold": null,
    "send_balance_notifications_to": [
      2946,
      2947,
      2948
    ]
  },
  "event_time": "2025-10-18 13:06:39 UTC"
}
```

### after
POST https://example.com/callback
```json
{
  "event_type": "AccountLowThesholdReached",
  "event_data": {
    "id": 1856,
    "contractor_id": 3752,
    "balance": "0.0",
    "min_balance": "0.0",
    "max_balance": "0.0",
    "name": "account2",
    "origination_capacity": null,
    "termination_capacity": null,
    "invoice_period_id": null,
    "invoice_template_id": null,
    "next_invoice_at": null,
    "send_invoices_to": null,
    "timezone_id": 1,
    "next_invoice_type_id": null,
    "uuid": "f127a800-ac22-11f0-b1e7-4e1f71c596a5",
    "external_id": 2,
    "vat": "23.1",
    "total_capacity": null,
    "destination_rate_limit": "0.3444",
    "max_call_duration": 36000,
    "invoice_ref_template": "$id",
    "balance_low_threshold": null,
    "balance_high_threshold": null,
    "send_balance_notifications_to": [
      "rspec_mail_4@example.com",
      "rspec_mail_5@example.com",
      "rspec_mail_6@example.com"
    ]
  },
  "event_time": "2025-10-18 13:04:12 UTC"
}
```


## Additional links
https://github.com/yeti-switch/yeti-web/issues/1844