### PR TITLE
Restore Sentry event delivery after sentry-ruby 6 upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :development, :test do
   gem 'bullet'
   gem 'byebug'
 
-  gem 'brakeman'
+  gem 'brakeman', require: false
   gem 'bundler-audit', require: false
   gem 'factory_bot_rails'
   gem 'parallel_tests'

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,6 +4,6 @@
 # but only run the full configuration when sentry is enabled and not in a Rake task.
 require 'sentry-ruby'
 
-if CaptureError.enabled? && !defined?(::Rake)
+if CaptureError.enabled? && !CaptureError.rake_task_invocation?
   CaptureError.configure!
 end

--- a/lib/capture_error.rb
+++ b/lib/capture_error.rb
@@ -14,6 +14,19 @@ module CaptureError
       YetiConfig.sentry.enabled
     end
 
+    # Checks whether the current process is executing a Rake task.
+    #
+    # `defined?(::Rake)` is unreliable here: `Rake` is an ordinary Ruby constant
+    # and gets loaded into long-running processes (puma, delayed_job, schedulers)
+    # transitively via `Bundler.require`. `Rake.application.top_level_tasks` is
+    # only populated when Rake is actually executing tasks.
+    # @return [TrueClass,FalseClass]
+    def rake_task_invocation?
+      return false unless defined?(::Rake)
+
+      ::Rake.application.top_level_tasks.any?
+    end
+
     # Configures Sentry gem.
     # Use only once in initializer.
     def configure!
@@ -32,14 +45,7 @@ module CaptureError
         sentry_config.inspect_exception_causes_for_exclusion = false
 
         # use Rails' parameter filter to sanitize the event
-        filters = [
-          ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters),
-          ActiveSupport::ParameterFilter.new(['Authorization'])
-        ]
-        sentry_config.before_send = lambda { |event, _hint = nil|
-          filters.each { |filter| event = filter.filter(event.to_hash) }
-          event
-        }
+        sentry_config.before_send = build_before_send
 
         # Usage of an async option is discouraged by sentry-ruby developers.
         # By default sentry will create its own background workers to send sentry events.
@@ -169,6 +175,40 @@ module CaptureError
     end
 
     private
+
+    # Builds the `before_send` lambda that sanitizes events using Rails'
+    # configured `filter_parameters` plus an explicit `Authorization` filter.
+    #
+    # Sentry-ruby 6 requires `before_send` to return a `Sentry::ErrorEvent`
+    # (events that come back as `Hash` are dropped by `Sentry::Client#send_event`
+    # with `Discarded event because before_send didn't return a Sentry::ErrorEvent`).
+    # We therefore mutate the event in place via its public setters and return
+    # the event itself.
+    # @return [Proc]
+    def build_before_send
+      filters = [
+        ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters),
+        ActiveSupport::ParameterFilter.new(['Authorization'])
+      ]
+      lambda do |event, _hint = nil|
+        filters.each { |filter| filter_event!(event, filter) }
+        event
+      end
+    end
+
+    def filter_event!(event, filter)
+      event.user     = filter.filter(event.user)     if event.user.is_a?(Hash)
+      event.extra    = filter.filter(event.extra)    if event.extra.is_a?(Hash)
+      event.tags     = filter.filter(event.tags)     if event.tags.is_a?(Hash)
+      event.contexts = filter.filter(event.contexts) if event.contexts.is_a?(Hash)
+
+      return unless event.request
+
+      request = event.request
+      request.data    = filter.filter(request.data)    if request.data.is_a?(Hash)
+      request.headers = filter.filter(request.headers) if request.headers.is_a?(Hash)
+      request.env     = filter.filter(request.env)     if request.env.is_a?(Hash)
+    end
 
     def with_capture_context(context, exception: nil)
       Sentry.with_scope do |scope|

--- a/spec/lib/capture_error_spec.rb
+++ b/spec/lib/capture_error_spec.rb
@@ -1,6 +1,99 @@
 # frozen_string_literal: true
 
 RSpec.describe CaptureError do
