### PR TITLE
Fix write_rtp_statistics_spec.rb

### DIFF
--- a/spec/sql/switch/write_rtp_statistics_spec.rb
+++ b/spec/sql/switch/write_rtp_statistics_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'switch.write_rtp_statistics()' do
   let(:pop_id) { 1 }
   let(:node_id) { 2 }
   # Passed by writecdr as the CDR time_start; stream rows store it in time_start.
-  let(:cdr_time_start) { Time.utc(2026, 5, 16, 12, 0, 0) }
+  let(:cdr_time_start) { Time.current.change(hour: 12) }
 
   let(:data) do
     [


### PR DESCRIPTION
```
$ bundle exec rspec spec/sql/switch/write_rtp_statistics_spec.rb:238
App Timezone UTC
Yeti DB timezone UTC
CDR DB timezone UTC
ActiveRecord timezone utc
Run options:
  include {focus: true, locations: {"./spec/sql/switch/write_rtp_statistics_spec.rb" => [238]}}
  exclude {oidc_mode: true}
F

Failures:

  1) switch.write_rtp_statistics() Known tags creates TX streams with known tags
     Failure/Error:
       SqlCaller::Cdr.execute("SELECT switch.write_rtp_statistics(
         '#{data}'::json,
         #{pop_id},
         #{node_id},
         #{lega_gateway_id},
         #{lega_gateway_external_id},
         #{legb_gateway_id},
         #{legb_gateway_external_id},
         '#{lega_local_tag}',
         '#{legb_local_tag}',

     ActiveRecord::StatementInvalid:
       PG::CheckViolation: ERROR:  no partition of relation "tx_streams" found for row
       DETAIL:  Partition key of the failing row contains (time_start) = (2026-05-16 12:00:00+00).
       CONTEXT:  SQL statement "INSERT INTO rtp_statistics.tx_streams VALUES(v_rtp_tx_stream_data.*)"
       PL/pgSQL function switch.write_rtp_statistics(json,integer,integer,bigint,bigint,bigint,bigint,character varying,character varying,timestamp with time zone) line 59 at SQL statement
     # ./spec/sql/switch/write_rtp_statistics_spec.rb:5:in 'block (2 levels) in <main>'
     # ./spec/sql/switch/write_rtp_statistics_spec.rb:239:in 'block (4 levels) in <main>'
     # ./spec/sql/switch/write_rtp_statistics_spec.rb:239:in 'block (3 levels) in <main>'
     # ------------------
     # --- Caused by: ---
     # PG::CheckViolation:
     #   ERROR:  no partition of relation "tx_streams" found for row
     #   DETAIL:  Partition key of the failing row contains (time_start) = (2026-05-16 12:00:00+00).
     #   CONTEXT:  SQL statement "INSERT INTO rtp_statistics.tx_streams VALUES(v_rtp_tx_stream_data.*)"
     #   PL/pgSQL function switch.write_rtp_statistics(json,integer,integer,bigint,bigint,bigint,bigint,character varying,character varying,timestamp with time zone) line 59 at SQL statement
     #   ./spec/sql/switch/write_rtp_statistics_spec.rb:5:in 'block (2 levels) in <main>'

Top 1 slowest examples (0.0781 seconds, 59.8% of total time):
  switch.write_rtp_statistics() Known tags creates TX streams with known tags
    0.0781 seconds ./spec/sql/switch/write_rtp_statistics_spec.rb:238

Finished in 0.13054 seconds (files took 1.3 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/sql/switch/write_rtp_statistics_spec.rb:238 # switch.write_rtp_statistics() Known tags creates TX streams with known tags
```