### PR TITLE
Fix flaky rate management project Account tom-select at the source

### DIFF
--- a/app/assets/javascripts/tom-select-ajax-fillable.js
+++ b/app/assets/javascripts/tom-select-ajax-fillable.js
@@ -43,16 +43,24 @@
                 return
             }
 
-            // by some reason el.value and ts.getValue() return empty string
-            var currentValue = el.multiple
-                ? $el.find('option[selected]').map(function() { return $(this).val() })
-                : $el.find('option[selected]').val()
             if (abortControllers[key]) abortControllers[key].abort()
             abortControllers[key] = new AbortController()
 
             fetch(path + $.param(data), { signal: abortControllers[key].signal })
                 .then(function(r) { return r.json() })
                 .then(function(items) {
+                    // Read the current selection at resolve time (not before the
+                    // fetch) so a value chosen while the request was in flight is
+                    // preserved instead of being wiped by ts.clear() below. This
+                    // is the Account-right-after-Vendor race: the parent field
+                    // change kicks off this fetch, the dependent field is filled
+                    // immediately, and the late response used to clobber it.
+                    // ts.getValue() reflects the live selection (property based);
+                    // option[selected] only carries the server-rendered initial
+                    // value, so fall back to it for the edit form.
+                    var currentValue = el.multiple
+                        ? $el.find('option[selected]').map(function() { return $(this).val() })
+                        : (ts.getValue() || $el.find('option[selected]').val())
                     ts.clear(true)
                     ts.clearOptions()
                     var hasPrev = false

--- a/spec/features/rate_management/project/account_fill_race_spec.rb
+++ b/spec/features/rate_management/project/account_fill_race_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Guards the vendor -> account tom-select fill race (see
+# app/assets/javascripts/tom-select-ajax-fillable.js). Selecting the Vendor
+# kicks off an async fillOptions() fetch for the dependent Account field; the
+# Account is then filled immediately, while that request is still in flight.
+# The late response must NOT clobber the value the user just picked.
+#
+# This spec forces the race deterministically by delaying the /accounts/search
+# response client-side so it always resolves after the Account is selected.
+# Before the fix the async ts.clear() wiped the selection and the form failed
+# with "Account must exist"; that flake bounced between the create/update specs
+# for several commits before being fixed at the source.
+RSpec.describe 'Rate Management Project Account fill race', js: true, bullet: [:n] do
+  include_context :login_as_admin
+
+  let!(:vendor) { FactoryBot.create(:vendor) }
+  let!(:account) { FactoryBot.create(:account, contractor: vendor) }
+
+  it 'keeps the selected account after the delayed fetch resolves' do
+    visit new_rate_management_project_path
+
+    # Delay every /accounts/search response so it resolves after the Account is
+    # selected below, guaranteeing the in-flight race is exercised.
+    page.execute_script(<<~JS)
+      (function () {
+        var orig = window.fetch;
+        window.fetch = function (url) {
+          var p = orig.apply(this, arguments);
+          if (String(url).indexOf('/accounts/search') !== -1) {
+            return p.then(function (r) {
+              return new Promise(function (res) { setTimeout(function () { res(r); }, 800); });
+            });
+          }
+          return p;
+        };
+      })();
+    JS
+
+    fill_in_tom_select 'Vendor', with: vendor.name, search: true
+    select_tom_select_by_value 'Account', { account.id => account.name }
+
+    # Wait past the delayed fetch's resolution, then assert the submitted value
+    # (account_id) survived the async options rebuild.
+    sleep 1.5
+
+    selected_value = page.evaluate_script(
+      "document.getElementById('rate_management_project_account_id').value"
+    )
+    expect(selected_value).to eq(account.id.to_s)
+  end
+end


### PR DESCRIPTION
The Account field is an ajax-fillable tom-select whose options reload asynchronously when the Vendor changes: the Vendor change kicks off a fillOptions() fetch that, on resolve, calls ts.clear()/clearOptions() and re-adds the server options. The specs select the Account immediately after the Vendor, while that request is still in flight, so the late response wiped the just-picked value and the form failed with "Account must exist".

fillOptions() captured the value to restore *before* the fetch, reading option[selected] -- which only reflects the server-rendered initial value, never a value set at runtime (tom-select sets option.selected as a property, not the attribute). So a selection made during the request could never be restored. Read the value at resolve time via ts.getValue() (property based, reflects the live selection) instead, falling back to option[selected] for the edit form's initial value.

This fixes the race at its source for every ajax-fillable field (Account, Gateway, Gateway Group across the app), rather than in one spec at a time -- the earlier test-only attempts (541b14fb, dec32698, 95e8b1ba) each traded one selection race for another. Add a spec that forces the race deterministically by delaying /accounts/search so it always resolves after the Account is selected.

Co-Authored-By: Clanker