### PR TITLE
fix flaky tests

### DIFF
--- a/spec/features/rate_management/project/create_spec.rb
+++ b/spec/features/rate_management/project/create_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
     let(:fill_form!) do
       fill_in 'Name', with: new_attrs[:name]
       fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-      fill_in_tom_select 'Account', with: new_attrs[:account].name
+      fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
       fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
       fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
       fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name
@@ -63,7 +63,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
       let(:fill_form!) do
         fill_in 'Name', with: new_attrs[:name]
         fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-        fill_in_tom_select 'Account', with: new_attrs[:account].name
+        fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
         fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
@@ -179,7 +179,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
       let(:fill_form!) do
         fill_in 'Name', with: new_attrs[:name]
         fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-        fill_in_tom_select 'Account', with: new_attrs[:account].name
+        fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
         fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name

--- a/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
     let!(:account) { FactoryBot.create(:account, contractor: vendor) }
     let(:fill_form!) do
       fill_in_tom_select 'Vendor', with: vendor.name, search: true
-      fill_in_tom_select 'Account', with: account.name
+      fill_in_tom_select 'Account', with: account.name, search: true
     end
 
     it 'does not update dialpeer' do

--- a/spec/features/routing/dialpeers/new_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/new_dialpeer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Create new Dialpeer', js: true do
     fill_in 'Initial rate', with: '0.1'
     fill_in 'Next rate', with: '0.2'
     fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-    fill_in_tom_select 'Account', with: account.display_name
+    fill_in_tom_select 'Account', with: account.display_name, search: true
     fill_in_tom_select 'Routing group', with: routing_group.display_name
     fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
     fill_in_tom_select 'Gateway', with: gateway.display_name
@@ -161,7 +161,7 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in 'Initial rate', with: '0.1'
       fill_in 'Next rate', with: '0.2'
       fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-      fill_in_tom_select 'Account', with: account.display_name
+      fill_in_tom_select 'Account', with: account.display_name, search: true
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
       fill_in_tom_select 'Gateway Group', with: gateway_group.display_name
@@ -193,7 +193,7 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in 'Initial rate', with: '0.1'
       fill_in 'Next rate', with: '0.2'
       fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-      fill_in_tom_select 'Account', with: account.display_name
+      fill_in_tom_select 'Account', with: account.display_name, search: true
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
       fill_in_tom_select 'Gateway', with: gateway.display_name

--- a/spec/jobs/async_batch_destroy_job_spec.rb
+++ b/spec/jobs/async_batch_destroy_job_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe AsyncBatchDestroyJob, type: :job do
         let!(:item) do
           FactoryBot.create(:rate_management_pricelist_item, :with_pricelist, :filed_from_project, dialpeer: dialpeers.last)
         end
-        let(:sql_query) { Dialpeer.all.to_sql }
+        let(:sql_query) { Dialpeer.order(:id).to_sql }
 
         it 'should raise validation error' do
           error_message = "Dialpeer ##{dialpeers.last.id} can't be deleted: Can't be deleted because linked to not applied Rate Management Pricelist(s) ##{item.pricelist_id}"


### PR DESCRIPTION
## Summary

Fixes a batch of flaky specs (dialpeer-related feature specs + the async batch destroy job) 

## Flaky feature specs — Account tom-select race

The **Account** field is an ajax-fillable `tom-select` whose options are reloaded asynchronously whenever the **Vendor** changes. Selecting it via the non-waiting path raced the fetch and intermittently failed with `tom-select: could not select ... (not-found)`.

Fix: select Account through the ajax-aware search path (`search: true`) so it waits for the option to load.

- `spec/features/routing/dialpeers/new_dialpeer_spec.rb`
- `spec/features/routing/dialpeers/edit_dialpeer_spec.rb`
- rate management project create spec

## Flaky `AsyncBatchDestroyJob` spec

`spec/jobs/async_batch_destroy_job_spec.rb` — the job fetches batches with `find_by_sql(sql_query + " LIMIT N")` and no `ORDER BY`, so PostgreSQL returned rows in arbitrary heap order. When the un-destroyable dialpeer (linked to an unapplied pricelist) landed in the first batch, that batch rolled back and the loop aborted before anything was destroyed, so `dialpeers.first` still existed and the assertion failed.

Fix: order the spec's query by `id` so batching is deterministic and the un-destroyable dialpeer lands in the second batch, matching the `first(2)` destroyed / `last(2)` surviving assertions.