+  describe '.rake_task_invocation?' do
+    subject { described_class.rake_task_invocation? }
+
+    context 'when Rake is not loaded' do
+      before { hide_const('Rake') }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when Rake is loaded but no top-level tasks (puma, scheduler, console)' do
+      before do
+        allow(Rake.application).to receive(:top_level_tasks).and_return([])
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context 'when Rake is executing a top-level task' do
+      before do
+        allow(Rake.application).to receive(:top_level_tasks).and_return(['db:migrate'])
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#build_before_send (private)' do
+    subject(:before_send) { described_class.send(:build_before_send) }
+
+    let(:configuration) do
+      config = Sentry::Configuration.new
+      config.dsn = 'http://public@example.invalid/1'
+      config
+    end
+    let(:event) { Sentry::ErrorEvent.new(configuration: configuration) }
+
+    before do
+      allow(Rails.application.config).to receive(:filter_parameters).and_return([:password])
+    end
+
+    it 'should return the same Sentry::ErrorEvent object (not a Hash)' do
+      result = before_send.call(event)
+      expect(result).to be(event)
+      expect(result).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'should mask filter_parameters keys in event.extra and keep other keys' do
+      event.extra = { password: 'secret', visible: 'ok' }
+      result = before_send.call(event)
+      expect(result.extra).to eq(password: '[FILTERED]', visible: 'ok')
+    end
+
+    it 'should mask Authorization in event.tags' do
+      event.tags = { 'Authorization' => 'Bearer abc', 'probe' => 'on' }
+      result = before_send.call(event)
+      expect(result.tags).to eq('Authorization' => '[FILTERED]', 'probe' => 'on')
+    end
+
+    it 'should mask filter_parameters keys in event.user and event.contexts' do
+      event.user = { id: 1, password: 'pw' }
+      event.contexts = { extra_ctx: { password: 'pw2', note: 'visible' } }
+      result = before_send.call(event)
+      expect(result.user).to eq(id: 1, password: '[FILTERED]')
+      expect(result.contexts).to eq(extra_ctx: { password: '[FILTERED]', note: 'visible' })
+    end
+
+    it 'should mask filter_parameters keys and Authorization in event.request fields' do
+      request = Sentry::RequestInterface.allocate
+      request.data = { password: 'pw', visible: 'ok' }
+      request.headers = { 'Authorization' => 'Bearer xyz', 'X-Trace' => 't1' }
+      request.env = { 'HTTP_AUTHORIZATION' => 'Bearer xyz', 'REMOTE_ADDR' => '127.0.0.1' }
+      event.instance_variable_set(:@request, request)
+
+      result = before_send.call(event)
+      expect(result.request.data).to eq(password: '[FILTERED]', visible: 'ok')
+      expect(result.request.headers).to eq('Authorization' => '[FILTERED]', 'X-Trace' => 't1')
+      expect(result.request.env).to eq('HTTP_AUTHORIZATION' => '[FILTERED]', 'REMOTE_ADDR' => '127.0.0.1')
+    end
+
+    it 'should not raise when event.request is nil' do
+      event.extra = { password: 'pw' }
+      expect { before_send.call(event) }.not_to raise_error
+    end
+
+    it 'should not raise when event fields are nil' do
+      event.extra = nil
+      event.tags = nil
+      event.user = nil
+      event.contexts = nil
+      expect { before_send.call(event) }.not_to raise_error
+    end
+  end
+
   describe '.with_clean_context' do
     subject do
       described_class.with_clean_context(context) { block_result }


### PR DESCRIPTION
## Summary

Two independent regressions introduced after the `sentry-ruby` 6 upgrade together silence **all** Sentry delivery from `puma`, `delayed_job`, `scheduler` and `cdr_processor`. This PR fixes both. Background: see #1989.

### Bug #1 — `!defined?(::Rake)` guard is unreliable in long-running processes

`Rake` is a normal Ruby constant. Default-group gems pull it transitively via `Bundler.require`, so by the time `config/initializers/sentry.rb` runs `defined?(::Rake)` is already `true` in `puma`, `delayed_job`, etc. — `CaptureError.configure!` is therefore never called and `Sentry.initialized?` stays `false` in production.

**Fix:** detect "we are actually executing a Rake task" instead. `Rake.application.top_level_tasks` is only populated while Rake is running tasks; in long-running processes it stays empty even after `rake` is loaded.

```ruby
# config/initializers/sentry.rb
if CaptureError.enabled? && !CaptureError.rake_task_invocation?
  CaptureError.configure!
end

# lib/capture_error.rb
def rake_task_invocation?
  return false unless defined?(::Rake)

  ::Rake.application.top_level_tasks.any?
end
```

### Bug #2 — `before_send` is incompatible with `sentry-ruby` 6

