### PR TITLE
Add regression test: admin API auth in OIDC mode

### DIFF
--- a/app/models/concerns/admin_user_oidc_handler.rb
+++ b/app/models/concerns/admin_user_oidc_handler.rb
@@ -15,8 +15,10 @@ module AdminUserOidcHandler
     # which would shadow a method defined earlier in the ancestor chain.
     define_method(:valid_password?) { |_password| false }
 
-    # REST API auth calls admin_user.authenticate(password) — alias it
-    # so it returns false instead of raising NoMethodError.
-    alias_method :authenticate, :valid_password?
+    # Keep web password sign-in disabled while preserving the legacy
+    # password-backed admin JWT API authentication path.
+    define_method(:authenticate) do |password|
+      Devise::Encryptor.compare(self.class, encrypted_password, password)
+    end
   end
 end

--- a/spec/models/concerns/admin_user_oidc_handler_spec.rb
+++ b/spec/models/concerns/admin_user_oidc_handler_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe AdminUserOidcHandler do
     end
   end
 
+  describe '#authenticate' do
+    it 'checks the encrypted password for API auth callers' do
+      user = DummyOidcUser.new(username: 'alice')
+      user.password = 'Password123!'
+
+      expect(user.authenticate('Password123!')).to be(true)
+      expect(user.authenticate('wrong-password')).to be(false)
+    end
+  end
+
   describe 'oidc_raw_info serialization' do
     it 'round-trips a hash through JSON' do
       user = DummyOidcUser.new(username: 'alice')

--- a/spec/requests/api/rest/admin/auth_controller_spec.rb
+++ b/spec/requests/api/rest/admin/auth_controller_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe Api::Rest::Admin::AuthController, type: :request do
           expect(response_json).to match(jwt: a_kind_of(String))
         end
       end
+
+      context 'oidc mode', oidc_mode: true do
+        it 'still authenticates via password' do
+          subject
+          expect(response.status).to eq(201)
+          expect(response_json).to match(jwt: a_kind_of(String))
+        end
+      end
+
+      context 'ldap mode', :ldap do
+        it 'still authenticates via password' do
+          subject
+          expect(response.status).to eq(201)
+          expect(response_json).to match(jwt: a_kind_of(String))
+        end
+      end
     end
 
     context 'when attributes are invalid' do

--- a/spec/requests/api/rest/admin/auth_controller_spec.rb
+++ b/spec/requests/api/rest/admin/auth_controller_spec.rb
@@ -82,6 +82,29 @@ RSpec.describe Api::Rest::Admin::AuthController, type: :request do
           expect(response_json).to match(jwt: a_kind_of(String))
         end
       end
+
+      context 'oidc' do
+        let!(:oidc_admin) do
+          create(:admin_user, username: 'oidc-admin', password: 'password')
+        end
+
+        let(:attributes) do
+          {
+            username: oidc_admin.username,
+            password: 'password'
+          }
+        end
+
+        before do
+          allow(AdminUser).to receive(:oidc?).and_return(true)
+        end
+
+        it 'responds successfully' do
+          subject
+          expect(response.status).to eq(201)
+          expect(response_json).to match(jwt: a_kind_of(String))
+        end
+      end
     end
 
     context 'when attributes are invalid' do


### PR DESCRIPTION
## Summary
- Adds an `oidc_mode: true` tagged test to `auth_controller_spec.rb` that verifies `POST /api/rest/admin/auth` still returns a JWT when the OIDC handler is loaded.
- **Expected to fail** on this branch — `AdminUserOidcHandler` aliases `authenticate` to `valid_password?` which always returns false.
- Will be fixed by merging #1981 into this branch.

## Test plan
- [x] CI `rspec_oidc` job should show the new test failing
- [x] After merging #1981, the test should pass