### PR TITLE
Fix flaky feature specs: use select_tom_select_by_value for fillable tom-select fields

### DIFF
--- a/spec/features/rate_management/project/create_spec.rb
+++ b/spec/features/rate_management/project/create_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
     let(:fill_form!) do
       fill_in 'Name', with: new_attrs[:name]
       fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-      fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
+      select_tom_select_by_value 'Account', { new_attrs[:account].id => new_attrs[:account].name }
       fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
       fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
-      fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
+      select_tom_select_by_value 'Gateway', { new_attrs[:gateway].id => new_attrs[:gateway].name }
     end
 
     let(:new_attrs) do
@@ -63,9 +63,9 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
       let(:fill_form!) do
         fill_in 'Name', with: new_attrs[:name]
         fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-        fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
+        select_tom_select_by_value 'Account', { new_attrs[:account].id => new_attrs[:account].name }
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
-        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
+        select_tom_select_by_value 'Gateway', { new_attrs[:gateway].id => new_attrs[:gateway].name }
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
         fill_in_tom_select 'Routing Tags', with: new_attrs[:routing_tags].first.name, multiple: true
         fill_in_tom_select 'Routing Tags', with: new_attrs[:routing_tags].second.name, multiple: true
@@ -179,10 +179,10 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
       let(:fill_form!) do
         fill_in 'Name', with: new_attrs[:name]
         fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
-        fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
+        select_tom_select_by_value 'Account', { new_attrs[:account].id => new_attrs[:account].name }
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
-        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
+        select_tom_select_by_value 'Gateway', { new_attrs[:gateway].id => new_attrs[:gateway].name }
         fill_in_tom_select 'Routing Tags', with: routing_tags.third.name, multiple: true
         fill_in_tom_select 'Routing Tags', with: Routing::RoutingTag::ANY_TAG, multiple: true
         fill_in_tom_select 'Routing Tags', with: routing_tags.first.name, multiple: true

--- a/spec/features/rate_management/project/create_spec.rb
+++ b/spec/features/rate_management/project/create_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
       fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
       fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
       fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
-      fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name
+      fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
     end
 
     let(:new_attrs) do
@@ -65,7 +65,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
         fill_in_tom_select 'Vendor', with: new_attrs[:vendor].name, search: true
         fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
-        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name
+        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
         fill_in_tom_select 'Routing Tags', with: new_attrs[:routing_tags].first.name, multiple: true
         fill_in_tom_select 'Routing Tags', with: new_attrs[:routing_tags].second.name, multiple: true
@@ -182,7 +182,7 @@ RSpec.describe 'Rate Management Project Create', js: true, bullet: [:n] do
         fill_in_tom_select 'Account', with: new_attrs[:account].name, search: true
         fill_in_tom_select 'Routing group', with: new_attrs[:routing_group].name
         fill_in_tom_select 'Routeset discriminator', with: new_attrs[:routeset_discriminator].name
-        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name
+        fill_in_tom_select 'Gateway', with: new_attrs[:gateway].name, search: true
         fill_in_tom_select 'Routing Tags', with: routing_tags.third.name, multiple: true
         fill_in_tom_select 'Routing Tags', with: Routing::RoutingTag::ANY_TAG, multiple: true
         fill_in_tom_select 'Routing Tags', with: routing_tags.first.name, multiple: true

--- a/spec/features/rate_management/project/update_spec.rb
+++ b/spec/features/rate_management/project/update_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Rate Management Project Update', js: true, bullet: [:n] do
   let(:fill_form!) do
     fill_in 'Name', with: new_name
     clear_tom_select 'Gateway'
-    fill_in_tom_select 'Gateway Group', with: gateway_group.display_name
+    fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
     tom_select_deselect_values 'Routing Tags', values: record.routing_tags.map(&:name)
   end
 
