### PR TITLE
[no issue] Update session timeout test descriptions & fix float test

### DIFF
--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'the sign in process', js: true do
       error_message
     end
 
-    it 'create session and after 61 seconds of inactivity logout' do
+    it 'create session and then after 61 seconds of inactivity session should be removed' do
       expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
       visit new_admin_user_session_path
       fill_form!
@@ -125,13 +125,13 @@ RSpec.describe 'the sign in process', js: true do
       expect(Rails.application.config.session_options[:expire_after]).to eq 60.seconds
     end
 
-    it 'signs in successfully and after 60 seconds inactivity still valid session' do
+    it 'after 55 seconds of inactivity session stilla alive' do
       expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
       visit new_admin_user_session_path
       fill_form!
       click_button 'Login'
       expect(page).to have_current_path root_path
-      travel_to(YetiConfig.admin_ui.session_lifetime.seconds.from_now) do
+      travel_to(55.seconds.from_now) do
         visit root_path
         expect(page).to have_current_path root_path
       end


### PR DESCRIPTION
### Description

This test verifies that the Admin session is removed after a specific timeout interval. On some machines the test passes, while on others it fails. The reason is that the current timeout value is set to 60 seconds, which is exactly the final moment before the session expires. On machines with lower performance or slower timing resolution, this boundary condition can cause intermittent failures.

To make the test more stable across different environments, we will adjust the value from 60 seconds to 55 seconds. This ensures that the session is still valid within the tested time window, reducing flakiness and preventing false negatives on slower machines.