### PR TITLE
Preserve admin API authentication in OIDC mode

### DIFF
--- a/app/models/concerns/admin_user_oidc_handler.rb
+++ b/app/models/concerns/admin_user_oidc_handler.rb
@@ -15,8 +15,10 @@ module AdminUserOidcHandler
     # which would shadow a method defined earlier in the ancestor chain.
     define_method(:valid_password?) { |_password| false }
 
-    # REST API auth calls admin_user.authenticate(password) — alias it
-    # so it returns false instead of raising NoMethodError.
-    alias_method :authenticate, :valid_password?
+    # Keep web password sign-in disabled while preserving the legacy
+    # password-backed admin JWT API authentication path.
+    define_method(:authenticate) do |password|
+      Devise::Encryptor.compare(self.class, encrypted_password, password)
+    end
   end
 end

--- a/spec/models/concerns/admin_user_oidc_handler_spec.rb
+++ b/spec/models/concerns/admin_user_oidc_handler_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe AdminUserOidcHandler do
     end
   end
 
+  describe '#authenticate' do
+    it 'checks the encrypted password for API auth callers' do
+      user = DummyOidcUser.new(username: 'alice')
+      user.password = 'Password123!'
+
+      expect(user.authenticate('Password123!')).to be(true)
+      expect(user.authenticate('wrong-password')).to be(false)
+    end
+  end
+
   describe 'oidc_raw_info serialization' do
     it 'round-trips a hash through JSON' do
       user = DummyOidcUser.new(username: 'alice')

--- a/spec/requests/api/rest/admin/auth_controller_spec.rb
+++ b/spec/requests/api/rest/admin/auth_controller_spec.rb
@@ -82,6 +82,29 @@ RSpec.describe Api::Rest::Admin::AuthController, type: :request do
           expect(response_json).to match(jwt: a_kind_of(String))
         end
       end
+
+      context 'oidc' do
+        let!(:oidc_admin) do
+          create(:admin_user, username: 'oidc-admin', password: 'password')
+        end
+
+        let(:attributes) do
+          {
+            username: oidc_admin.username,
+            password: 'password'
+          }
+        end
+
+        before do
+          allow(AdminUser).to receive(:oidc?).and_return(true)
+        end
+
+        it 'responds successfully' do
+          subject
+          expect(response.status).to eq(201)
+          expect(response_json).to match(jwt: a_kind_of(String))
+        end
+      end
     end
 
     context 'when attributes are invalid' do


### PR DESCRIPTION
## Description

When config/oidc.yml is present, AdminUser#authenticate is aliased to valid_password?, which now unconditionally returns false. Authentication::AdminAuth.authenticate! still calls admin_user.authenticate(@password) for POST /api/rest/admin/auth, so every admin API login starts failing as soon as OIDC is enabled, even for existing users with allowed IPs. That is a user-visible regression for any integration that relies on the documented admin JWT endpoint.