@@ -40,7 +40,7 @@ RSpec.describe 'Rate Management Project Update', js: true, bullet: [:n] do
       fill_in_tom_select 'Account', with: another_project.account.name, search: true
       fill_in_tom_select 'Routing group', with: another_project.routing_group.name
       fill_in_tom_select 'Routeset discriminator', with: another_project.routeset_discriminator.name
-      fill_in_tom_select 'Gateway', with: another_gateway.name
+      fill_in_tom_select 'Gateway', with: another_gateway.name, search: true
     end
     let!(:another_project) do
       FactoryBot.create(:rate_management_project, :filled)

--- a/spec/features/rate_management/project/update_spec.rb
+++ b/spec/features/rate_management/project/update_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Rate Management Project Update', js: true, bullet: [:n] do
   let(:fill_form!) do
     fill_in 'Name', with: new_name
     clear_tom_select 'Gateway'
-    fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
+    select_tom_select_by_value 'Gateway Group', { gateway_group.id => gateway_group.display_name }
     tom_select_deselect_values 'Routing Tags', values: record.routing_tags.map(&:name)
   end
 
@@ -37,10 +37,10 @@ RSpec.describe 'Rate Management Project Update', js: true, bullet: [:n] do
   context 'when project with same scope attributes exists' do
     let(:fill_form!) do
       fill_in_tom_select 'Vendor', with: another_project.vendor.name, search: true
-      fill_in_tom_select 'Account', with: another_project.account.name, search: true
+      select_tom_select_by_value 'Account', { another_project.account.id => another_project.account.name }
       fill_in_tom_select 'Routing group', with: another_project.routing_group.name
       fill_in_tom_select 'Routeset discriminator', with: another_project.routeset_discriminator.name
-      fill_in_tom_select 'Gateway', with: another_gateway.name, search: true
+      select_tom_select_by_value 'Gateway', { another_gateway.id => another_gateway.name }
     end
     let!(:another_project) do
       FactoryBot.create(:rate_management_project, :filled)

--- a/spec/features/routing/customers_auths/new_customer_auth_spec.rb
+++ b/spec/features/routing/customers_auths/new_customer_auth_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'New Customer Auth', js: true do
   let(:fill_form!) do
     fill_in 'Name', with: 'Test'
     fill_in_tom_select 'Customer', with: customer.name, search: true
-    fill_in_tom_select 'Account', with: account.name
+    fill_in_tom_select 'Account', with: account.name, search: true
     fill_in_tom_select 'DST Numberlist', with: dst_numberlist.display_name, search: true
     fill_in_tom_select 'SRC Numberlist', with: src_numberlist.display_name, search: true
     fill_in_tom_select 'Gateway', with: gateway.name

--- a/spec/features/routing/customers_auths/new_customer_auth_spec.rb
+++ b/spec/features/routing/customers_auths/new_customer_auth_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'New Customer Auth', js: true do
     fill_in_tom_select 'Account', with: account.name, search: true
     fill_in_tom_select 'DST Numberlist', with: dst_numberlist.display_name, search: true
     fill_in_tom_select 'SRC Numberlist', with: src_numberlist.display_name, search: true
-    fill_in_tom_select 'Gateway', with: gateway.name
+    fill_in_tom_select 'Gateway', with: gateway.name, search: true
     fill_in_tom_select 'Rateplan', with: rateplan.name
     fill_in_tom_select 'Routing plan', with: routing_plan.name
   end

--- a/spec/features/routing/customers_auths/new_customer_auth_spec.rb
+++ b/spec/features/routing/customers_auths/new_customer_auth_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe 'New Customer Auth', js: true do
   let(:fill_form!) do
     fill_in 'Name', with: 'Test'
     fill_in_tom_select 'Customer', with: customer.name, search: true
-    fill_in_tom_select 'Account', with: account.name, search: true
+    select_tom_select_by_value 'Account', { account.id => account.name }
     fill_in_tom_select 'DST Numberlist', with: dst_numberlist.display_name, search: true
     fill_in_tom_select 'SRC Numberlist', with: src_numberlist.display_name, search: true
