### PR TITLE
[no issue] quieter, safer, and more readable test/CI output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -245,6 +245,10 @@ Lint/CircularArgumentReference:
   Enabled: true
 Lint/Debugger:
   Enabled: true
+  DebuggerMethods:
+    - p
+    - pp
+    - puts
 Lint/DeprecatedClassMethods:
   Enabled: true
 Lint/DuplicateCaseCondition:

--- a/db/custom_seeds/network_prefixes.rb
+++ b/db/custom_seeds/network_prefixes.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
-# rubocop:disable Rails/Output
-puts 'loading global data'
+Rails.logger.info 'loading global data'
 network_types = YAML.load_file('db/network_types.yml')
 networks = YAML.load_file('db/networks.yml')
 countries = YAML.load_file('db/countries.yml')
 network_prefixes = YAML.load_file('db/network_prefixes.yml')
 
 System::NetworkPrefix.transaction do
-  puts 'deleting old data'
+  Rails.logger.info 'deleting old data'
   System::NetworkPrefix.delete_all
   System::Network.delete_all
   System::NetworkType.delete_all
   System::Country.delete_all
 
-  puts 'insert new global'
+  Rails.logger.info 'insert new global'
   System::NetworkType.insert_all!(network_types) if network_types.any?
   System::Network.insert_all!(networks) if networks.any?
   System::Country.insert_all!(countries) if countries.any?
@@ -25,22 +24,22 @@ System::NetworkPrefix.transaction do
   network_attrs_list = []
   network_prefix_attrs_list = []
   Dir.glob('db/network_data/**/*.yml') do |f|
-    puts "load file #{f}:"
+    Rails.logger.info "load file #{f}:"
     data = YAML.load_file(f, aliases: true)
     network_attrs_list.concat(data['networks'])
     network_prefix_attrs_list.concat(data['network_prefixes'])
   end
 
   System::Network.insert_all!(network_attrs_list) if network_attrs_list.any?
-  puts "  loaded #{network_attrs_list.length} networks"
+  Rails.logger.info "  loaded #{network_attrs_list.length} networks"
   n_network_ids = network_attrs_list.map { |network_attrs| network_attrs['id'] }
 
   System::NetworkPrefix.insert_all!(network_prefix_attrs_list) if network_prefix_attrs_list.any?
-  puts "  loaded #{network_prefix_attrs_list.length} network prefixes"
+  Rails.logger.info "  loaded #{network_prefix_attrs_list.length} network prefixes"
   np_network_ids = network_prefix_attrs_list.map { |network_prefix_attrs| network_prefix_attrs['network_id'] }.uniq
 
   no_prefixes = n_network_ids - np_network_ids
-  puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any?
+  Rails.logger.info "  networks without prefixes: #{no_prefixes}" if no_prefixes.any?
 end
 
 System::NetworkPrefix.transaction do
@@ -49,4 +48,3 @@ System::NetworkPrefix.transaction do
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.countries_id_seq', MAX(id), true) FROM sys.countries"
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.network_prefixes_id_seq', MAX(id), true) FROM sys.network_prefixes"
 end
-# rubocop:enable Rails/Output

--- a/lib/scheduler/base.rb
+++ b/lib/scheduler/base.rb
@@ -111,14 +111,14 @@ class Scheduler::Base
     raise ArgumentError, 'scheduler already running' if running?
 
     @rufus_scheduler = Rufus::Scheduler.new
-    puts 'Scheduler started.' # rubocop:disable Rails/Output
+    Rails.logger.info 'Scheduler started.'
 
     Kernel.trap('TERM') do
-      puts "TERM received.\nShutting down..." # rubocop:disable Rails/Output
+      Rails.logger.info "TERM received.\nShutting down..."
       shutdown
     end
     Kernel.trap('INT') do
-      puts "\nINT received.\nShutting down..." # rubocop:disable Rails/Output
+      Rails.logger.info "\nINT received.\nShutting down..."
       shutdown
     end
 

--- a/lib/tasks/check_timezones.rake
+++ b/lib/tasks/check_timezones.rake
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 
 task check_timezones: :environment do |_t, _args|
-  puts "\e[1m\e[32mChecking Scheduler timezones:\e[0m"
+  Rails.logger.info "\e[1m\e[32mChecking Scheduler timezones:\e[0m"
 
   bad_schedulers = 0
   System::Scheduler.where('timezone not in (?)', Yeti::TimeZoneHelper.all).find_each do |scheduler|
-    puts "      \e[1m\e[33mWrong timezone #{scheduler.timezone} in scheduler id=#{scheduler.id}\e[0m"
+    Rails.logger.info "      \e[1m\e[33mWrong timezone #{scheduler.timezone} in scheduler id=#{scheduler.id}\e[0m"
     bad_schedulers = 1
   end
 
   if bad_schedulers != 0
-    puts "      \e[1m\e[31mACTION REQUIRED: You SHOULD fix timezones in schedulers\n\e[0m"
+    Rails.logger.info "      \e[1m\e[31mACTION REQUIRED: You SHOULD fix timezones in schedulers\n\e[0m"
   else
