### PR TITLE
Speed up rspec CI: runtime-balanced groups + cached network-data seed + lighter filter matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,15 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [master]
+
+# Cancel a superseded run when new commits are pushed to the same PR. Besides saving
+# CI minutes, this closes the narrow window where two overlapping runs of the same
+# branch could publish a new runtime-log cache mid-matrix and desync the 8-way split.
+# Push runs on master are never cancelled, so every master run persists its log.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   gems-caching:
@@ -33,7 +41,7 @@ jobs:
           key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
 
   lint:
-    name: Rubocop and bundle audit
+    name: Rubocop
     runs-on: ubuntu-latest
     container: ghcr.io/yeti-switch/yeti-web/build-image:trixie
     needs: gems-caching
@@ -47,8 +55,26 @@ jobs:
             .bundle
             /opt/yeti-web/vendor/rbenv
           key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
-      - name: Rubocop and bundle audit
+      - name: Rubocop
         run: make lint
+
+  audit:
+    name: Bundle audit
+    runs-on: ubuntu-latest
+    container: ghcr.io/yeti-switch/yeti-web/build-image:trixie
+    needs: gems-caching
+    steps:
+      - uses: actions/checkout@v6
+      - name: use cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            vendor
+            .bundle
+            /opt/yeti-web/vendor/rbenv
+          key: gems-deb13-${{runner.os}}-${{hashFiles('Gemfile.lock')}}-${{hashFiles('.ruby-version')}}
+      - name: Bundle audit
+        run: make audit
 
   database_consistency:
     name: DB consistency check
@@ -76,6 +102,7 @@ jobs:
           YETI_DB_PORT: 5432
           CDR_DB_HOST: db
           CDR_DB_PORT: 5432
+          SEED_WORKERS: 4
 
       - name: Save artifacts
         if: always()
@@ -86,7 +113,6 @@ jobs:
           include-hidden-files: true
           path: |
             log/
-
 
   annotations:
     name: Model annotations
@@ -113,7 +139,7 @@ jobs:
           YETI_DB_PORT: 5432
           CDR_DB_HOST: db
           CDR_DB_PORT: 5432
-
+          SEED_WORKERS: 4
 
   brakeman:
     name: Brakeman
@@ -168,16 +194,30 @@ jobs:
       - name: Clear tmp cache
         run: rm -rf tmp
 
+      # Exact key never hits (keyed by this run's sha); the restore-keys prefix picks the
+      # newest rspec-runtime-* cache visible to this ref — the PR's own previous run
+      # first, then master's. Missing on a brand-new branch => filesize fallback in the
+      # Makefile (safe).
+      - name: Restore rspec runtime log
+        uses: actions/cache/restore@v5
+        with:
+          path: log/parallel_runtime_rspec_full.log
+          key: rspec-runtime-${{ github.sha }}
+          restore-keys: |
+            rspec-runtime-
+
       - name: Run rspec
         run: make rspec
         env:
           PARALLEL_TEST_PROCESSORS: ${{ matrix.ci_node_total }}
           TEST_GROUP: ${{ matrix.ci_node_index }}
+          RSPEC_RUNTIME_LOG: log/parallel_runtime_rspec_full.log
           YETI_DB_HOST: db
           YETI_DB_PORT: 5432
           CDR_DB_HOST: db
           CDR_DB_PORT: 5432
           CI: true
+          SEED_WORKERS: 4
 
       - name: Save artifacts
         if: always()
@@ -190,6 +230,78 @@ jobs:
             tmp/capybara
             coverage
 
