### PR TITLE
#1875, Add NumberlistItem batch operation

### DIFF
--- a/app/admin/routing/numberlist_items.rb
+++ b/app/admin/routing/numberlist_items.rb
@@ -10,6 +10,9 @@ ActiveAdmin.register Routing::NumberlistItem do
   acts_as_audit
   acts_as_clone
   acts_as_safe_destroy
+  acts_as_async_destroy('Routing::NumberlistItem')
+  acts_as_async_update BatchUpdateForm::NumberlistItem
+  acts_as_delayed_job_lock
 
   acts_as_export :id,
                  :key,

--- a/app/forms/batch_update_form/numberlist_item.rb
+++ b/app/forms/batch_update_form/numberlist_item.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class BatchUpdateForm::NumberlistItem < BatchUpdateForm::Base
+  model_class 'Routing::NumberlistItem'
+
+  attribute :number_min_length
+  attribute :number_max_length
+  attribute :action_id, type: :integer_collection, collection: Routing::NumberlistItem::ACTIONS.invert.to_a
+  attribute :src_rewrite_rule
+  attribute :src_rewrite_result
+  attribute :defer_src_rewrite, type: :boolean
+  attribute :dst_rewrite_rule
+  attribute :dst_rewrite_result
+  attribute :defer_dst_rewrite, type: :boolean
+  attribute :tag_action_id, type: :foreign_key, class_name: 'Routing::TagAction'
+  attribute :tag_action_value, type: :integer_collection, collection: proc { Routing::RoutingTag.order(:name).pluck(:name, :id) }
+  attribute :rewrite_ss_status_id, type: :integer_collection, collection: Equipment::StirShaken::Attestation::ATTESTATIONS.invert.to_a
+  attribute :lua_script_id, type: :foreign_key, class_name: 'System::LuaScript'
+  attribute :variables_json
+
+  validates :number_min_length, numericality: {
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 100,
+    allow_nil: false,
+    only_integer: true,
+    allow_blank: true
+  }, if: :number_min_length_changed?
+
+  validates :number_max_length, numericality: {
+    greater_than_or_equal_to: 0,
+    less_than_or_equal_to: 100,
+    allow_nil: false,
+    only_integer: true,
+    allow_blank: true
+  }, if: :number_max_length_changed?
+
+  validates :action_id, inclusion: { in: Routing::NumberlistItem::ACTIONS.keys.map(&:to_s) }, if: :action_id_changed?
+  validates :rewrite_ss_status_id, inclusion: { in: Equipment::StirShaken::Attestation::ATTESTATIONS.keys.map(&:to_s) }, if: :rewrite_ss_status_id_changed?
+end

--- a/spec/features/routing/numberlist_items/batch_update_spec.rb
+++ b/spec/features/routing/numberlist_items/batch_update_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe BatchUpdateForm::NumberlistItem, :js do
+  include_context :login_as_admin
+
+  let!(:_numberlist_items) { create_list :numberlist_item, 3 }
+  let(:success_message) { I18n.t('flash.actions.batch_actions.batch_update.job_scheduled') }
+  let!(:lua_script) { create :lua_script }
+
+  before do
+    visit routing_numberlist_items_path
+    click_button 'Update batch'
+    expect(page).to have_selector('.ui-dialog')
+  end
+
+  let(:assign_params) do
+    {
+      number_min_length: '3',
+      number_max_length: '12',
+      action_id: Routing::NumberlistItem::ACTION_ACCEPT.to_s,
+      src_rewrite_rule: '^100',
+      src_rewrite_result: '200',
+      defer_src_rewrite: 'true',
+      dst_rewrite_rule: '^300',
+      dst_rewrite_result: '400',
+      defer_dst_rewrite: 'false',
+      lua_script_id: lua_script.id.to_s
+    }
+  end
+
+  subject do
+    fill_batch_form
+    click_button 'OK'
+  end
+
+  let(:fill_batch_form) do
+    if assign_params.key? :number_min_length
+      check :Number_min_length
+      fill_in :number_min_length, with: assign_params[:number_min_length]
+    end
+
+    if assign_params.key? :number_max_length
+      check :Number_max_length
+      fill_in :number_max_length, with: assign_params[:number_max_length]
+    end
+
+    if assign_params.key? :action_id
+      check :Action_id
+      select_by_value assign_params[:action_id], from: :action_id
+    end
+
+    if assign_params.key? :src_rewrite_rule
+      check :Src_rewrite_rule
+      fill_in :src_rewrite_rule, with: assign_params[:src_rewrite_rule]
+    end
+
+    if assign_params.key? :src_rewrite_result
+      check :Src_rewrite_result
+      fill_in :src_rewrite_result, with: assign_params[:src_rewrite_result]
+    end
+
+    if assign_params.key? :defer_src_rewrite
+      check :Defer_src_rewrite
+      select_by_value assign_params[:defer_src_rewrite], from: :defer_src_rewrite
+    end
+
+    if assign_params.key? :dst_rewrite_rule
+      check :Dst_rewrite_rule
+      fill_in :dst_rewrite_rule, with: assign_params[:dst_rewrite_rule]
+    end
+
+    if assign_params.key? :dst_rewrite_result
+      check :Dst_rewrite_result
+      fill_in :dst_rewrite_result, with: assign_params[:dst_rewrite_result]
+    end
+
+    if assign_params.key? :defer_dst_rewrite
+      check :Defer_dst_rewrite
+      select_by_value assign_params[:defer_dst_rewrite], from: :defer_dst_rewrite
+    end
+
+    if assign_params.key? :lua_script_id
+      check :Lua_script_id
+      select_by_value assign_params[:lua_script_id], from: :lua_script_id
+    end
+  end
+
+  context 'when all fields filled with valid values' do
+    it 'schedules async batch update job' do
+      expect do
+        subject
+        expect(page).to have_selector '.flash', text: success_message
+      end.to have_enqueued_job(AsyncBatchUpdateJob).on_queue('batch_actions').with 'Routing::NumberlistItem', be_present, assign_params, be_present
+    end
+  end
+end

--- a/spec/models/batch_update_form/numberlist_item_spec.rb
+++ b/spec/models/batch_update_form/numberlist_item_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe BatchUpdateForm::NumberlistItem do
+  let!(:lua_script) { create :lua_script }
+  let!(:tag_action) { create :tag_action }
+  let!(:routing_tag) { create :routing_tag }
+
+  let(:assign_params) do
+    {
+      number_min_length: '4',
+      number_max_length: '10',
+      action_id: Routing::NumberlistItem::ACTION_ACCEPT.to_s,
+      src_rewrite_rule: '^123',
+      src_rewrite_result: '456',
+      defer_src_rewrite: '1',
+      dst_rewrite_rule: '^321',
+      dst_rewrite_result: '654',
+      defer_dst_rewrite: '0',
+      tag_action_id: tag_action.id.to_s,
+      tag_action_value: routing_tag.id.to_s,
+      rewrite_ss_status_id: Equipment::StirShaken::Attestation::ATTESTATION_B.to_s,
+      lua_script_id: lua_script.id.to_s,
+      variables_json: '{"foo":"bar"}'
+    }
+  end
+
+  subject do
+    form = described_class.new(assign_params)
+    form.valid?
+    form
+  end
+
+  it { is_expected.to be_valid }
+end


### PR DESCRIPTION
## Description

Introduce BatchUpdateForm::NumberlistItem, add async update/destroy
and delayed lock to admin, handle proc-backed integer collections
in Base, and add related feature and model specs.

## Additional links
closes #1875
