### PR TITLE
allow specifying S3 storage file prefix for dump file paths

### DIFF
--- a/app/models/cdr/cdr.rb
+++ b/app/models/cdr/cdr.rb
@@ -372,6 +372,12 @@ class Cdr::Cdr < Cdr::Base
     "/dump/#{name}"
   end
 
+  def dump_file_s3_path
+    return unless (name = dump_file_name)
+
+    "#{YetiConfig.s3_storage&.pcap&.prefix}#{name}"
+  end
+
   def dump_file_name
     return if local_tag.blank? || node_id.blank?
 

--- a/app/services/cdr/download_pcap.rb
+++ b/app/services/cdr/download_pcap.rb
@@ -44,7 +44,7 @@ module Cdr
       response_object.headers['Content-Disposition'] = "attachment; filename=\"#{cdr.dump_file_name}\""
       response_object.headers['Content-Type'] = 'application/octet-stream'
 
-      S3AttachmentWrapper.stream_to!(pcap_bucket, cdr.dump_file_path) do |chunk|
+      S3AttachmentWrapper.stream_to!(pcap_bucket, cdr.dump_file_s3_path) do |chunk|
         response_object.stream.write(chunk)
       end
     end

--- a/config/yeti_web.yml.ci
+++ b/config/yeti_web.yml.ci
@@ -91,6 +91,7 @@ s3_storage:
     http_wire_trace: false
   pcap:
     bucket: ''
+    prefix: 'dump'
   call_record:
     bucket: ''
   cdr_export:

--- a/config/yeti_web.yml.distr
+++ b/config/yeti_web.yml.distr
@@ -71,6 +71,7 @@ s3_storage:
     http_wire_trace: false
   pcap:
     bucket: ''
+    prefix: 'dump'
   call_record:
     bucket: ''
   cdr_export:

--- a/spec/config/yeti_web_spec.rb
+++ b/spec/config/yeti_web_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe 'config/yeti_web.yml' do
         force_path_style: be_one_of(true, false),
         client_options: a_kind_of(Hash),
         pcap: {
-          bucket: a_kind_of(String)
+          bucket: a_kind_of(String),
+          prefix: a_kind_of(String)
         },
         call_record: {
           bucket: a_kind_of(String)

--- a/spec/features/cdr/cdr_history/cdr_show_spec.rb
+++ b/spec/features/cdr/cdr_history/cdr_show_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'CDR show', type: :feature do
         allow(YetiConfig).to receive(:s3_storage).and_return(
           OpenStruct.new(
             endpoint: 'http::some_example_s3_storage_url',
-            pcap: OpenStruct.new(bucket: 'test-pcap-bucket'),
+            pcap: OpenStruct.new(bucket: 'test-pcap-bucket', prefix: 'dump'),
             call_record: OpenStruct.new(bucket: 'test-call-record-bucket')
           )
         )


### PR DESCRIPTION
## Description

add S3 storage config

```
s3_storage:
  endpoint: ''
  access_key_id: ''
  secret_access_key: ''
  region: ''
  force_path_style: false
  client_options:
    http_read_timeout: 60
    http_wire_trace: false
  pcap:
    bucket: ''
    prefix: '' // <-- the new key
  call_record:
    bucket: ''
  cdr_export:
    bucket: ''
```

### Behavious:

- when `prefix` equal to blank string THEN YETI will remove prefix
- when `prefix` equal to some string THEN YETI will use this string as prefix
- when there is no `prefix` at all THEN YETI will use 

## Requirement:

- backward compatibility

when new key is absent then the application should work as before

## Additional links

#1897 