### PR TITLE
Api Log: Store JWT token customer/account information to meta

### DIFF
--- a/app/controllers/api/rest/customer/v1/auth_controller.rb
+++ b/app/controllers/api/rest/customer/v1/auth_controller.rb
@@ -40,10 +40,6 @@ class Api::Rest::Customer::V1::AuthController < ApplicationController
     head 204
   end
 
-  def meta
-    nil
-  end
-
   private
 
   def authenticate!
@@ -54,6 +50,8 @@ class Api::Rest::Customer::V1::AuthController < ApplicationController
     )
     @auth_token = result.token
     @expires_at = result.expires_at
+    @auth_context = result.auth_context
+    @jwt_payload = result.payload
   end
 
   def auth_params

--- a/app/controllers/concerns/admin_api_authorizable.rb
+++ b/app/controllers/concerns/admin_api_authorizable.rb
@@ -25,12 +25,19 @@ module AdminApiAuthorizable
     }
   end
 
+  def meta
+    return if @jwt_payload.blank?
+
+    { 'auth' => @jwt_payload }
+  end
+
   private
 
   def authorize
-    auth_token = params[:token] || request.headers['Authorization']&.split&.last
-    result = Authorization::AdminAuth.authorize!(auth_token, remote_ip: request.remote_ip)
+    @auth_token = params[:token] || request.headers['Authorization']&.split&.last
+    result = Authorization::AdminAuth.authorize!(@auth_token, remote_ip: request.remote_ip)
     @current_admin_user = result.entity
+    @jwt_payload = result.payload
   end
 
   def handle_authorization_error

--- a/app/controllers/concerns/customer_v1_authorizable.rb
+++ b/app/controllers/concerns/customer_v1_authorizable.rb
@@ -9,12 +9,19 @@ module CustomerV1Authorizable
     attr_reader :auth_context
   end
 
+  def meta
+    return if @jwt_payload.blank?
+
+    { 'auth' => @jwt_payload }
+  end
+
   private
 
   def authorize!
     source_context = build_source_context
-    auth_context = CustomerV1Auth::Authorizer.authorize! source_context[:token]
-    @auth_context = auth_context
+    result = CustomerV1Auth::Authorizer.authorize! source_context[:token]
+    @auth_context = result.auth_context
+    @jwt_payload = result.payload
     @response_cookie_needed = source_context[:from_cookie]
   end
 

--- a/app/lib/authorization/admin_auth.rb
+++ b/app/lib/authorization/admin_auth.rb
@@ -2,7 +2,7 @@
 
 module Authorization
   class AdminAuth
-    Result = Struct.new(:entity)
+    Result = Struct.new(:entity, :payload)
     AuthorizationError = Class.new(StandardError)
 
     class << self
@@ -34,7 +34,7 @@ module Authorization
       raise AuthorizationError if admin_user.nil?
       raise AuthorizationError unless admin_user.ip_allowed?(@remote_ip)
 
-      Result.new(admin_user)
+      Result.new(admin_user, payload)
     end
   end
 end

--- a/app/lib/customer_v1_auth/authenticator.rb
+++ b/app/lib/customer_v1_auth/authenticator.rb
@@ -6,7 +6,7 @@ module CustomerV1Auth
     AUDIENCE = 'customer-v1'
     COOKIE_NAME = '_yeti_customer_v1_session'
     DYNAMIC_SUB = 'D'
-    Result = Struct.new(:token, :expires_at)
+    Result = Struct.new(:token, :expires_at, :auth_context, :payload)
     AuthenticationError = Class.new(StandardError)
 
     # @param login [String]
@@ -23,20 +23,16 @@ module CustomerV1Auth
     # @return [CustomerV1Auth::Authenticator::Result]
     def self.build_auth_data(auth_context)
       expires_at = EXPIRATION_INTERVAL&.from_now
