### PR TITLE
Add admin UI session expiration configuration

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -102,6 +102,10 @@ Config.setup do |setup_config|
       optional(:auto_approve).value(:bool)
     end
     optional(:default_ldap_roles).array(:string)
+
+    optional(:admin_ui).schema do
+      optional(:session_lifetime).maybe(:int?)
+    end
   end
 end
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,14 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_yeti_session'
+session_options = {
+  key: '_yeti_session'
+}
+
+# Configure session expiration if admin_ui.session_lifetime is set
+# Note: Config is loaded in config/initializers/config.rb which runs before this file
+if defined?(YetiConfig) && YetiConfig.admin_ui&.session_lifetime.present?
+  session_options[:expire_after] = YetiConfig.admin_ui.session_lifetime.seconds
+end
+
+Rails.application.config.session_store :cookie_store, **session_options

--- a/config/yeti_web.yml.ci
+++ b/config/yeti_web.yml.ci
@@ -91,3 +91,9 @@ s3_storage:
     bucket: ''
 
 tmpdir: 'tmp'
+
+# Admin UI session expiration configuration (optional)
+# If not set, sessions will not expire (current behavior)
+# If set, sessions will expire after the specified number of seconds of inactivity
+admin_ui:
+  session_lifetime: 60  # Session expires after 60 seconds of inactivity

--- a/config/yeti_web.yml.distr
+++ b/config/yeti_web.yml.distr
@@ -72,3 +72,9 @@ s3_storage:
     bucket: ''
 
 tmpdir: 'tmp'
+
+# Admin UI session expiration configuration (optional)
+# If not set, sessions will not expire (current behavior)
+# If set, sessions will expire after the specified number of seconds of inactivity
+# admin_ui:
+#   session_lifetime: 60  # Session expires after 60 seconds of inactivity

--- a/spec/config/yeti_web_spec.rb
+++ b/spec/config/yeti_web_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe 'config/yeti_web.yml' do
           bucket: a_kind_of(String)
         }
       },
-      tmpdir: a_kind_of(String)
+      tmpdir: a_kind_of(String),
+      admin_ui: be_kind_of(Hash)
     }
   end
 

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -93,4 +93,49 @@ RSpec.describe 'the sign in process', js: true do
       expect(page).to have_current_path root_path
     end
   end
+
+  context 'when admin_ui.session_lifetime is configured', js: false do
+    let(:admin_user_attrs) { super().merge email: 'test@example.com', password: '111111' }
+    let(:error_message) do
+      error_message = <<~MESSAGE
+        session_lifetime is not configured for this spec
+
+        file: config/yeti_web.yml
+
+        ```yml
+
+        admin_ui:
+          session_lifetime: 60
+        ```
+      MESSAGE
+      error_message
+    end
+
+    it 'create session and after 61 seconds of inactivity logout' do
+      expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
+      visit new_admin_user_session_path
+      fill_form!
+      click_button 'Login'
+      expect(page).to have_current_path root_path
+      expect(page).to have_flash_message 'Signed in successfully.', type: :notice
+      travel_to((YetiConfig.admin_ui.session_lifetime + 1).seconds.from_now) do
+        visit root_path
+        expect(page).to have_current_path new_admin_user_session_path
+      end
+      expect(Rails.application.config.session_options[:expire_after]).to eq 60.seconds
+    end
+
+    it 'signs in successfully and after 60 seconds inactivity still valid session' do
+      expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
+      visit new_admin_user_session_path
+      fill_form!
+      click_button 'Login'
+      expect(page).to have_current_path root_path
+      travel_to(YetiConfig.admin_ui.session_lifetime.seconds.from_now) do
+        visit root_path
+        expect(page).to have_current_path root_path
+      end
+      expect(Rails.application.config.session_options[:expire_after]).to eq 60.seconds
+    end
+  end
 end


### PR DESCRIPTION
## Description

Introduce optional session expiration settings for the admin UI in the configuration files. Update `yeti_web.yml.ci`
Update `yeti_web.yml.distr` 

### example of new config
config/yeti_web.yml
```yml
admin_ui:
  session_lifetime: 60
```

## Additional links

closes #1859