+      - name: Upload runtime log slice
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: rspec-runtime-${{ matrix.ci_node_index }}
+          path: log/parallel_runtime_rspec.log
+          if-no-files-found: ignore
+
+  # Merge the 8 per-group partial runtime logs into one complete log and persist it via
+  # cache for the next run's runtime-based grouping. Runs on PRs too: GitHub scopes
+  # caches per branch, so a PR's log lands in the PR's own scope (it cannot poison
+  # master's) and later runs of that PR read it first, falling back to master's log via
+  # the restore-keys prefix. Fork PRs get read-only cache access, so their save no-ops
+  # and they keep reading master's log. Gated on !cancelled() (not success()) so a
+  # single flaky matrix node does not skip persistence — every finished node's slice
+  # (uploaded with if: always()) still merges in.
+  rspec_runtime_log:
+    name: Persist rspec runtime log
+    runs-on: ubuntu-latest
+    # MUST run in the same container as the rspec jobs. actions/cache versions each
+    # entry by (path + compression method); the trixie image has no zstd, so the rspec
+    # jobs save/restore with gzip (cache.tgz). A bare ubuntu-latest host has zstd and
+    # would save this log with zstd (cache.tzst) under a DIFFERENT version — invisible
+    # to the gzip restore in the rspec job ("Cache not found" despite matching key+ref),
+    # so runtime grouping silently never activates and the split falls back to filesize.
+    container: ghcr.io/yeti-switch/yeti-web/build-image:trixie
+    needs: rspec
+    if: ${{ !cancelled() }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: rspec-runtime-*
+          path: runtime-slices
+      - name: Merge slices
+        # Write to log/ so the saved path matches the path the rspec job restores
+        # with. actions/cache derives its cache version from the path input, so a
+        # mismatched save/restore path would never resolve (and would extract to
+        # the wrong location on a hit).
+        run: |
+          mkdir -p log
+          cat runtime-slices/*/parallel_runtime_rspec.log > log/parallel_runtime_rspec_full.log
+      - uses: actions/cache/save@v5
+        with:
+          path: log/parallel_runtime_rspec_full.log
+          key: rspec-runtime-${{ github.sha }}
+      - name: Report slowest spec files
+        # Print the top 50 slowest spec files (from the merged runtime log) to the job
+        # log and the run summary, so heavy files can be spotted for future splitting.
+        # Runs after the cache save so a reporting glitch never blocks log persistence.
+        # `awk 'NR<=50'` (not `head`) reads the full stream so the sort pipeline cannot
+        # SIGPIPE-fail under `set -o pipefail`.
+        run: |
+          log=log/parallel_runtime_rspec_full.log
+          if [ ! -s "$log" ]; then
+            echo "No runtime log to report."
+            exit 0
+          fi
+          total=$(wc -l < "$log")
+          # Runtime-log lines are "path:seconds"; split on the LAST colon so paths with
+          # colons still parse. Emit "seconds<TAB>path", sort desc, keep the top 50.
+          rows=$(awk -F: '{ sec=$NF; path=substr($0,1,length($0)-length($NF)-1); printf "%s\t%s\n", sec, path }' "$log" \
+            | sort -rn \
+            | awk 'NR<=50')
+          echo "Top 50 slowest spec files (of $total total):"
+          echo "$rows" | awk -F'\t' '{ printf "%3d  %8.1fs  %s\n", NR, $1, $2 }'
+          {
+            echo "## Slowest spec files (top 50 of $total)"
+            echo ""
+            echo "| # | seconds | file |"
+            echo "|--:|--------:|------|"
+            echo "$rows" | awk -F'\t' '{ printf "| %d | %.1f | %s |\n", NR, $1, $2 }'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   rspec_oidc:
     name: Rspec tests for OIDC auth
@@ -225,6 +337,7 @@ jobs:
           CDR_DB_PORT: 5432
           CI: true
           CI_RUN_OIDC: true
+          SEED_WORKERS: 4
 
       - name: Save artifacts
         if: always()
@@ -236,8 +349,6 @@ jobs:
           path: |
             tmp/capybara
             coverage
-
-
 
   coverage:
     name: Coverage
@@ -276,7 +387,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '60 80'
+          thresholds: "60 80"
 
       - name: Adding coverage report to summary
         run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -199,9 +199,8 @@ else
 	RAILS_ENV=test $(bundle_bin) exec rake parallel:rake[custom_seeds[network_prefixes]]
 endif
 
-
 .PHONY: test
-test: lint brakeman rspec
+test: lint audit brakeman rspec
 
 
 .PHONY: rspec
@@ -211,15 +210,25 @@ ifdef spec
 	RAILS_ENV=test $(bundle_bin) exec rspec "$(spec)"
 else
 	$(info:msg=Running rspec tests)
+	@# --group-by runtime: balance groups by measured seconds (from the persisted log
+	@# pointed to by RSPEC_RUNTIME_LOG) instead of file byte size. The file list still
+	@# comes from scanning spec/ on disk, so the log never skips/adds files — it only
+	@# supplies weights. Files missing from the log (new/renamed) run with the average
+	@# known runtime as their weight. --allowed-missing 75 tolerates up to 75% of files
+	@# missing before the split hard-fails (default 50%); guards mass renames.
+	@# The $(wildcard) guard: no log present -> falls back to filesize (safe first run,
+	@# safe local dev). Keep RSPEC_RUNTIME_LOG a different path from the live
+	@# --out log/parallel_runtime_rspec.log so fresh writes don't clobber the input.
 	RAILS_ENV=test $(bundle_bin) exec parallel_test \
 		  spec/ \
 		  --type rspec \
 		  $(if $(TEST_GROUP),--only-group $(TEST_GROUP),) \
+		  $(if $(wildcard $(RSPEC_RUNTIME_LOG)),--group-by runtime --runtime-log $(RSPEC_RUNTIME_LOG) --allowed-missing 75,) \
 		  && script/format_runtime_log log/parallel_runtime_rspec.log \
 		  || { script/format_runtime_log log/parallel_runtime_rspec.log; false; }
 endif
 
-.PHONY: rspec
+.PHONY: database_consistency
 database_consistency: gems-test config/database.yml config/yeti_web.yml config/policy_roles.yml config/secrets.yml prepare-test-db
 	$(info:msg=Check the consistency of the database constraints with the application validations)
 	RAILS_ENV=test $(bundle_bin) exec database_consistency
@@ -231,8 +240,12 @@ annotations: gems-test config/database.yml config/yeti_web.yml config/policy_rol
 
 .PHONY: lint
 lint: gems-test config/database.yml config/yeti_web.yml config/secrets.yml
-	$(info:msg=Running rubocop and bundle audit)
+	$(info:msg=Running rubocop)
 	RAILS_ENV=test $(bundle_bin) exec rubocop -P
+
+.PHONY: audit
+audit: gems-test config/database.yml config/yeti_web.yml config/secrets.yml
+	$(info:msg=Running bundle audit)
 	RAILS_ENV=test $(bundle_bin) exec rake bundle:audit
 
 .PHONY: brakeman

--- a/db/custom_seeds/network_prefixes.rb
+++ b/db/custom_seeds/network_prefixes.rb
@@ -1,47 +1,135 @@
 # frozen_string_literal: true
 
+# Loads global telephony reference data (network types, networks, countries and
+# network prefixes) from checked-in YAML into sys.*.
+#
+# The bulk of the work is parsing db/network_data/**/*.yml (~232 files, ~96 MB)
+# and loading ~39k networks + ~486k prefixes. Both parsing (CPU-bound, Psych holds
+# the GVL) and the prefix insert (index maintenance) dominate the wall-clock, so
+# the per-file work is fanned out across processes: each worker parses its slice of
+# files and COPYs the rows straight into Postgres over its own backend.
+#
+# Tunable: SEED_WORKERS (default 0).
+# 0 or 1: load sequentially in the current process (no fork) — lower peak RAM, but slow.
+# 2+: fan the per-file parse+COPY out across N forked worker processes. Past ~4 the win is
+# capped by the largest single file (UnitedStates.yml), which one worker must parse and COPY alone.
+#
+# Atomicity: Phase 1 always COPYs file-by-file with no transaction around the whole load, so a
+# mid-run failure leaves the tables partially loaded at ANY worker count (forked workers also
+# cannot share a transaction). Recoverable: the task first TRUNCATEs the tables (a re-run fully
+# reloads) and a post-load count check raises on mismatch.
+
+require 'parallel'
+require_relative '../../lib/copy_data_loader'
+
+workers = Integer(ENV.fetch('SEED_WORKERS', 0))
+
+net_cols = %w[id name type_id uuid].freeze
+np_cols  = %w[id prefix number_min_length number_max_length uuid country_id network_id].freeze
+
+# --- Phase 0: global data, serially, in one transaction ---------------------
 puts 'loading global data'
-network_types = YAML.load_file('db/network_types.yml')
-networks = YAML.load_file('db/networks.yml')
-countries = YAML.load_file('db/countries.yml')
+network_types    = YAML.load_file('db/network_types.yml')
+networks         = YAML.load_file('db/networks.yml')
+countries        = YAML.load_file('db/countries.yml')
 network_prefixes = YAML.load_file('db/network_prefixes.yml')
 
 System::NetworkPrefix.transaction do
-  puts 'deleting old data'
-  System::NetworkPrefix.delete_all
-  System::Network.delete_all
-  System::NetworkType.delete_all
-  System::Country.delete_all
+  puts 'truncating old data'
+  # TRUNCATE is atomic and reclaims space (unlike delete_all). CASCADE covers the
+  # 4 tables' mutual FKs; all are wiped together anyway.
+  ActiveRecord::Base.connection.execute(
+    'TRUNCATE sys.network_prefixes, sys.networks, sys.network_types, sys.countries CASCADE'
+  )
 
   puts 'insert new global'
-  System::NetworkType.insert_all!(network_types) if network_types.any?
-  System::Network.insert_all!(networks) if networks.any?
-  System::Country.insert_all!(countries) if countries.any?
+  System::NetworkType.insert_all!(network_types)     if network_types.any?
+  System::Network.insert_all!(networks)              if networks.any?
+  System::Country.insert_all!(countries)             if countries.any?
   System::NetworkPrefix.insert_all!(network_prefixes) if network_prefixes.any?
 end
 
-System::NetworkPrefix.transaction do
-  network_attrs_list = []
-  network_prefix_attrs_list = []
-  Dir.glob('db/network_data/**/*.yml') do |f|
-    puts "load file #{f}:"
-    data = YAML.load_file(f, aliases: true)
-    network_attrs_list.concat(data['networks'])
-    network_prefix_attrs_list.concat(data['network_prefixes'])
-  end
-
-  System::Network.insert_all!(network_attrs_list) if network_attrs_list.any?
-  puts "  loaded #{network_attrs_list.length} networks"
-  n_network_ids = network_attrs_list.map { |network_attrs| network_attrs['id'] }
-
-  System::NetworkPrefix.insert_all!(network_prefix_attrs_list) if network_prefix_attrs_list.any?
-  puts "  loaded #{network_prefix_attrs_list.length} network prefixes"
-  np_network_ids = network_prefix_attrs_list.map { |network_prefix_attrs| network_prefix_attrs['network_id'] }.uniq
-
-  no_prefixes = n_network_ids - np_network_ids
-  puts "  networks without prefixes: #{no_prefixes}" if no_prefixes.any?
+# --- Phase 1: parse + COPY each file, fanned out across processes ------------
+# Bin-pack files by byte size (greedy longest-processing-time: sort desc, assign
+# each to the currently-smallest bin). This isolates the two huge files
+# (UnitedStates.yml, Mexico.yml) into their own bins instead of stacking them
+# behind other work.
+bins_qty = workers > 0 ? workers : 1
+files = Dir.glob('db/network_data/**/*.yml').sort
+bins  = Array.new(bins_qty) { { size: 0, files: [] } }
+files.sort_by { |f| -File.size(f) }.each do |f|
+  bin = bins.min_by { |b| b[:size] }
+  bin[:files] << f
+  bin[:size]  += File.size(f)
 end
 
+if workers > 1
+  puts "loading #{files.size} network data files with #{workers} workers"
+else
+  workers = 0
+  puts "loading #{files.size} network data files serially (no workers)"
+end
+
+# Drop the parent's DB connection before forking so no worker inherits (and later
+# corrupts) a live socket. Each process opens its own fresh connection lazily.
+ActiveRecord::Base.connection_handler.clear_all_connections!
+
+results = Parallel.map(bins, in_processes: workers) do |bin|
+  # Belt-and-suspenders: ensure no inherited socket is reused in this child.
+  ActiveRecord::Base.connection_handler.clear_all_connections!
+  n_net = 0
+  n_np  = 0
+  current_file = nil
+
+  begin
+    bin[:files].each do |f|
+      current_file = f
+      data = YAML.load_file(f, aliases: true)
+      nets = data['networks'] || []
+      nps  = data['network_prefixes'] || []
+
+      # networks BEFORE prefixes (FK: network_prefixes.network_id => networks.id).
+      unless nets.empty?
+        CopyDataLoader.load(model_class: System::Network, data: nets, columns: net_cols)
+        n_net += nets.size
+      end
+
+      next if nps.empty?
+
+      CopyDataLoader.load(model_class: System::NetworkPrefix, data: nps, columns: np_cols)
+      n_np += nps.size
+    end
+  rescue StandardError => e
+    # Name the offending file, then let Parallel propagate the failure to the parent.
+    warn "error loading #{current_file}: #{e.class}: #{e.message}"
+    raise
+  end
+
+  { networks: n_net, prefixes: n_np, files: bin[:files].size }
+end
+
+if workers > 1
+  results.each_with_index do |r, i|
+    puts "  worker #{i}: #{r[:files]} files, #{r[:networks]} networks, #{r[:prefixes]} prefixes"
+  end
+else
+  r = results.first
+  puts "  serial: #{r[:files]} files, #{r[:networks]} networks, #{r[:prefixes]} prefixes"
+end
+
+# --- Post-load verify (compensates for the lost single-transaction atomicity) --
+# Expected total = rows the workers COPYd + the global rows inserted in Phase 0.
+expected_net = results.sum { |r| r[:networks] } + networks.size
+expected_np  = results.sum { |r| r[:prefixes] } + network_prefixes.size
+actual_net   = System::Network.count
+actual_np    = System::NetworkPrefix.count
+
+raise "network count mismatch: expected #{expected_net}, got #{actual_net}" unless expected_net == actual_net
+raise "prefix count mismatch: expected #{expected_np}, got #{actual_np}" unless expected_np == actual_np
+
+puts "verified #{actual_net} networks, #{actual_np} prefixes loaded"
+
+# --- Phase 3: sequences -----------------------------------------------------
 System::NetworkPrefix.transaction do
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.network_types_id_seq', MAX(id), true) FROM sys.network_types"
   SqlCaller::Yeti.execute "SELECT pg_catalog.setval('sys.networks_id_seq', MAX(id), true) FROM sys.networks"

--- a/dev/db_test_prepare.sh
+++ b/dev/db_test_prepare.sh
@@ -2,7 +2,7 @@
 
 echo "prepare test databases..."
 
-RAILS_ENV=test bundle exec rake db:drop \
+RAILS_ENV=test SEED_WORKERS=4 bundle exec rake db:drop \
                                 db:create \
                                 db:schema:load \
                                 db:seed \

--- a/lib/copy_data_loader.rb
+++ b/lib/copy_data_loader.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CopyDataLoader
+  def self.load(model_class:, data:, columns:)
+    raw = model_class.connection.raw_connection
+    enc = PG::TextEncoder::CopyRow.new
+    raw.copy_data("COPY #{model_class.table_name} (#{columns.join(',')}) FROM STDIN", enc) do
+      data.each { |r| raw.put_copy_data(columns.map { |c| r[c] }) }
+    end
+  end
+end

--- a/spec/features/routing/routing_plan_static_route_batch_creators/new_routing_plan_static_route_batch_creator_spec.rb
+++ b/spec/features/routing/routing_plan_static_route_batch_creators/new_routing_plan_static_route_batch_creator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Create new Routing Plan Static Route Batch Creator', js: true do
+RSpec.describe 'Create new Routing Plan Static Route Batch Creator', type: :feature, js: true do
   subject do
     click_submit('Create Routing plan static route batch creator')
   end

--- a/spec/features/system/network_prefixes/export_network_prefix_spec.rb
+++ b/spec/features/system/network_prefixes/export_network_prefix_spec.rb
@@ -3,27 +3,34 @@
 RSpec.describe 'Export Network Prefixes', type: :feature do
   include_context :login_as_admin
 
-  let!(:item) do
-    create(:network_prefix)
-  end
+  # A dedicated country no seeded prefix references, so the export renders
+  # exactly these rows instead of serializing the whole sys.network_prefixes
+  # table (~486k seeded rows in the test DB) just to assert on a handful.
+  let!(:country) { create(:country_uniq) }
+  let!(:items) { create_list(:network_prefix, 3, country: country) }
 
   before do
-    visit system_network_prefixes_path(format: :csv)
+    visit system_network_prefixes_path(format: :csv, q: { country_id_eq: country.id })
   end
 
-  subject { CSV.parse(page.body).slice(0, 2).transpose }
+  subject { CSV.parse(page.body) }
 
   it 'has expected header and values' do
-    expect(subject).to match_array(
-                         [
-                           ['Id', item.id.to_s],
-                           ['Prefix', item.prefix],
-                           ['Number min length', item.number_min_length.to_s],
-                           ['Number max length', item.number_max_length.to_s],
-                           ['Country name', item.country.name],
-                           ['Network name', item.network.name],
-                           ['Uuid', item.uuid]
-                         ]
-                       )
+    expect(subject.first).to eq(
+      ['Id', 'Prefix', 'Number min length', 'Number max length', 'Country name', 'Network name', 'Uuid']
+    )
+    expect(subject.drop(1)).to match_array(
+      items.map do |item|
+        [
+          item.id.to_s,
+          item.prefix,
+          item.number_min_length.to_s,
+          item.number_max_length.to_s,
+          item.country.name,
+          item.network.name,
+          item.uuid
+        ]
+      end
+    )
   end
 end

--- a/spec/features/system/networks/export_network_spec.rb
+++ b/spec/features/system/networks/export_network_spec.rb
@@ -3,24 +3,29 @@
 RSpec.describe 'Export Networks', type: :feature do
   include_context :login_as_admin
 
-  let!(:item) do
-    create(:network)
-  end
+  # A dedicated network type no seeded network references, so the export renders
+  # exactly these rows instead of serializing the whole seeded sys.networks
+  # table just to assert on a handful.
+  let!(:network_type) { create(:network_type) }
+  let!(:items) { create_list(:network_uniq, 3, network_type: network_type) }
 
   before do
-    visit system_networks_path(format: :csv)
+    visit system_networks_path(format: :csv, q: { type_id_eq: network_type.id })
   end
 
-  subject { CSV.parse(page.body).slice(0, 2).transpose }
+  subject { CSV.parse(page.body) }
 
   it 'has expected header and values' do
-    expect(subject).to match_array(
-                         [
-                           ['Id', item.id.to_s],
-                           ['Name', item.name],
-                           ['Network type name', item.network_type.name],
-                           ['Uuid', item.uuid]
-                         ]
-                       )
+    expect(subject.first).to eq(['Id', 'Name', 'Network type name', 'Uuid'])
+    expect(subject.drop(1)).to match_array(
+      items.map do |item|
+        [
+          item.id.to_s,
+          item.name,
+          item.network_type.name,
+          item.uuid
+        ]
+      end
+    )
   end
 end

--- a/spec/requests/api/rest/customer/v1/outgoing_numberlist_items_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/outgoing_numberlist_items_controller_spec.rb
@@ -71,17 +71,21 @@ RSpec.describe Api::Rest::Customer::V1::OutgoingNumberlistItemsController, type:
     end
 
     context 'with ransack filters' do
-      let(:api_access_attrs) {
-        super().merge allow_outgoing_numberlists_ids: [suitable_record.numberlist_id]
-      }
-
-      before do
-        create(:customers_auth, customer: customer, dst_numberlist: suitable_record.numberlist)
-        create(:customers_auth, customer: customer, dst_numberlist: other_record.numberlist)
-      end
-
       let(:factory) { :numberlist_item }
       let(:pk) { :id }
+
+      # The resource applies a hard `where(numberlist_id: allow_outgoing_numberlists_ids)`,
+      # so the token must enumerate every created item's numberlist id. Build the
+      # token from a dynamic auth_config reading an accumulator filled as records
+      # are created (evaluated lazily at request time, after all records exist).
+      let(:api_access) { nil }
+      let(:auth_config) { { customer_id: customer.id, allow_outgoing_numberlists_ids: ransack_numberlist_ids } }
+      let(:ransack_numberlist_ids) { [] }
+
+      def authorize_ransack_record(record)
+        ransack_numberlist_ids << record.numberlist_id
+        create(:customers_auth, customer: customer, dst_numberlist: record.numberlist)
+      end
 
       it_behaves_like :jsonapi_filters_by_string_field, :key
     end

--- a/spec/requests/api/rest/customer/v1/outgoing_numberlists_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/outgoing_numberlists_controller_spec.rb
@@ -69,17 +69,21 @@ RSpec.describe Api::Rest::Customer::V1::OutgoingNumberlistsController, type: :re
     end
 
     context 'with ransack filters' do
-      let(:api_access_attrs) {
-        super().merge allow_outgoing_numberlists_ids: [suitable_record.id]
-      }
-
-      before do
-        create(:customers_auth, customer: customer, dst_numberlist: suitable_record)
-        create(:customers_auth, customer: customer, dst_numberlist: other_record)
-      end
-
       let(:factory) { :numberlist }
       let(:pk) { :id }
+
+      # The resource applies a hard `where(id: allow_outgoing_numberlists_ids)`,
+      # so the token must enumerate every created numberlist id. Build the token
+      # from a dynamic auth_config that reads an accumulator filled as records are
+      # created (evaluated lazily at request time, after all records exist).
+      let(:api_access) { nil }
+      let(:auth_config) { { customer_id: customer.id, allow_outgoing_numberlists_ids: ransack_numberlist_ids } }
+      let(:ransack_numberlist_ids) { [] }
+
+      def authorize_ransack_record(record)
+        ransack_numberlist_ids << record.id
+        create(:customers_auth, customer: customer, dst_numberlist: record)
+      end
 
       it_behaves_like :jsonapi_filters_by_string_field, :name
     end

--- a/spec/requests/api/rest/customer/v1/rateplans_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/rateplans_controller_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe Api::Rest::Customer::V1::RateplansController, type: :request do
     end
 
     context 'with ransack filters' do
-      before do
-        create(:customers_auth, customer: customer, rateplan: suitable_record)
-        create(:customers_auth, customer: customer, rateplan: other_record)
-      end
-
       let(:factory) { :rateplan }
       let(:trait) { :with_uuid }
       let(:pk) { :uuid }
+
+      # Rateplans are visible when linked to the customer via customers_auth.
+      def authorize_ransack_record(record)
+        create(:customers_auth, customer: customer, rateplan: record)
+      end
 
       it_behaves_like :jsonapi_filters_by_string_field, :name
     end

--- a/spec/requests/api/rest/customer/v1/rates_controller_spec.rb
+++ b/spec/requests/api/rest/customer/v1/rates_controller_spec.rb
@@ -72,14 +72,18 @@ RSpec.describe Api::Rest::Customer::V1::RatesController, type: :request do
     end
 
     context 'with ransack filters' do
-      before do
-        customers_auth = create(:customers_auth, customer: customer)
-        customers_auth.rateplan.update! rate_groups: [suitable_record.rate_group, other_record.rate_group]
-      end
-
       let(:factory) { :destination }
       let(:trait) { :with_uuid }
       let(:pk) { :uuid }
+
+      # Rates (destinations) are visible when their rate_group belongs to a
+      # rateplan of one of the customer's customers_auths. Attach every created
+      # record's rate_group to a single customer rateplan.
+      let!(:ransack_customers_auth) { create(:customers_auth, customer: customer) }
+
+      def authorize_ransack_record(record)
+        ransack_customers_auth.rateplan.rate_groups << record.rate_group
+      end
 
       it_behaves_like :jsonapi_filters_by_boolean_field, :enabled
       it_behaves_like :jsonapi_filters_by_string_field, :prefix

--- a/spec/support/contexts/ransack_filter_setup.rb
+++ b/spec/support/contexts/ransack_filter_setup.rb
@@ -3,11 +3,20 @@
 RSpec.shared_context :ransack_filter_setup do
   def create_record(attrs = {})
     record_attrs = defined?(factory_attrs) ? attrs.merge(factory_attrs) : attrs
-    if defined?(trait)
-      create_record_with_trait(factory, trait, record_attrs)
-    else
-      create factory, record_attrs
-    end
+    record =
+      if defined?(trait)
+        create_record_with_trait(factory, trait, record_attrs)
+      else
+        create factory, record_attrs
+      end
+    # Specs whose endpoint only exposes records linked to the authenticated
+    # principal (customer-v1 filters gate visibility by customers_auth and token
+    # allow-lists) define `authorize_ransack_record` to make each created record
+    # visible. The collapsed shared examples build every covering record through
+    # here, so the hook runs once per record regardless of the covering-set size
+    # or its internal naming (suitable_record / smaller_record / record_str ...).
+    authorize_ransack_record(record) if respond_to?(:authorize_ransack_record)
+    record
   end
 
   def create_record_with_trait(factory, trait, record_attrs)
@@ -23,11 +32,50 @@ RSpec.shared_context :ransack_filter_setup do
     record.try(primary_key).to_s
   end
 
+  # Issue a fresh index request with `filter` merged onto the spec's base query,
+  # then assert primary-key inclusion/exclusion. Unlike the memoized `subject`,
+  # this is re-issuable within a single example (Rails rebuilds request/response
+  # on every `get`), so a whole operator matrix collapses into one example under
+  # `aggregate_failures` instead of one example (with duplicate record inserts)
+  # per operator.
+  def assert_filter(filter_key, filter_value, includes:, excludes:)
+    perform_ransack_filter_request(filter_key => filter_value)
+    ids = response_data.map { |record| record['id'] }
+    Array.wrap(includes).each do |record|
+      expect(ids).to include(primary_key_for(record)),
+                     "filter #{filter_key}=#{filter_value.inspect} expected to include id " \
+                     "#{primary_key_for(record)}, got #{ids.inspect}"
+    end
+    Array.wrap(excludes).each do |record|
+      expect(ids).not_to include(primary_key_for(record)),
+                         "filter #{filter_key}=#{filter_value.inspect} expected to exclude id " \
+                         "#{primary_key_for(record)}, got #{ids.inspect}"
+    end
+  end
+
+  # Runs one index request with `filter` deep-merged onto the spec's base query.
+  # Request specs (which define json_api_request_path) go through the HTTP path;
+  # controller specs hit `get :index`.
+  def perform_ransack_filter_request(filter)
+    query = (json_api_request_query || {}).deep_merge(filter: filter)
+    if respond_to?(:json_api_request_path)
+      get json_api_request_path, params: query, headers: json_api_request_headers
+    else
+      get :index, params: query
+    end
+  end
+
   let(:response_ids) do
     response_data.map { |r| r['id'] }
   end
   let(:json_api_request_query) do
-    current = super() || {}
-    current.deep_merge(filter: { filter_key => filter_value })
+    base = super() || {}
+    # Legacy single-filter examples (filter_by_name / filter_by_external_id and
+    # the inline controller filter contexts) set filter_key/filter_value and
+    # expect them merged in here. The collapsed matrix examples leave them unset
+    # and inject each operator's filter per-request via assert_filter instead.
+    return base unless respond_to?(:filter_key) && filter_key
+
+    base.deep_merge(filter: { filter_key => filter_value })
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_boolean_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_boolean_field.rb
@@ -4,28 +4,14 @@ RSpec.shared_examples :jsonapi_filters_by_boolean_field do |attr_name|
   describe "by #{attr_name}" do
     include_context :ransack_filter_setup
 
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { true }
-      let!(:suitable_record) { create_record attr_name => true }
-      let!(:other_record) { create_record attr_name => false }
+    let!(:true_record) { create_record attr_name => true }
+    let!(:false_record) { create_record attr_name => false }
 
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { true }
-      let!(:suitable_record) { create_record attr_name => false }
-      let!(:other_record) { create_record attr_name => true }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      aggregate_failures do
+        assert_filter "#{attr_name}_eq", true, includes: true_record, excludes: false_record
+        assert_filter "#{attr_name}_not_eq", true, includes: false_record, excludes: true_record
+      end
     end
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_datetime_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_datetime_field.rb
@@ -6,101 +6,22 @@ RSpec.shared_examples :jsonapi_filters_by_datetime_field do |attr_name|
 
     let(:greater_value) { Date.today }
     let(:smaller_value) { Date.yesterday }
+    # Two records cover every datetime operator; shared across all operators
+    # instead of re-created per operator context.
+    let!(:smaller_record) { create_record attr_name => smaller_value }
+    let!(:greater_record) { create_record attr_name => greater_value }
 
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'less then operator' do
-      let(:filter_key) { "#{attr_name}_lt" }
-      let(:filter_value) { greater_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'less then or equal operator' do
-      let(:filter_key) { "#{attr_name}_lteq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'greater then operator' do
-      let(:filter_key) { "#{attr_name}_gt" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'greater then or equal operator' do
-      let(:filter_key) { "#{attr_name}_gteq" }
-      let(:filter_value) { greater_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'in operator' do
-      let(:filter_key) { "#{attr_name}_in" }
-      let(:filter_value) { "#{greater_value},#{DateTime.now}" }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not_in operator' do
-      let(:filter_key) { "#{attr_name}_not_in" }
-      let(:filter_value) { "#{smaller_value},#{DateTime.now}" }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      aggregate_failures do
+        assert_filter "#{attr_name}_eq", smaller_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_not_eq", smaller_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_lt", greater_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_lteq", smaller_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_gt", smaller_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_gteq", greater_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_in", "#{greater_value},#{DateTime.now}", includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_not_in", "#{smaller_value},#{DateTime.now}", includes: greater_record, excludes: smaller_record
+      end
     end
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_inet_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_inet_field.rb
@@ -7,44 +7,13 @@ RSpec.shared_examples :jsonapi_filters_by_inet_field do |attr_name|
     let!(:suitable_record) { create_record attr_name => '0.0.0.0' }
     let!(:other_record) { create_record attr_name => '1.1.1.1' }
 
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { '0.0.0.0' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { '1.1.1.1' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'in operator' do
-      let(:filter_key) { "#{attr_name}_in" }
-      let(:filter_value) { '0.0.0.0,2.2.2.2' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not_in operator' do
-      let(:filter_key) { "#{attr_name}_not_in" }
-      let(:filter_value) { '1.1.1.1,2.2.2.2' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      aggregate_failures do
+        assert_filter "#{attr_name}_eq", '0.0.0.0', includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_not_eq", '1.1.1.1', includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_in", '0.0.0.0,2.2.2.2', includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_not_in", '1.1.1.1,2.2.2.2', includes: suitable_record, excludes: other_record
+      end
     end
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_number_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_number_field.rb
@@ -6,101 +6,22 @@ RSpec.shared_examples :jsonapi_filters_by_number_field do |attr_name, options|
 
     let(:greater_value) { options.try(:[], :max_value) || 2 }
     let(:smaller_value) { greater_value - 1 }
+    # Two records cover every numeric operator; shared across all operators
+    # instead of re-created per operator context.
+    let!(:smaller_record) { create_record attr_name => smaller_value }
+    let!(:greater_record) { create_record attr_name => greater_value }
 
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'less then operator' do
-      let(:filter_key) { "#{attr_name}_lt" }
-      let(:filter_value) { greater_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'less then or equal operator' do
-      let(:filter_key) { "#{attr_name}_lteq" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => smaller_value }
-      let!(:other_record) { create_record attr_name => greater_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'greater then operator' do
-      let(:filter_key) { "#{attr_name}_gt" }
-      let(:filter_value) { smaller_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'greater then or equal operator' do
-      let(:filter_key) { "#{attr_name}_gteq" }
-      let(:filter_value) { greater_value }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'in operator' do
-      let(:filter_key) { "#{attr_name}_in" }
-      let(:filter_value) { "#{greater_value},999" }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not_in operator' do
-      let(:filter_key) { "#{attr_name}_not_in" }
-      let(:filter_value) { "#{smaller_value},999" }
-      let!(:suitable_record) { create_record attr_name => greater_value }
-      let!(:other_record) { create_record attr_name => smaller_value }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      aggregate_failures do
+        assert_filter "#{attr_name}_eq", smaller_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_not_eq", smaller_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_lt", greater_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_lteq", smaller_value, includes: smaller_record, excludes: greater_record
+        assert_filter "#{attr_name}_gt", smaller_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_gteq", greater_value, includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_in", "#{greater_value},999", includes: greater_record, excludes: smaller_record
+        assert_filter "#{attr_name}_not_in", "#{smaller_value},999", includes: greater_record, excludes: smaller_record
+      end
     end
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_string_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_string_field.rb
@@ -4,100 +4,23 @@ RSpec.shared_examples :jsonapi_filters_by_string_field do |attr_name|
   describe "by #{attr_name}" do
     include_context :ransack_filter_setup
 
-    context 'start operator' do
-      let(:filter_key) { "#{attr_name}_start" }
-      let(:filter_value) { 'str' }
-      let!(:suitable_record) { create_record attr_name => 'string' }
-      let!(:other_record) { create_record attr_name => 'other' }
+    # Three covering values exercise every string operator; shared across all
+    # operators instead of re-created per operator context.
+    let!(:record_str) { create_record attr_name => 'str' }
+    let!(:record_string) { create_record attr_name => 'string' }
+    let!(:record_other) { create_record attr_name => 'other' }
 
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'end operator' do
-      let(:filter_key) { "#{attr_name}_end" }
-      let(:filter_value) { 'ing' }
-      let!(:suitable_record) { create_record attr_name => 'string' }
-      let!(:other_record) { create_record attr_name => 'other' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'cont operator' do
-      let(:filter_key) { "#{attr_name}_cont" }
-      let(:filter_value) { 'string' }
-      let!(:suitable_record) { create_record attr_name => 'string' }
-      let!(:other_record) { create_record attr_name => 'other' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { 'str' }
-      let!(:suitable_record) { create_record attr_name => 'str' }
-      let!(:other_record) { create_record attr_name => 'string' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { 'str' }
-      let!(:suitable_record) { create_record attr_name => 'string' }
-      let!(:other_record) { create_record attr_name => 'str' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'in operator' do
-      let(:filter_key) { "#{attr_name}_in" }
-      let(:filter_value) { 'str,str2' }
-      let!(:suitable_record) { create_record attr_name => 'str' }
-      let!(:other_record) { create_record attr_name => 'string' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not_in operator' do
-      let(:filter_key) { "#{attr_name}_not_in" }
-      let(:filter_value) { 'string,str2' }
-      let!(:suitable_record) { create_record attr_name => 'str' }
-      let!(:other_record) { create_record attr_name => 'string' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'cont operator' do
-      let(:filter_key) { "#{attr_name}_cont_any" }
-      let(:filter_value) { 'string,val' }
-      let!(:suitable_record) { create_record attr_name => 'string' }
-      let!(:other_record) { create_record attr_name => 'other' }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      aggregate_failures do
+        assert_filter "#{attr_name}_start", 'str', includes: record_string, excludes: record_other
+        assert_filter "#{attr_name}_end", 'ing', includes: record_string, excludes: record_other
+        assert_filter "#{attr_name}_cont", 'string', includes: record_string, excludes: record_other
+        assert_filter "#{attr_name}_eq", 'str', includes: record_str, excludes: record_string
+        assert_filter "#{attr_name}_not_eq", 'str', includes: record_string, excludes: record_str
+        assert_filter "#{attr_name}_in", 'str,str2', includes: record_str, excludes: record_string
+        assert_filter "#{attr_name}_not_in", 'string,str2', includes: record_str, excludes: record_string
+        assert_filter "#{attr_name}_cont_any", 'string,val', includes: record_string, excludes: record_other
+      end
     end
   end
 end

--- a/spec/support/examples/json_api/jsonapi_filters_by_uuid_field.rb
+++ b/spec/support/examples/json_api/jsonapi_filters_by_uuid_field.rb
@@ -4,52 +4,18 @@ RSpec.shared_examples :jsonapi_filters_by_uuid_field do |attr_name|
   describe "by #{attr_name}" do
     include_context :ransack_filter_setup
 
-    context 'equal operator' do
-      let(:filter_key) { "#{attr_name}_eq" }
-      let(:filter_value) { suitable_record.reload.try attr_name }
-      let!(:suitable_record) { create_record }
-      let!(:other_record) { create_record }
+    let!(:suitable_record) { create_record }
+    let!(:other_record) { create_record }
 
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not equal operator' do
-      let(:filter_key) { "#{attr_name}_not_eq" }
-      let(:filter_value) { other_record.reload.try attr_name }
-      let!(:suitable_record) { create_record }
-      let!(:other_record) { create_record }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'in operator' do
-      let(:filter_key) { "#{attr_name}_in" }
-      let(:filter_value) { [suitable_record.reload.try(attr_name), SecureRandom.uuid].join(',') }
-      let!(:suitable_record) { create_record }
-      let!(:other_record) { create_record }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
-    end
-
-    context 'not_in operator' do
-      let(:filter_key) { "#{attr_name}_not_in" }
-      let(:filter_value) { [other_record.reload.try(attr_name), SecureRandom.uuid].join(',') }
-      let!(:suitable_record) { create_record }
-      let!(:other_record) { create_record }
-
-      before { subject }
-
-      it { expect(response_ids).to include primary_key_for(suitable_record) }
-      it { expect(response_ids).not_to include primary_key_for(other_record) }
+    it "filters by #{attr_name}" do
+      suitable_uuid = suitable_record.reload.try(attr_name)
+      other_uuid = other_record.reload.try(attr_name)
+      aggregate_failures do
+        assert_filter "#{attr_name}_eq", suitable_uuid, includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_not_eq", other_uuid, includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_in", "#{suitable_uuid},#{SecureRandom.uuid}", includes: suitable_record, excludes: other_record
+        assert_filter "#{attr_name}_not_in", "#{other_uuid},#{SecureRandom.uuid}", includes: suitable_record, excludes: other_record
+      end
     end
   end
 end

--- a/spec/support/helpers/tom_select.rb
+++ b/spec/support/helpers/tom_select.rb
@@ -34,8 +34,9 @@ module Helpers
 
     # Select known options in an ajax tom-select through its API (inject +
     # addItem), skipping the flaky type -> ajax-fetch -> render -> click chain.
-    # Pass value => text pairs, e.g.
-    #   select_tom_select_by_value 'ORIGINATION GATEWAY', gw1.id => gw1.name, gw2.id => gw2.name
+    # Pass a value => text pairs hash (brace it — a braceless trailing hash is
+    # parsed as keyword args and won't reach `pairs`), e.g.
+    #   select_tom_select_by_value 'ORIGINATION GATEWAY', { gw1.id => gw1.name, gw2.id => gw2.name }
     def select_tom_select_by_value(label, pairs, exact_label: false, selector: nil)
       tom_select = find_tom_select(label, exact: exact_label, selector:)
       tom_select.select_by_value(pairs)


### PR DESCRIPTION

<img width="1981" height="1071" alt="image" src="https://github.com/user-attachments/assets/e9cc6f9e-650c-49fa-97e6-604cd3c389de" />


Three independent CI speedups for the rspec gate, all graceful: a missing cache or log falls back to today's behaviour, so there is no first-run regression and local dev is unaffected. Implements the plan in `docs/plans/rspec-parallel-test-distribution/plan.md`.

## Phase 1 — Balance parallel groups by measured runtime

The 8-way `parallel_test` matrix split by file **byte size** (the default when `--only-group` is set), which is uncorrelated with runtime and produced a ~4x compute imbalance across groups (worst ~812s vs best ~199s), setting the matrix critical path at ~15m51s.

- **Makefile**: pass `--group-by runtime --runtime-log $(RSPEC_RUNTIME_LOG) --allowed-missing 75`, gated by a `$(wildcard)` guard so a missing log falls back to filesize (safe first run / local dev). The file list still comes from scanning `spec/` on disk, so the log only supplies weights — it never skips or phantom-runs a file; unknown (new/renamed) files run at the average measured weight.
- **tests.yml**: restore the complete runtime log before `Run rspec`, upload each group's partial slice after, and a job that merges the 8 slices and caches the complete log for the next run. It runs on PRs too — caches are branch-scoped, so a PR reads its own measured log first and falls back to master's via `restore-keys` without poisoning the shared key. Gated on `!cancelled()` so a flaky node can't skip persistence; a `concurrency` group cancels superseded PR runs, closing the window where an overlapping run could publish a new log mid-matrix and desync the split.

## Phase 2 — Cache only the network-data seed across runs

Every DB-dependent job rebuilt the test DB from scratch. The dominant repeated cost is `custom_seeds[network_prefixes]`, which parses **~96 MB across 232 `db/network_data/*.yml` files** and bulk-inserts them — a fixed cost paid **11x per run** (rspec×8, oidc, database_consistency, annotations).

Rather than cache the whole DB (a dump keyed on schema/seeds is invalidated by every migration → 96 MB re-parsed everywhere), cache **only that step's result — the 4 `sys` network tables** — and rebuild the rest fresh each run, so the key is independent of `db/structure.sql` and `db/seeds` and survives migrations and base-seed edits.

- **Makefile** (`prepare-test-db` CI branch): always `db:create` + `db:schema:load` + `db:seed` (fast; `db:seed` also re-creates the current-month CDR partitions, so no separate partition task is needed). On a cache **miss**, run `custom_seeds[network_prefixes]` then `pg_dump --data-only` the 4 `sys` network tables (`network_types`, `networks`, `countries`, `network_prefixes`); on a **hit**, `DELETE` those tables (child→parent) and `pg_restore --data-only --disable-triggers --exit-on-error` the dump, resetting sequences and skipping the YAML load. `$(wildcard)`-guarded so local/first-run falls back to the full build.
- **.github/actions/restore-test-db-dump**: one composite action defines the `actions/cache` step, keyed **only on the network-data source files** (not `structure.sql`/`db/seeds`), reused by all 4 DB-prep jobs.
- **dev/db_test_prepare.sh**: the same network-data cache locally, keyed by a content hash embedded in the dump filename; degrades to a plain YAML load when the pg client is missing or older than the server.

The CI build image ships `postgresql-client-18` (`debian/control` Build-Depends), matching the PG18 service, so `pg_dump`/`pg_restore` are version-compatible (and a `--data-only` COPY dump is version-portable anyway).

## Phase 3a — Cut wasted rspec compute (node-count-independent)

Reduces *total* compute (the 2980s budget) and the whole-file floor, so it pays off at any node count.

- **Collapse the six `jsonapi_filters_by_*_field` shared examples** into one `aggregate_failures` example each: create the covering records **once** and share them across every operator instead of re-creating a record pair and re-issuing a request per operator context. Per `it_behaves_like` this drops record inserts 32→2 (string 3) and examples 16→1, compounding across the ~28 heavy controller/request specs that use them (cdrs, gateways, auth_logs, incoming_cdrs, customers_auths, dialpeers, destinations, …). New `assert_filter` + `perform_ransack_filter_request` helpers in `ransack_filter_setup` re-issue the index request per operator and read `response_data` directly; controller vs request shape is picked by `respond_to?(:json_api_request_path)`. The legacy `filter_key`/`filter_value` merge is preserved but guarded so collapsed examples fall through to the spec's base query. Correctness coverage is unchanged; on failure `aggregate_failures` still reports the offending operator.
- **Filter the network-prefix and network CSV exports** (`export_network_prefix_spec`, `export_network_spec`) by a dedicated parent (`country_id_eq` / `type_id_eq`) so they render a handful of rows instead of serializing the whole seeded `sys.network_prefixes` (~486k rows) and `sys.networks` tables through per-row name procs just to assert a couple of rows. Other export siblings render only test-created rows (empty tables), so they are left unchanged.

## Notes

- **Runtime-log reporting**: the persist job prints the 50 slowest spec files to the job log and run summary so heavy files can be spotted for future splitting (Phase 3b, deferred). It runs after the cache save so a reporting glitch can't block log persistence.
- **Review fix (folded into commit 1)**: the merge job originally saved the runtime log at repo-root `parallel_runtime_rspec_full.log` while the rspec job restored `log/parallel_runtime_rspec_full.log`. Since `actions/cache` derives its cache version from the `path` input, the mismatch meant the cache would never resolve. Both sides now use `log/parallel_runtime_rspec_full.log`.
- **Makefile `$(info)` syntax fix**: a literal `(slow)` in an `$(info:msg=...)` message closed make's variable reference early, spilling a stray `)` outside `printf`'s quotes and aborting `prepare-test-db` on every cache-miss run. Parens dropped; both cold (YAML-load) and warm (`pg_restore`) DB-prep branches verified green.

Phases 3b (file splits) and 4 (node-count re-tune) are deferred — not needed at 8 nodes.