-      token = build_token(auth_context, expires_at:)
-      Result.new(token, expires_at)
+      payload = build_payload(auth_context, expires_at:)
+      token = TokenBuilder.encode(payload)
+      Result.new(token, expires_at, auth_context, payload)
     end
 
     # @param auth_context [CustomerV1Auth::AuthContext]
     # @param expires_at [Time, nil]
     # @return [String] JWT token
     def self.build_token(auth_context, expires_at:)
-      payload = if auth_context.api_access_id.nil?
-                  { aud: AUDIENCE, sub: DYNAMIC_SUB, cfg: auth_context.to_config }
-                else
-                  { aud: AUDIENCE, sub: auth_context.api_access_id }
-                end
-      payload[:exp] = expires_at.to_i unless expires_at.nil?
+      payload = build_payload(auth_context, expires_at:)
       TokenBuilder.encode(payload)
     end
 
@@ -59,6 +55,20 @@ module CustomerV1Auth
 
       auth_context = AuthContext.from_api_access(api_access)
       self.class.build_auth_data(auth_context)
+    end
+
+    class << self
+      private
+
+      def build_payload(auth_context, expires_at:)
+        payload = if auth_context.api_access_id.nil?
+                    { aud: AUDIENCE, sub: DYNAMIC_SUB, cfg: auth_context.to_config }
+                  else
+                    { aud: AUDIENCE, sub: auth_context.api_access_id }
+                  end
+        payload[:exp] = expires_at.to_i unless expires_at.nil?
+        payload
+      end
     end
   end
 end

--- a/app/lib/customer_v1_auth/authorizer.rb
+++ b/app/lib/customer_v1_auth/authorizer.rb
@@ -2,10 +2,11 @@
 
 module CustomerV1Auth
   class Authorizer
+    Result = Struct.new(:auth_context, :payload)
     AuthorizationError = Class.new(StandardError)
 
     # @param token [String]
-    # @return [CustomerV1Auth::AuthContext] when success
+    # @return [CustomerV1Auth::Authorizer::Result] when success
     # @raise [CustomerV1Auth::Authorizer::AuthenticationError] when failed
     def self.authorize!(token)
       instance = new(token)
@@ -17,7 +18,7 @@ module CustomerV1Auth
       @token = token
     end
 
-    # @return [CustomerV1Auth::AuthContext] when success
+    # @return [CustomerV1Auth::Authorizer::Result] when success
     # @raise [CustomerV1Auth::Authorizer::AuthenticationError] when failed
     def authorize!
       verify_expiration = Authenticator::EXPIRATION_INTERVAL.present?
@@ -32,13 +33,14 @@ module CustomerV1Auth
           raise AuthorizationError, 'customer_portal_access_profile not exist'
         end
 
-        return auth_context
+        return Result.new(auth_context, payload)
       end
 
       api_access = System::ApiAccess.find_by(id: payload[:sub])
       raise AuthorizationError, 'api_access not exist' if api_access.nil?
 
-      AuthContext.from_api_access(api_access)
+      auth_context = AuthContext.from_api_access(api_access)
+      Result.new(auth_context, payload)
     end
   end
 end

--- a/spec/requests/api/rest/admin/area_prefixes_spec.rb
+++ b/spec/requests/api/rest/admin/area_prefixes_spec.rb
@@ -25,6 +25,31 @@ RSpec.describe Api::Rest::Admin::AreaPrefixesController, type: :request do
   describe 'API Log recording' do
     subject { get json_api_request_path, params: nil, headers: json_api_request_headers }
 
