### PR TITLE
bump activeadmin and device gems to fix vulnerability [no issue]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,8 +151,8 @@ GEM
       activerecord-import (>= 0.27)
       rchardet (>= 1.6)
       rubyzip (>= 1.2)
-    active_admin_scoped_collection_actions (1.0.1)
-      activeadmin (>= 1.1, < 4.0)
+    active_admin_scoped_collection_actions (2.0.0)
+      activeadmin (>= 3.0, < 4.0)
     active_admin_sidebar (1.1.0)
       activeadmin
     active_admin_theme (1.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     active_record_extended (3.3.0)
       activerecord (>= 5.2, < 8.0.0)
       pg (< 3.0)
-    activeadmin (3.2.2)
+    activeadmin (3.5.1)
       arbre (~> 1.2, >= 1.2.1)
       csv
       formtastic (>= 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,10 +316,10 @@ GEM
     delayed_job_active_record (4.1.11)
       activerecord (>= 3.0, < 9.0)
       delayed_job (>= 3.0, < 5)
-    devise (4.9.4)
+    devise (5.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -113,11 +113,9 @@ RSpec.describe 'the sign in process', js: true do
 
     it 'create session and then after 61 seconds of inactivity session should be removed' do
       expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
-      visit new_admin_user_session_path
-      fill_form!
-      click_button 'Login'
+      login_as admin_user, scope: :admin_user
+      visit root_path
       expect(page).to have_current_path root_path
-      expect(page).to have_flash_message 'Signed in successfully.', type: :notice
       travel_to((YetiConfig.admin_ui.session_lifetime + 1).seconds.from_now) do
         visit root_path
         expect(page).to have_current_path new_admin_user_session_path
@@ -127,9 +125,8 @@ RSpec.describe 'the sign in process', js: true do
 
     it 'after 55 seconds of inactivity session stilla alive' do
       expect(YetiConfig.admin_ui.session_lifetime).to eq(60), error_message
-      visit new_admin_user_session_path
-      fill_form!
-      click_button 'Login'
+      login_as admin_user, scope: :admin_user
+      visit root_path
       expect(page).to have_current_path root_path
       travel_to(55.seconds.from_now) do
         visit root_path

--- a/spec/features/sign_in_feature_spec.rb
+++ b/spec/features/sign_in_feature_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'the sign in process', js: true do
       fill_in 'Password', with: admin_user_attrs[:password]
     end
 
-    include_examples :does_not_sign_in, 'Invalid Username or password.'
+    include_examples :does_not_sign_in, 'Invalid username or password.'
   end
 
   context 'when allowed_ips are filled with not match ip' do
@@ -86,7 +86,7 @@ RSpec.describe 'the sign in process', js: true do
       visit new_admin_user_session_path
     end
 
-    it 'should render dashboard page without any content' do
+    it 'should render dashboard page without any content', :js do
       fill_form!
       click_button 'Login'
       expect(page).to have_selector('small', text: 'You have limited access to dashboard content.')


### PR DESCRIPTION
## Description

So the main goal for this PR is to fix the devise vulnerability, but when we update this gem, we have a second problem. ActiveAdmin depends on old Devise. Therefore, we update both gems. The current PR has a high risk of creating regression because Devise has changed its major version.

## Related commits that should be merged first of all.

https://github.com/activeadmin-plugins/active_admin_scoped_collection_actions/pull/53

- **Bump devise from v4.9.4 to v5.0.3** 🚨 (major version changed, here is [a link](https://github.com/heartcombo/devise/compare/v4.9.4...v5.0.3) to compare/review changes)
- **Bump activeadmin from v3.2.2 to 3.5.1**

## Additional links

https://github.com/yeti-switch/yeti-web/security/dependabot/130