-    puts "      \e[1m\e[32mOK\n\e[0m"
+    Rails.logger.info "      \e[1m\e[32mOK\n\e[0m"
   end
 
-  puts "\e[1m\e[32mChecking CDR Exports timezones(OPTIONAL):\e[0m"
+  Rails.logger.info "\e[1m\e[32mChecking CDR Exports timezones(OPTIONAL):\e[0m"
 
   bad_exports = 0
   CdrExport.where('time_zone_name not in (?)', Yeti::TimeZoneHelper.all).find_each do |s|
-    puts "      \e[1m\e[33mWrong timezone #{s.time_zone_name} in CDR Export id=#{s.id}\e[0m"
+    Rails.logger.info "      \e[1m\e[33mWrong timezone #{s.time_zone_name} in CDR Export id=#{s.id}\e[0m"
     bad_exports = 1
   end
 
   if bad_exports == 0
-    puts "      \e[1m\e[32mOK\n\e[0m"
+    Rails.logger.info "      \e[1m\e[32mOK\n\e[0m"
   end
 
   if bad_schedulers != 0 || bad_exports != 0

--- a/lib/tasks/custom_seeds.rake
+++ b/lib/tasks/custom_seeds.rake
@@ -9,7 +9,7 @@ task custom_seeds: :environment do |_t, args|
   args = args.to_a
   raise ArgumentError, 'provide at least one file like this: `rake custom_seeds[cdrs]`' if args.empty?
 
-  puts "Running custom_seeds #{args.join(', ')}"
+  Rails.logger.info "Running custom_seeds #{args.join(', ')}"
   files = args.map { |name| Rails.root.join("db/custom_seeds/#{name}.rb") }
   missing_files = files.reject { |filepath| File.exist?(filepath) }
   raise ArgumentError, "missing files: #{missing_files.join(', ')}" if missing_files.any?

--- a/pgq-processors/processors/cdr_billing.rb
+++ b/pgq-processors/processors/cdr_billing.rb
@@ -6,7 +6,6 @@ class CdrBilling < Pgq::ConsumerGroup
   def initialize(logger, queue, consumer, options)
     super
     Dir['models/*.rb'].each { |file| require_relative File.join('../', file) }
-    p options
     key = options['mode']
     ::RoutingBase.establish_connection options['databases'][key]['primary']
 

--- a/script/format_runtime_log
+++ b/script/format_runtime_log
@@ -1,18 +1,24 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-log_path = ARGV[0]
+require 'logger'
+
+log_path   = ARGV[0]
 filter_qty = (ARGV[1] || 10).to_i
 
+logger = Logger.new($stdout)
+logger.level = Logger::INFO
+logger.formatter = proc { |_sev, _time, _prog, msg| "#{msg}\n" }
+
 unless File.exist?(log_path)
-  puts "File #{log_path.inspect} does not exist. skipping"
-  exit
+  logger.info %(File #{log_path.inspect} does not exist. skipping)
+  exit 0
 end
 
 content = File.read(log_path).split("\n").select { |line| line.start_with?('spec/') }
 data = content.map { |line| line.split(':') }.sort_by { |parts| parts[1].to_f }.reverse[0..filter_qty]
 output_content = data.map { |parts| "  #{parts[1].to_f.round(2)}\tseconds for #{parts[0]}" }
 
-puts "Top #{filter_qty} slowest spec files:"
-puts output_content.join("\n")
-puts "\nTotal #{content.size} spec files."
+logger.info "Top #{filter_qty} slowest spec files:"
+logger.info output_content.join("\n")
+logger.info "Total #{content.size} spec files."

--- a/spec/prometheus_collectors/active_calls_collector_spec.rb
+++ b/spec/prometheus_collectors/active_calls_collector_spec.rb
@@ -297,7 +297,6 @@ RSpec.describe ActiveCallsCollector, '#metrics' do
     end
 
     it 'have all metrics' do
-      puts subject.map(&:to_prometheus_text).join("\n\n")
       expect(subject).to match_array(
                            [
                              be_a_gauge(:yeti_ac_account_originated)

--- a/spec/requests/api/rest/admin/destinations_spec.rb
+++ b/spec/requests/api/rest/admin/destinations_spec.rb
@@ -179,8 +179,6 @@ RSpec.describe Api::Rest::Admin::DestinationsController, type: :request do
       it 'should return correct response' do
         subject
 
-        p response_json
-
         expect(response_json[:meta]).to match('total-count': destinations.size)
         # 1 countries + 1 networks + 1 destination next rate = 5
         expect(response_json[:included].size).to eq(3)


### PR DESCRIPTION
## Motivation

Occasionally, our test runs (bundle exec rspec some_spec.rb) print stray debug output instead of only the expected green dots. These messages come from temporary helpers like puts, p, pp, ap, warn, debugger/byebug, and binding.pry that were left behind during local debugging

Result: quieter, safer, and more readable test/CI output with near-zero ongoing cost.