### PR TITLE
Add gateway privacy_mode_id field to api resource

### DIFF
--- a/app/resources/api/rest/admin/gateway_resource.rb
+++ b/app/resources/api/rest/admin/gateway_resource.rb
@@ -10,7 +10,7 @@ class Api::Rest::Admin::GatewayResource < ::BaseResource
              :auth_from_domain, :term_route_set,
              :term_next_hop_for_replies, :term_next_hop, :term_append_headers_req,
              :orig_append_headers_req, :orig_append_headers_reply,
-             :orig_route_set,
+             :orig_route_set, :privacy_mode_id,
              :sdp_alines_filter_list, :ringing_timeout, :relay_options, :relay_reinvite, :relay_hold, :relay_prack,
              :relay_update, :suppress_early_media, :fake_180_timer,
              :transit_headers_from_origination, :transit_headers_from_termination,
@@ -77,6 +77,7 @@ class Api::Rest::Admin::GatewayResource < ::BaseResource
   ransack_filter :port, type: :number
   ransack_filter :src_rewrite_rule, type: :string
   ransack_filter :dst_rewrite_rule, type: :string
+  ransack_filter :privacy_mode_id, type: :number
   ransack_filter :acd_limit, type: :number
   ransack_filter :asr_limit, type: :number
   ransack_filter :enabled, type: :boolean
@@ -218,6 +219,7 @@ class Api::Rest::Admin::GatewayResource < ::BaseResource
       orig_append_headers_reply
       orig_route_set
       orig_disconnect_policy
+      privacy_mode_id
       sdp_alines_filter_list
       ringing_timeout
       relay_options

--- a/spec/requests/api/rest/admin/gateways_spec.rb
+++ b/spec/requests/api/rest/admin/gateways_spec.rb
@@ -461,6 +461,7 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
         'auth-from-domain': gateway.auth_from_domain,
         'term-route-set': gateway.term_route_set,
         'orig-route-set': gateway.orig_route_set,
+        'privacy-mode-id': gateway.privacy_mode_id,
         'termination-capacity': gateway.termination_capacity,
         'term-next-hop-for-replies': gateway.term_next_hop_for_replies,
         'term-next-hop': gateway.term_next_hop,
@@ -559,6 +560,7 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
         'ice-mode-id': 2,
         'rtcp-mux-mode-id': 1,
         'rtcp-feedback-mode-id': 0,
+        'privacy-mode-id': 3,
         'allowed-methods': %w[INVITE ACK],
         'supported-tags': %w[100rel timer]
       }
@@ -630,6 +632,7 @@ RSpec.describe Api::Rest::Admin::GatewaysController, type: :request do
                                   tx_inband_dtmf_filtering_mode: tx_inband_dtmf_filtering_mode,
                                   network_protocol_priority: network_protocol_priority,
                                   media_encryption_mode: media_encryption_mode,
+                                  privacy_mode_id: json_api_request_attributes[:'privacy-mode-id'],
                                   sip_schema_id: json_api_request_attributes[:'sip-schema-id'],
                                   ice_mode_id: json_api_request_attributes[:'ice-mode-id'],
                                   rtcp_mux_mode_id: json_api_request_attributes[:'rtcp-mux-mode-id'],


### PR DESCRIPTION
The privacy mode field in the gateway translations panel cannot be controlled using the rest api. Could this field be added?