+    it 'creates Log::ApiLog with auth meta and remote IP' do
+      expect { subject }.to change { Log::ApiLog.count }.by(1)
+
+      token_payload = JwtToken.decode(
+        json_api_auth_token,
+        verify_expiration: Authentication::AdminAuth::EXPIRATION_INTERVAL.present?,
+        aud: Authentication::AdminAuth::AUDIENCE
+      )
+      expect(Log::ApiLog.last).to have_attributes(
+        meta: { 'auth' => token_payload.deep_stringify_keys },
+        remote_ip: '127.0.0.1'
+      )
+    end
+
+    context 'when authorization fails' do
+      let(:json_api_auth_token) { 'invalid' }
+
+      it 'does not persist auth meta' do
+        expect { subject }.to change { Log::ApiLog.count }.by(1)
+
+        expect(response.status).to eq(401)
+        expect(Log::ApiLog.last).to have_attributes(meta: nil, remote_ip: '127.0.0.1')
+      end
+    end
+
     context 'when controller contains meta info' do
       before do
         allow_any_instance_of(described_class).to receive(:meta).and_return({ foo: :bar })

--- a/spec/requests/api/rest/admin/customer_tokens_spec.rb
+++ b/spec/requests/api/rest/admin/customer_tokens_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe Api::Rest::Admin::CustomerTokensController, type: :request do
                                      'expires-at': be_present
                                    )
 
-      auth_context = CustomerV1Auth::Authorizer.authorize! data[:attributes][:token]
+      auth_result = CustomerV1Auth::Authorizer.authorize! data[:attributes][:token]
+      auth_context = auth_result.auth_context
       expect(auth_context).to be_a CustomerV1Auth::AuthContext
       expect(auth_context).to have_attributes(
         customer_id: customer.id,
@@ -93,7 +94,8 @@ RSpec.describe Api::Rest::Admin::CustomerTokensController, type: :request do
                                        'expires-at': be_present
                                      )
 
-        auth_context = CustomerV1Auth::Authorizer.authorize! data[:attributes][:token]
+        auth_result = CustomerV1Auth::Authorizer.authorize! data[:attributes][:token]
+        auth_context = auth_result.auth_context
         expect(auth_context).to be_a CustomerV1Auth::AuthContext
         expect(auth_context).to have_attributes(
           customer_id: customer.id,

--- a/spec/requests/api/rest/customer/v1/auth_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/auth_controller_spec.rb
@@ -7,6 +7,23 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
   let!(:api_access) { create :api_access, api_access_attrs }
   let(:customer) { create(:customer) }
   let(:api_access_attrs) { { customer: } }
+  let(:verify_auth_token_expiration) { CustomerV1Auth::Authenticator::EXPIRATION_INTERVAL.present? }
+  let(:decoded_auth_payload) do
+    CustomerV1Auth::TokenBuilder.decode(
+      auth_token,
+      verify_expiration: verify_auth_token_expiration,
+      aud: CustomerV1Auth::Authenticator::AUDIENCE
+    )
+  end
+  let(:expected_auth_meta) { { 'auth' => decoded_auth_payload.deep_stringify_keys } }
+
+  shared_examples :stores_auth_payload_in_api_log_meta do
+    it 'stores auth payload in api log meta' do
+      expect { subject }.to change(Log::ApiLog, :count).by(1)
+
+      expect(Log::ApiLog.last!).to have_attributes(meta: expected_auth_meta)
+    end
+  end
 
   describe 'POST /api/rest/customer/v1/auth' do
     subject do
@@ -38,6 +55,7 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
     let(:json_request_body) { { auth: attributes } }
     let(:remote_ip) { '127.0.0.1' }
     let(:attributes) { { login: api_access.login, password: api_access.password } }
+    let(:auth_token) { response_json.fetch(:jwt) }
 
     context 'when attributes are valid' do
       it 'responds with jwt', freeze_time: true do
@@ -55,6 +73,8 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
                                           exp: CustomerV1Auth::Authenticator::EXPIRATION_INTERVAL.from_now.to_i
                                         )
       end
+
+      include_examples :stores_auth_payload_in_api_log_meta
 
       context 'when expiration interval is blank' do
         before do
@@ -111,6 +131,13 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
       let(:attributes) { super().merge password: 'wrong.password' }
 
       include_examples :responds_with_failed_login