The previous lambda called `event.to_hash` (removed in `sentry-ruby` 6) and returned a `Hash`. In `sentry-ruby` 6 `Sentry::Client#send_event` is strict:

```ruby
# sentry-ruby-6.4.1 lib/sentry/client.rb:243-253
if event.is_a?(ErrorEvent) && configuration.before_send
  event = configuration.before_send.call(event, hint)

  if !event.is_a?(ErrorEvent)
    log_debug("Discarded event because before_send didn't return a Sentry::ErrorEvent object…")
    transport.record_lost_event(:before_send, data_category)
    return
  end
end
```

Either path silently drops the event: `NoMethodError` from `to_hash` is rescued by the SDK and logged as `Event capturing failed`; even if `to_hash` is replaced with `to_h` the lambda still returns a `Hash` and is dropped with `Discarded event because before_send didn't return…`.

**Fix:** mutate the event in place using the setters `Sentry::Event` already exposes (`event.user=`, `event.extra=`, `event.tags=`, `event.contexts=`, plus the `RequestInterface` accessors), and return the event. Same `filter_parameters` + `Authorization` filtering as before — public contract unchanged.

```ruby
# lib/capture_error.rb (private)
def build_before_send
  filters = [
    ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters),
    ActiveSupport::ParameterFilter.new(['Authorization'])
  ]
  lambda do |event, _hint = nil|
    filters.each { |filter| filter_event!(event, filter) }
    event
  end
end

def filter_event!(event, filter)
  event.user     = filter.filter(event.user)     if event.user.is_a?(Hash)
  event.extra    = filter.filter(event.extra)    if event.extra.is_a?(Hash)
  event.tags     = filter.filter(event.tags)     if event.tags.is_a?(Hash)
  event.contexts = filter.filter(event.contexts) if event.contexts.is_a?(Hash)

  return unless event.request

  request = event.request
  request.data    = filter.filter(request.data)    if request.data.is_a?(Hash)
  request.headers = filter.filter(request.headers) if request.headers.is_a?(Hash)
  request.env     = filter.filter(request.env)     if request.env.is_a?(Hash)
end
```

### Hardening — `gem 'brakeman', require: false`

`brakeman` is a CLI; it doesn't need to be `require`d into the running app. Adding `require: false` matches `bundler-audit` and `rubocop` next to it and removes one implicit way for `Rake` to leak into unrelated processes.

## Test plan

New unit specs in `spec/lib/capture_error_spec.rb` cover:

- `CaptureError.rake_task_invocation?`
  - returns `false` when `Rake` is not loaded
  - returns `false` when `Rake` is loaded but `top_level_tasks` is empty (puma / scheduler / console)
  - returns `true` when `Rake.application.top_level_tasks` contains a task
- `before_send` (built via the private `build_before_send`)
  - returns the same `Sentry::ErrorEvent` instance (not a `Hash`)
  - masks `Rails.application.config.filter_parameters` keys in `event.extra`, `event.user`, `event.contexts`
  - masks `Authorization` in `event.tags`, `event.request.headers`, `event.request.env`
  - leaves non-secret keys untouched
  - does not raise when `event.request` is `nil`
  - does not raise when `event.extra/user/tags/contexts` are `nil`

```
$ bundle exec rspec spec/lib/capture_error_spec.rb
14 examples, 0 failures

$ bundle exec rubocop lib/capture_error.rb config/initializers/sentry.rb \
                     spec/lib/capture_error_spec.rb Gemfile
4 files inspected, no offenses detected
```

End-to-end verification on a Rails 7.2 / Ruby 3.4 / sentry-ruby 6.4.1 deployment after applying this fix:

- `Sentry.initialized?` → `true` in `puma` / `delayed_job` / `scheduler` / `cdr_processor`.
- `Sentry.capture_message('ping')` and `Sentry.capture_exception(e)` both deliver to the configured DSN.
- For `event.extra = { token: 'secret', visible: 'ok' }`, the resulting Sentry event shows `token: "[FILTERED]"`, `visible: "ok"`, with `_meta.context == nil` (i.e. masking happened client-side, not via Sentry's server-side scrubber — uppercase `[FILTERED]` is the `ActiveSupport::ParameterFilter` default).

## Compatibility

No changes to public APIs of `CaptureError.{capture, capture_message, with_clean_context, with_exception_context, store_exception_context, retrieve_exception_context, log_error}`. Behaviour difference is purely the bug fixes above.

Closes #1989
