### PR TITLE
Fix 500 error when visit ActiveCall

### DIFF
--- a/app/admin/realtime_data/active_calls.rb
+++ b/app/admin/realtime_data/active_calls.rb
@@ -110,6 +110,9 @@ ActiveAdmin.register RealtimeData::ActiveCall, as: 'Active Calls' do
     rescue NodeApi::Error => e
       flash[:warning] = e.message
       redirect_to_back
+    rescue RealtimeData::ActiveNode::Error, Node::Error => e
+      flash[:warning] = e.message
+      redirect_to_back
     end
 
     def scoped_collection

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -20,6 +20,8 @@
 #
 
 class Node < ApplicationRecord
+  Error = Class.new(StandardError)
+
   include WithPaperTrail
 
   belongs_to :pop
@@ -120,8 +122,17 @@ class Node < ApplicationRecord
     super(options.merge(include: :pop))
   end
 
-  def active_call(id)
-    RealtimeData::ActiveCall.new(api.calls(id))
+  def active_call(local_tag)
+    items = Array.wrap(api.calls(local_tag))
+
+    case items.size
+    when 0
+      nil
+    when 1
+      RealtimeData::ActiveCall.new(items.first)
+    else
+      raise Error, "Expected 1 result from Node 'yeti.show.calls' for node_id=#{id} local_tag=#{local_tag}, got #{items.size}"
+    end
   end
 
   def active_calls(only = nil)

--- a/app/models/realtime_data/active_node.rb
+++ b/app/models/realtime_data/active_node.rb
@@ -20,6 +20,8 @@
 #
 
 class RealtimeData::ActiveNode < Node
+  Error = Class.new(StandardError)
+
   def self.random_node
     ids = pluck(:id)
     find(ids.sample)
@@ -39,8 +41,17 @@ class RealtimeData::ActiveNode < Node
     api.call_disconnect(id)
   end
 
-  def active_call(id)
-    RealtimeData::ActiveCall.new(api.calls(id))
+  def active_call(local_tag)
+    items = Array.wrap(api.calls(local_tag))
+
+    case items.size
+    when 0
+      nil
+    when 1
+      RealtimeData::ActiveCall.new(items.first)
+    else
+      raise Error, "Expected 1 result from Node 'yeti.show.calls' for node_id=#{id} local_tag=#{local_tag}, got #{items.size}"
+    end
   end
 
   def active_calls(options = {})

--- a/app/resources/api/rest/admin/active_call_resource.rb
+++ b/app/resources/api/rest/admin/active_call_resource.rb
@@ -93,6 +93,8 @@ class Api::Rest::Admin::ActiveCallResource < ::BaseResource
     raise JSONAPI::Exceptions::RecordNotFound, key if model.nil?
 
     new(model, context)
+  rescue RealtimeData::ActiveNode::Error, Node::Error => _e
+    raise JSONAPI::Exceptions::RecordNotFound, key
   end
 
   def self.sort_records(records, _order_options, _context = {})

--- a/spec/features/realtime_data/active_calls/show_spec.rb
+++ b/spec/features/realtime_data/active_calls/show_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Active Calls show' do
+  let(:visit_show_page!) { visit active_call_path(record_id) }
+
+  include_context :login_as_admin
+
+  let!(:node) { create(:node) }
+  let(:active_call_attributes) { FactoryBot.attributes_for(:active_call, :filled, node_id: node.id) }
+  let(:active_call_attributes_second) { FactoryBot.attributes_for(:active_call, :filled, node_id: node.id) }
+  let(:record_id) { "#{node.id}*#{active_call_attributes[:local_tag]}" }
+
+  before do
+    stub_jrpc_request(node.rpc_endpoint, 'yeti.show.calls', [active_call_attributes[:local_tag]])
+      .and_return([active_call_attributes.stringify_keys, active_call_attributes_second.stringify_keys])
+  end
+
+  it 'renders show page when API returns an array for a attributes' do
+    visit_show_page!
+
+    expect(page).to have_http_status :ok
+  end
+end


### PR DESCRIPTION
## Description

When Admin visits the show page of ActiveCall the Yeti web perform `yeti.show.calls` request to the Node Node responds with four type of responses

1. Hash
2. [Hash]
3. [Hash, Hash, Hash...]

see the implementation of `normalize_result` method
```ruby
def normalize_result(result)
  return result.deep_symbolize_keys if result.is_a?(Hash)
  return result.map { |item| normalize_result(item) } if result.is_a?(Array)

  result
end
# app/lib/node_api.rb
```

I suggest to render flash message in case when we expect one result from Node bit instead of this there is two or many.

## Additional links

closes #1750