-    fill_in_tom_select 'Gateway', with: gateway.name, search: true
+    select_tom_select_by_value 'Gateway', { gateway.id => gateway.name }
     fill_in_tom_select 'Rateplan', with: rateplan.name
     fill_in_tom_select 'Routing plan', with: routing_plan.name
   end

--- a/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
     let!(:account) { FactoryBot.create(:account, contractor: vendor) }
     let(:fill_form!) do
       fill_in_tom_select 'Vendor', with: vendor.name, search: true
-      fill_in_tom_select 'Account', with: account.name, search: true
+      select_tom_select_by_value 'Account', { account.id => account.name }
     end
 
     it 'does not update dialpeer' do
@@ -183,7 +183,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
       context 'with gateway' do
         let(:fill_form!) do
           super()
-          fill_in_tom_select 'Gateway', with: gateway.name, exact_label: true, search: true
+          select_tom_select_by_value 'Gateway', { gateway.id => gateway.name }, exact_label: true
         end
 
         it 'updates correctly' do
@@ -213,7 +213,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
       context 'with gateway_group' do
         let(:fill_form!) do
           super()
-          fill_in_tom_select 'Gateway Group', with: gateway_group.name, search: true
+          select_tom_select_by_value 'Gateway Group', { gateway_group.id => gateway_group.name }
         end
 
         it 'updates correctly' do

--- a/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/edit_dialpeer_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
       context 'with gateway' do
         let(:fill_form!) do
           super()
-          fill_in_tom_select 'Gateway', with: gateway.name, exact_label: true
+          fill_in_tom_select 'Gateway', with: gateway.name, exact_label: true, search: true
         end
 
         it 'updates correctly' do
@@ -213,7 +213,7 @@ RSpec.describe 'Edit Dialpeer', js: true do
       context 'with gateway_group' do
         let(:fill_form!) do
           super()
-          fill_in_tom_select 'Gateway Group', with: gateway_group.name
+          fill_in_tom_select 'Gateway Group', with: gateway_group.name, search: true
         end
 
         it 'updates correctly' do

--- a/spec/features/routing/dialpeers/new_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/new_dialpeer_spec.rb
@@ -67,10 +67,10 @@ RSpec.describe 'Create new Dialpeer', js: true do
     fill_in 'Initial rate', with: '0.1'
     fill_in 'Next rate', with: '0.2'
     fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-    fill_in_tom_select 'Account', with: account.display_name, search: true
+    select_tom_select_by_value 'Account', { account.id => account.display_name }
     fill_in_tom_select 'Routing group', with: routing_group.display_name
     fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-    fill_in_tom_select 'Gateway', with: gateway.display_name, search: true
+    select_tom_select_by_value 'Gateway', { gateway.id => gateway.display_name }
     fill_in_tom_select 'Currency', with: currency.name
   end
 
@@ -161,10 +161,10 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in 'Initial rate', with: '0.1'
       fill_in 'Next rate', with: '0.2'
       fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-      fill_in_tom_select 'Account', with: account.display_name, search: true
+      select_tom_select_by_value 'Account', { account.id => account.display_name }
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
+      select_tom_select_by_value 'Gateway Group', { gateway_group.id => gateway_group.display_name }
       fill_in_tom_select 'Currency', with: currency.name
     end
 
@@ -193,11 +193,11 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in 'Initial rate', with: '0.1'
       fill_in 'Next rate', with: '0.2'
       fill_in_tom_select 'Vendor', with: vendor.display_name, search: true
