### PR TITLE
set default filter to show only today's records in payments and trans…

### DIFF
--- a/app/admin/billing/payments.rb
+++ b/app/admin/billing/payments.rb
@@ -24,6 +24,11 @@ ActiveAdmin.register Payment do
                  :balance_before_payment,
                  :rolledback_at
 
+  with_default_params do
+    params[:q] = { created_at_gteq_datetime_picker: 0.days.ago.beginning_of_day }
+    'Only records from beginning of the day showed by default'
+  end
+
   controller do
     def scoped_collection
       Payment.includes(:account)

--- a/app/admin/billing/transactions.rb
+++ b/app/admin/billing/transactions.rb
@@ -16,6 +16,11 @@ ActiveAdmin.register Billing::Transaction, as: 'Transactions' do
 
   includes :account, :service
 
+  with_default_params do
+    params[:q] = { created_at_gteq_datetime_picker: 0.days.ago.beginning_of_day }
+    'Only records from beginning of the day showed by default'
+  end
+
   filter :id
   filter :created_at, as: :date_time_range
   account_filter :account_id_eq


### PR DESCRIPTION
## Description

default filters by date on transactions and payments

### Example

```ruby
  with_default_params do
    params[:q] = { created_at_gteq_datetime_picker: 0.days.ago.beginning_of_day }
    'Only records from beginning of the day showed by default'
  end
```

## Additional links

#1908 