+
+      it 'does not store auth context in api log meta' do
+        expect { subject }.to change(Log::ApiLog, :count).by(1)
+
+        api_log = Log::ApiLog.last!
+        expect(api_log.meta).to be_nil
+      end
 
       context 'with cookie_auth=true' do
         let(:attributes) do
@@ -194,6 +221,7 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
     let(:json_api_auth_token) do
       build_customer_token(api_access.id, expiration: 1.minute.from_now)
     end
+    let(:auth_token) { json_api_auth_token }
 
     it 'responds with 200' do
       subject
@@ -201,10 +229,24 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
       expect(response_json).to match('allow-rec': false)
     end
 
-    it 'should create API Log record' do
+    it 'creates API log record' do
       expect { subject }.to change(Log::ApiLog, :count).by(1)
 
-      expect(Log::ApiLog.last!).to have_attributes(remote_ip: '127.0.0.1')
+      expect(Log::ApiLog.last!).to have_attributes(
+        remote_ip: '127.0.0.1',
+        meta: expected_auth_meta
+      )
+    end
+
+    context 'with invalid Authorization header' do
+      let(:json_api_auth_token) { 'invalid' }
+
+      it 'does not persist auth meta' do
+        expect { subject }.to change(Log::ApiLog, :count).by(1)
+
+        expect(response.status).to eq(401)
+        expect(Log::ApiLog.last!).to have_attributes(meta: nil, remote_ip: '127.0.0.1')
+      end
     end
 
     it_behaves_like :json_api_customer_v1_check_authorization
@@ -218,11 +260,7 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
         expect(response_json).to match('allow-rec': true)
       end
 
-      it 'should create API Log record' do
-        expect { subject }.to change(Log::ApiLog, :count).by(1)
-
-        expect(Log::ApiLog.last!).to have_attributes(remote_ip: '127.0.0.1')
-      end
+      include_examples :stores_auth_payload_in_api_log_meta
     end
 
     context 'with dynamic auth' do
@@ -238,11 +276,7 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
         expect(response_json).to match('allow-rec': false)
       end
 
-      it 'should create API Log record' do
-        expect { subject }.to change(Log::ApiLog, :count).by(1)
-
-        expect(Log::ApiLog.last!).to have_attributes(remote_ip: '127.0.0.1')
-      end
+      include_examples :stores_auth_payload_in_api_log_meta
 
       context 'when customer_portal_access_profile.allow_listen_recording=true' do
         let(:profile_with_recording) { create(:customer_portal_access_profile, allow_listen_recording: true) }
@@ -254,11 +288,7 @@ RSpec.describe Api::Rest::Customer::V1::AuthController, type: :request do
           expect(response_json).to match('allow-rec': true)
         end
 
-        it 'should create API Log record' do
-          expect { subject }.to change(Log::ApiLog, :count).by(1)
-
-          expect(Log::ApiLog.last!).to have_attributes(remote_ip: '127.0.0.1')
-        end
+        include_examples :stores_auth_payload_in_api_log_meta
       end
     end
   end


### PR DESCRIPTION
## Screenshot
<img width="1068" height="478" alt="Screenshot 2026-02-10 at 19 03 41" src="https://github.com/user-attachments/assets/e4fada2f-6b87-4e5c-af35-384c3275b260" />

## Additional links

closes #1900

## Manual check

1. run rails
2. Create customer portal login
3. Make a post request to the auth API
```bash
curl -X POST http://127.0.0.1:3000/api/rest/customer/v1/auth \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'X-Request-Id: manual-auth-meta-1774792238' \
  --data '{"auth":{"login":"manual-login-1774792238","password":"manual-pass-123"}}'

```
4. verify that the Log::ApiLog.last! contains valid meta
```
{"id":12,"status":201,"path":"/api/rest/customer/v1/auth","remote_ip":"127.0.0.1","meta":{"auth":{"aud":["customer-v1"],"exp":1774792848,"sub":2}}}

```