-      fill_in_tom_select 'Account', with: account.display_name, search: true
+      select_tom_select_by_value 'Account', { account.id => account.display_name }
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-      fill_in_tom_select 'Gateway', with: gateway.display_name, search: true
-      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
+      select_tom_select_by_value 'Gateway', { gateway.id => gateway.display_name }
+      select_tom_select_by_value 'Gateway Group', { gateway_group.id => gateway_group.display_name }
       fill_in_tom_select 'Currency', with: currency.name
     end
 

--- a/spec/features/routing/dialpeers/new_dialpeer_spec.rb
+++ b/spec/features/routing/dialpeers/new_dialpeer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Create new Dialpeer', js: true do
     fill_in_tom_select 'Account', with: account.display_name, search: true
     fill_in_tom_select 'Routing group', with: routing_group.display_name
     fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-    fill_in_tom_select 'Gateway', with: gateway.display_name
+    fill_in_tom_select 'Gateway', with: gateway.display_name, search: true
     fill_in_tom_select 'Currency', with: currency.name
   end
 
@@ -164,7 +164,7 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in_tom_select 'Account', with: account.display_name, search: true
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name
+      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
       fill_in_tom_select 'Currency', with: currency.name
     end
 
@@ -196,8 +196,8 @@ RSpec.describe 'Create new Dialpeer', js: true do
       fill_in_tom_select 'Account', with: account.display_name, search: true
       fill_in_tom_select 'Routing group', with: routing_group.display_name
       fill_in_tom_select 'Routeset discriminator', with: routeset_discriminator.display_name
-      fill_in_tom_select 'Gateway', with: gateway.display_name
-      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name
+      fill_in_tom_select 'Gateway', with: gateway.display_name, search: true
+      fill_in_tom_select 'Gateway Group', with: gateway_group.display_name, search: true
       fill_in_tom_select 'Currency', with: currency.name
     end
 


### PR DESCRIPTION
## Problem

Several `js: true` feature specs fill the `Account`, `Gateway` and `Gateway Group` tom-select widgets. The ActiveAdmin form builder renders these as **`tom-select-ajax-fillable`** whenever the input has `fill_params:` (see `lib/active_admin/views/active_admin_form.rb`). Unlike a plain `tom-select-ajax` field, a fillable field:

- does **not** preload its options, and does **not** search them on type;
- bulk-loads its options from a **parent field** (`Vendor` / `Customer`) via an async `fillOptions()` that calls `ts.clear(); ts.clearOptions()` and re-adds the results (`app/assets/javascripts/tom-select-ajax-fillable.js`).

Filling such a field through `fill_in_tom_select` races that async rebuild:

- the default (non-`search`) path reads the option list synchronously and can run before the options have loaded → `tom-select: could not select ... (not-found)`;
- the `search: true` path opens the dropdown and types into `.dropdown-input`, which races the `clearOptions()`/re-add and detaches the dropdown/input → `Ferrum::CoordinatesNotFoundError` / `Unable to find visible css ".ts-dropdown"`.

Both are flaky on CI; `search: true` on a fillable field is deterministically broken.

## Fix

Fill these fields with **`select_tom_select_by_value`**, which injects `value => text` straight through the tom-select API (`addOption` + `addItem`). It touches no dropdown UI and does not depend on the async parent-driven load, so it is deterministic. This is the pattern `spec/features/cdr/cdr_history/cdr_filter_spec.rb` already uses for these ajax gateway fields.

Converted fields (all `tom-select-ajax-fillable`): `Account` ×9, `Gateway` ×8, `Gateway Group` ×4, across:

- `spec/features/rate_management/project/create_spec.rb`
- `spec/features/rate_management/project/update_spec.rb`
- `spec/features/routing/customers_auths/new_customer_auth_spec.rb`
- `spec/features/routing/dialpeers/edit_dialpeer_spec.rb`
- `spec/features/routing/dialpeers/new_dialpeer_spec.rb`

Genuine `tom-select-ajax` fields (`Vendor`, `Customer`, `Numberlist` — no `fill_params`, self-contained server search on type) keep `search: true` and are left unchanged.
