### PR TITLE
improve CI performance by changing test grouping strategy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}
           restore-keys: |
             rspec-runtime-${{ github.head_ref || github.ref_name }}-
             rspec-runtime-master-
@@ -336,7 +336,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}
 
       - name: Save rspec runtime log cache (master)
         if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref == 'refs/heads/master'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,17 +180,57 @@ jobs:
             /opt/yeti-web/vendor/rbenv
           key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('pgq-processors/Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
 
+      - name: Restore rspec runtime log cache
+        id: rspec-runtime-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp/parallel_runtime_rspec.log
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            rspec-runtime-${{ github.head_ref || github.ref_name }}-
+            rspec-runtime-master-
+
+      - name: Configure runtime grouping
+        id: rspec-runtime-config
+        run: |
+          runtime_log="tmp/parallel_runtime_rspec.log"
+          if [ -s "$runtime_log" ]; then
+            echo "Using runtime log at $runtime_log"
+            echo "PARALLEL_GROUP_BY=runtime" >> "$GITHUB_ENV"
+            echo "PARALLEL_RUNTIME_LOG=$runtime_log" >> "$GITHUB_ENV"
+          else
+            echo "Runtime log missing or empty at $runtime_log; running without --group-by."
+          fi
+
       - name: Run rspec
         run: make rspec
         env:
           PARALLEL_TEST_PROCESSORS: ${{ matrix.ci_node_total }}
-          PARALLEL_GROUP_BY: runtime
           TEST_GROUP: ${{ matrix.ci_node_index }}
           YETI_DB_HOST: db
           YETI_DB_PORT: 5432
           CDR_DB_HOST: db
           CDR_DB_PORT: 5432
           CI: true
+
+      - name: Check runtime log for cache
+        if: always()
+        id: rspec-runtime-save
+        run: |
+          runtime_log="tmp/parallel_runtime_rspec.log"
+          if [ -s "$runtime_log" ]; then
+            echo "save=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "save=false" >> "$GITHUB_OUTPUT"
+            echo "Runtime log missing or empty at $runtime_log; skipping cache save."
+          fi
+
+      - name: Save rspec runtime log cache
+        if: always() && steps.rspec-runtime-save.outputs.save == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: tmp/parallel_runtime_rspec.log
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
 
       - name: Save artifacts
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,12 +225,13 @@ jobs:
             echo "Runtime log missing or empty at $runtime_log; skipping cache save."
           fi
 
-      - name: Save rspec runtime log cache
+      - name: Upload rspec runtime log artifact
         if: always() && steps.rspec-runtime-save.outputs.save == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/upload-artifact@v4
         with:
+          name: rspec-runtime-log-${{ matrix.ci_node_index }}
+          if-no-files-found: ignore
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
 
       - name: Save artifacts
         if: always()
@@ -291,6 +292,55 @@ jobs:
           path: |
             tmp/capybara
             coverage
+
+
+  rspec_runtime_cache:
+    name: Save combined rspec runtime log cache
+    runs-on: ubuntu-latest
+    needs: rspec
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download rspec runtime log artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rspec-runtime-log-*
+          path: tmp/runtime_logs
+          merge-multiple: true
+
+      - name: Merge rspec runtime logs
+        id: rspec-runtime-merge
+        run: |
+          mkdir -p tmp
+          runtime_log="tmp/parallel_runtime_rspec.log"
+          if ls tmp/runtime_logs/parallel_runtime_rspec.log >/dev/null 2>&1; then
+            awk -F: '{ if ($2 + 0 > max[$1]) max[$1] = $2 } END { for (f in max) print f ":" max[f] }' \
+              tmp/runtime_logs/parallel_runtime_rspec.log \
+              | sort -t: -k2,2nr > "$runtime_log"
+            if [ -s "$runtime_log" ]; then
+              echo "save=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "save=false" >> "$GITHUB_OUTPUT"
+              echo "Merged runtime log is empty; skipping cache save."
+            fi
+          else
+            echo "save=false" >> "$GITHUB_OUTPUT"
+            echo "No runtime log artifacts found; skipping cache save."
+          fi
+
+      - name: Save rspec runtime log cache (branch)
+        if: steps.rspec-runtime-merge.outputs.save == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: tmp/parallel_runtime_rspec.log
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
+
+      - name: Save rspec runtime log cache (master)
+        if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref_name == 'master'
+        uses: actions/cache/save@v4
+        with:
+          path: tmp/parallel_runtime_rspec.log
+          key: rspec-runtime-master-${{ github.run_id }}
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,15 +180,52 @@ jobs:
             /opt/yeti-web/vendor/rbenv
           key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('pgq-processors/Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
 
-      - name: Restore rspec runtime log cache
-        id: rspec-runtime-cache
-        uses: actions/cache/restore@v4
+      - name: Prepare runtime log directory
+        run: mkdir -p tmp
+
+      - name: Download runtime log artifact
+        id: download-runtime-log
+        uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
-          path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}
-          restore-keys: |
-            rspec-runtime-${{ github.head_ref || github.ref_name }}-
-            rspec-runtime-master-
+          script: |
+            const branch = process.env.BRANCH_NAME || 'unknown';
+            const artifactName = `runtime-log-${branch}`;
+            const artifacts = await github.paginate(github.rest.actions.listArtifactsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const available = artifacts
+              .filter(a => a.name === artifactName && !a.expired)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            if (!available.length) {
+              core.info(`No runtime log artifact found for ${artifactName}`);
+              core.setOutput('found', 'false');
+              return;
+            }
+            const artifact = available[0];
+            const response = await github.request('GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip'
+            });
+            const fs = require('fs');
+            const path = require('path');
+            const zipPath = path.join(process.cwd(), 'tmp', 'runtime_log_download.zip');
+            fs.mkdirSync(path.dirname(zipPath), { recursive: true });
+            fs.writeFileSync(zipPath, Buffer.from(response.data));
+            core.setOutput('found', 'true');
+            core.setOutput('zip-path', zipPath);
+            core.info(`Downloaded runtime artifact ${artifactName} (${artifact.id})`);
+
+      - name: Extract runtime log artifact
+        if: steps.download-runtime-log.outputs.found == 'true'
+        run: |
+          unzip -o "${{ steps.download-runtime-log.outputs.zip-path }}" -d tmp/runtime_log_import
+          mv tmp/runtime_log_import/parallel_runtime_rspec.log tmp/parallel_runtime_rspec.log
 
       - name: Configure runtime grouping
         id: rspec-runtime-config
@@ -319,7 +356,7 @@ jobs:
           mapfile -t runtime_logs < <(find tmp/runtime_logs -name 'parallel_runtime_rspec.log' -type f)
           if [ ${#runtime_logs[@]} -eq 0 ]; then
             echo "save=false" >> "$GITHUB_OUTPUT"
-            echo "No runtime log artifacts found; skipping cache save."
+            echo "No runtime log artifacts found; skipping artifact upload."
             exit 0
           fi
           awk -F: '{ if ($2 + 0 > max[$1]) max[$1] = $2 } END { for (file in max) print file ":" max[file] }' "${runtime_logs[@]}" \
@@ -328,22 +365,16 @@ jobs:
             echo "save=true" >> "$GITHUB_OUTPUT"
           else
             echo "save=false" >> "$GITHUB_OUTPUT"
-            echo "Merged runtime log is empty; skipping cache save."
+            echo "Merged runtime log is empty; skipping artifact upload."
           fi
 
-      - name: Save rspec runtime log cache (branch)
+      - name: Upload merged runtime log artifact
         if: steps.rspec-runtime-merge.outputs.save == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/upload-artifact@v4
         with:
+          name: runtime-log-${{ github.head_ref || github.ref_name }}
+          if-no-files-found: error
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}
-
-      - name: Save rspec runtime log cache (master)
-        if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
-        with:
-          path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-master-${{ github.sha }}
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,6 +298,7 @@ jobs:
     name: Save combined rspec runtime log cache
     runs-on: ubuntu-latest
     needs: rspec
+    if: always()
     steps:
       - uses: actions/checkout@v4
 
@@ -306,26 +307,28 @@ jobs:
         with:
           pattern: rspec-runtime-log-*
           path: tmp/runtime_logs
-          merge-multiple: true
+          if-no-files-found: ignore
+          merge-multiple: false
 
       - name: Merge rspec runtime logs
         id: rspec-runtime-merge
+        shell: bash
         run: |
           mkdir -p tmp
           runtime_log="tmp/parallel_runtime_rspec.log"
-          if ls tmp/runtime_logs/parallel_runtime_rspec.log >/dev/null 2>&1; then
-            awk -F: '{ if ($2 + 0 > max[$1]) max[$1] = $2 } END { for (f in max) print f ":" max[f] }' \
-              tmp/runtime_logs/parallel_runtime_rspec.log \
-              | sort -t: -k2,2nr > "$runtime_log"
-            if [ -s "$runtime_log" ]; then
-              echo "save=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "save=false" >> "$GITHUB_OUTPUT"
-              echo "Merged runtime log is empty; skipping cache save."
-            fi
-          else
+          mapfile -t runtime_logs < <(find tmp/runtime_logs -name 'parallel_runtime_rspec.log' -type f)
+          if [ ${#runtime_logs[@]} -eq 0 ]; then
             echo "save=false" >> "$GITHUB_OUTPUT"
             echo "No runtime log artifacts found; skipping cache save."
+            exit 0
+          fi
+          awk -F: '{ if ($2 + 0 > max[$1]) max[$1] = $2 } END { for (file in max) print file ":" max[file] }' "${runtime_logs[@]}" \
+            | sort -t: -k2,2nr > "$runtime_log"
+          if [ -s "$runtime_log" ]; then
+            echo "save=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "save=false" >> "$GITHUB_OUTPUT"
+            echo "Merged runtime log is empty; skipping cache save."
           fi
 
       - name: Save rspec runtime log cache (branch)
@@ -336,7 +339,7 @@ jobs:
           key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
 
       - name: Save rspec runtime log cache (master)
-        if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref_name == 'master'
+        if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4
         with:
           path: tmp/parallel_runtime_rspec.log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,9 +180,6 @@ jobs:
             /opt/yeti-web/vendor/rbenv
           key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('pgq-processors/Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
 
-      - name: Prepare runtime log directory
-        run: mkdir -p tmp
-
       - name: Download runtime log artifact
         id: download-runtime-log
         uses: actions/github-script@v7
@@ -236,13 +233,13 @@ jobs:
           log_path = target_dir / "parallel_runtime_rspec.log"
           if not log_path.exists():
             raise SystemExit("parallel_runtime_rspec.log not found in artifact")
-          log_path.replace(Path("tmp/parallel_runtime_rspec.log"))
+          log_path.replace(Path("log/parallel_runtime_rspec.log"))
           PY
 
       - name: Configure runtime grouping
         id: rspec-runtime-config
         run: |
-          runtime_log="tmp/parallel_runtime_rspec.log"
+          runtime_log="log/parallel_runtime_rspec.log"
           if [ -s "$runtime_log" ]; then
             echo "Using runtime log at $runtime_log"
             echo "PARALLEL_GROUP_BY=runtime" >> "$GITHUB_ENV"
@@ -266,7 +263,7 @@ jobs:
         if: always()
         id: rspec-runtime-save
         run: |
-          runtime_log="tmp/parallel_runtime_rspec.log"
+          runtime_log="log/parallel_runtime_rspec.log"
           if [ -s "$runtime_log" ]; then
             echo "save=true" >> "$GITHUB_OUTPUT"
           else
@@ -280,7 +277,7 @@ jobs:
         with:
           name: rspec-runtime-log-${{ matrix.ci_node_index }}
           if-no-files-found: ignore
-          path: tmp/parallel_runtime_rspec.log
+          path: log/parallel_runtime_rspec.log
 
       - name: Save artifacts
         if: always()
@@ -364,7 +361,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p tmp
-          runtime_log="tmp/parallel_runtime_rspec.log"
+          runtime_log="log/parallel_runtime_rspec.log"
           mapfile -t runtime_logs < <(find tmp/runtime_logs -name 'parallel_runtime_rspec.log' -type f)
           if [ ${#runtime_logs[@]} -eq 0 ]; then
             echo "save=false" >> "$GITHUB_OUTPUT"
@@ -386,7 +383,7 @@ jobs:
         with:
           name: runtime-log-${{ github.head_ref || github.ref_name }}
           if-no-files-found: error
-          path: tmp/parallel_runtime_rspec.log
+          path: log/parallel_runtime_rspec.log
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,8 +224,20 @@ jobs:
       - name: Extract runtime log artifact
         if: steps.download-runtime-log.outputs.found == 'true'
         run: |
-          unzip -o "${{ steps.download-runtime-log.outputs.zip-path }}" -d tmp/runtime_log_import
-          mv tmp/runtime_log_import/parallel_runtime_rspec.log tmp/parallel_runtime_rspec.log
+          python - <<'PY'
+          import zipfile
+          from pathlib import Path
+
+          zip_path = Path("${{ steps.download-runtime-log.outputs.zip-path }}")
+          target_dir = Path("tmp/runtime_log_import")
+          target_dir.mkdir(parents=True, exist_ok=True)
+          with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(target_dir)
+          log_path = target_dir / "parallel_runtime_rspec.log"
+          if not log_path.exists():
+            raise SystemExit("parallel_runtime_rspec.log not found in artifact")
+          log_path.replace(Path("tmp/parallel_runtime_rspec.log"))
+          PY
 
       - name: Configure runtime grouping
         id: rspec-runtime-config

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
           restore-keys: |
             rspec-runtime-${{ github.head_ref || github.ref_name }}-
             rspec-runtime-master-
@@ -333,14 +333,14 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.run_id }}
+          key: rspec-runtime-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
 
       - name: Save rspec runtime log cache (master)
         if: steps.rspec-runtime-merge.outputs.save == 'true' && github.ref_name == 'master'
         uses: actions/cache/save@v4
         with:
           path: tmp/parallel_runtime_rspec.log
-          key: rspec-runtime-master-${{ github.run_id }}
+          key: rspec-runtime-master-${{ github.sha }}
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Extract runtime log artifact
         if: steps.download-runtime-log.outputs.found == 'true'
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           import zipfile
           from pathlib import Path
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,6 +184,7 @@ jobs:
         run: make rspec
         env:
           PARALLEL_TEST_PROCESSORS: ${{ matrix.ci_node_total }}
+          PARALLEL_GROUP_BY: runtime
           TEST_GROUP: ${{ matrix.ci_node_index }}
           YETI_DB_HOST: db
           YETI_DB_PORT: 5432

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,5 +1,5 @@
 --format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::RuntimeLogger --out log/parallel_runtime_rspec.log
 --format ParallelTests::RSpec::SummaryLogger --out log/spec_summary.log
 --format ParallelTests::RSpec::FailuresLogger --out log/failing_specs.log
 --require spec_helper

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,5 +1,5 @@
 --format progress
---format ParallelTests::RSpec::RuntimeLogger --out log/parallel_runtime_rspec.log
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --format ParallelTests::RSpec::SummaryLogger --out log/spec_summary.log
 --format ParallelTests::RSpec::FailuresLogger --out log/failing_specs.log
 --require spec_helper

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ export PATH := $(RBENV_ROOT)/shims:$(PATH)
 rbenv_version = $(file < .ruby-version)
 
 export no_proxy ?= 127.0.0.1,localhost
-PARALLEL_RUNTIME_LOG ?= tmp/parallel_runtime_rspec.log
+PARALLEL_RUNTIME_LOG ?= log/parallel_runtime_rspec.log
 
 pgq_drop_roles :=	DROP ROLE IF EXISTS pgq_reader; \
 			DROP ROLE IF EXISTS pgq_writer; \

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ else
 	RAILS_ENV=test $(bundle_bin) exec parallel_test \
 		  spec/ \
 		  --type rspec \
+		  $(if $(PARALLEL_GROUP_BY),--group-by $(PARALLEL_GROUP_BY),) \
 		  $(if $(TEST_GROUP),--only-group $(TEST_GROUP),) \
 		  && script/format_runtime_log log/parallel_runtime_rspec.log \
 		  || { script/format_runtime_log log/parallel_runtime_rspec.log; false; }

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ export PATH := $(RBENV_ROOT)/shims:$(PATH)
 rbenv_version = $(file < .ruby-version)
 
 export no_proxy ?= 127.0.0.1,localhost
+PARALLEL_RUNTIME_LOG ?= tmp/parallel_runtime_rspec.log
 
 pgq_drop_roles :=	DROP ROLE IF EXISTS pgq_reader; \
 			DROP ROLE IF EXISTS pgq_writer; \
@@ -215,9 +216,10 @@ else
 		  spec/ \
 		  --type rspec \
 		  $(if $(PARALLEL_GROUP_BY),--group-by $(PARALLEL_GROUP_BY),) \
+		  $(if $(PARALLEL_GROUP_BY),$(if $(PARALLEL_RUNTIME_LOG),--runtime-log $(PARALLEL_RUNTIME_LOG),),) \
 		  $(if $(TEST_GROUP),--only-group $(TEST_GROUP),) \
-		  && script/format_runtime_log log/parallel_runtime_rspec.log \
-		  || { script/format_runtime_log log/parallel_runtime_rspec.log; false; }
+		  && script/format_runtime_log $(PARALLEL_RUNTIME_LOG) \
+		  || { script/format_runtime_log $(PARALLEL_RUNTIME_LOG); false; }
 endif
 
 .PHONY: rspec


### PR DESCRIPTION
## Before

<img width="1110" height="279" alt="Screenshot 2026-02-07 at 15 24 11" src="https://github.com/user-attachments/assets/046d80ed-130d-4cc4-8391-80ccd3e272b6" />

## After

<img width="794" height="271" alt="Screenshot 2026-02-07 at 15 24 48" src="https://github.com/user-attachments/assets/9f7b57bc-c4d6-4b50-947a-80ea441ee372" />

Total time before 18 minutes
Total time after  10 minutes

By changing the strategy of group_by of the [parallel_tests](https://github.com/grosser/parallel_tests) gem algorithm we can save al leate 8 minutes per each push 

in the [parallel_tests](https://github.com/grosser/parallel_tests) there is group-by config that has default value: "filesize" but we can change this to "runtime" to improve grouping algorithm and align specs per GitHub runners

<details>
  <summary>You can try it locally</summary>

#### file content: `log/parallel_runtime_rspec.log` (important because based on this data `runtime` mode works)
```
spec/models/billing/provisioning/phone_systems/route_service_spec.rb:0.5557039999985136
spec/models/billing/provisioning/phone_systems/customer_creation_service_spec.rb:0.15226900001289323
spec/models/billing/provisioning/phone_systems/gateway_service_spec.rb:0.07250499998917803
spec/models/billing/provisioning/phone_systems/incoming_trunk_service_spec.rb:0.07038400002056733
spec/models/billing/provisioning/phone_systems_spec.rb:1.0577889999840409

```
- we can see that the `phone_systems_spec.rb` spec have the largest execution time (1.05min) recorded from previous rspec run. Then paralle_tasks deside to run this spec in the separate process and other Four spec in different process


```
PARALLEL_TEST_PROCESSORS=2 RAILS_ENV=test rbenv exec bundle exec parallel_test spec/models/billing/provisioning --type rspec --runtime-log tmp/
  parallel_runtime_rspec.log --group-by runtime -o '--no-profile --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log'
```
</details>

In future we can optimize the performance of spec/features/system/network_prefixes/index_network_prefix_spec.rb spec that have execution time 9 minutes. this spec in our new `runtime` strategy have the separate runner (RSpec (8.1)) once we will fix this then the all runners will be aligned properly.

### Investigating
In the internet I found the [project](https://knapsackpro.com/) that do almost the same job by introducing the separate gem into project but in this situation it is no nedded.