### PR TITLE
fix flaky rate management project tom-select specs

### DIFF
--- a/spec/features/rate_management/project/update_spec.rb
+++ b/spec/features/rate_management/project/update_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Rate Management Project Update', js: true, bullet: [:n] do
   context 'when project with same scope attributes exists' do
     let(:fill_form!) do
       fill_in_tom_select 'Vendor', with: another_project.vendor.name, search: true
-      fill_in_tom_select 'Account', with: another_project.account.name
+      fill_in_tom_select 'Account', with: another_project.account.name, search: true
       fill_in_tom_select 'Routing group', with: another_project.routing_group.name
       fill_in_tom_select 'Routeset discriminator', with: another_project.routeset_discriminator.name
       fill_in_tom_select 'Gateway', with: another_gateway.name

--- a/spec/support/page_objects/section/tom_select.rb
+++ b/spec/support/page_objects/section/tom_select.rb
@@ -209,12 +209,19 @@ module Section
           if (!ts) { return 'no-instance'; }
           var text = String(arguments[1]).trim(), exact = arguments[2];
           var labelField = ts.settings.labelField, valueField = ts.settings.valueField;
-          var match = null;
+          // Always prefer an exact label match; only when exact is false and no
+          // exact match exists do we fall back to the first substring match.
+          // Without this preference a search for "Discriminator 1" could pick
+          // "Discriminator 10" (whichever option key is enumerated first),
+          // selecting the wrong record and flaking the spec.
+          var match = null, substringMatch = null;
           Object.keys(ts.options).some(function (key) {
             var label = String(ts.options[key][labelField]).trim();
-            if (exact ? label === text : label.indexOf(text) !== -1) { match = ts.options[key]; return true; }
+            if (label === text) { match = ts.options[key]; return true; }
+            if (!exact && substringMatch === null && label.indexOf(text) !== -1) { substringMatch = ts.options[key]; }
             return false;
           });
+          if (!match && !exact) { match = substringMatch; }
           if (!match) { return 'not-found'; }
           ts.addItem(String(match[valueField]), false);
           return 'ok';


### PR DESCRIPTION
Two independent flakes in the Rate Management Project feature specs, both rooted in tom-select selection races:

- update_spec "same scope attributes exists": the Account field is an ajax-loaded tom-select whose options reload when the vendor changes. It was filled via the non-waiting path, racing the fetch and failing with "could not select ... (not-found)". Use search: true so it waits for the option, matching the create_spec fix in 541b14fb.

- add_item_by_text matched the first option whose label *contained* the search text when exact was false. With sibling records that have sequential names ("Discriminator 1" vs "Discriminator 10"), it could select the wrong record depending on option enumeration order, picking a scope value that matched an existing project and silently failing creation (no success flash). Always prefer an exact label match, only falling back to substring when exact is false and no exact match exists. This hardens every field routed through the helper.

Co-Authored-By: Clanker