### PR TITLE
YETI-2071: Fix schema search path formatting

### DIFF
--- a/config/database.build.yml
+++ b/config/database.build.yml
@@ -7,7 +7,7 @@ production:
     username: postgres
     password:
     host: <%= (ENV['YETI_DB_HOST'] || 'localhost') %>
-    schema_search_path: >
+    schema_search_path: >-
       gui, public, switch,
       billing, class4, runtime_stats,
       sys, logs, data_import

--- a/config/database.yml.development
+++ b/config/database.yml.development
@@ -7,7 +7,7 @@ development:
     username: postgres
     password:
     host: 127.0.0.1
-    schema_search_path: >
+    schema_search_path: >-
       gui, public, switch,
       billing, class4, runtime_stats,
       sys, logs, data_import

--- a/config/database.yml.distr
+++ b/config/database.yml.distr
@@ -7,7 +7,7 @@ production:
     username: yeti
     password: somepassword
     host: 127.0.0.1
-    schema_search_path: >
+    schema_search_path: >-
       gui, public, switch,
       billing, class4, runtime_stats,
       sys, logs, data_import


### PR DESCRIPTION
## Summary

Strip the trailing newline from `schema_search_path` in database configuration templates.

This prevents Rails from producing an unnecessary line break in `db/structure.sql` after migrations.

The output is now consistent across Linux and macOS environments.

## Related links

closes #2071 