### PR TITLE
Upgrade activeadmin-oidc to 2.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '~> 8.1.0'
 gem 'responders'
 
 # Authentication
-gem 'activeadmin-oidc', github: 'activeadmin-plugins/activeadmin-oidc'
+gem 'activeadmin-oidc', '~> 2.2'
 gem 'devise', '>= 4.6.0'
 gem 'doorkeeper', '~> 5.9'
 # OIDC layer on top of Doorkeeper: id_token, /.well-known/openid-configuration,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,6 @@ GIT
     active_admin_date_range_preset (0.3.1)
 
 GIT
-  remote: https://github.com/activeadmin-plugins/activeadmin-oidc.git
-  revision: d6dbc83cf1641151d9c48a32196bbec132a5b92f
-  specs:
-    activeadmin-oidc (0.1.0)
-      activeadmin (>= 3.5, < 4)
-      devise (>= 4.9)
-      omniauth (>= 2.1)
-      omniauth-rails_csrf_protection (>= 1.0)
-      omniauth_openid_connect (>= 0.7)
-      rails (>= 7.2)
-
-GIT
   remote: https://github.com/activeadmin-plugins/capybara_active_admin.git
   revision: d2cdc2c0a5478d4ee1afb30f3465c7be3b760a86
   specs:
@@ -171,6 +159,13 @@ GEM
       kaminari (>= 1.2.1)
       railties (>= 6.1)
       ransack (>= 4.0)
+    activeadmin-oidc (2.2.1)
+      activeadmin (>= 3.5, < 5)
+      devise (~> 5.0)
+      omniauth (~> 2.1)
+      omniauth-rails_csrf_protection (>= 1.0, < 3)
+      omniauth_openid_connect (>= 0.6, < 1)
+      rails (>= 7.2, < 9)
     activejob (8.1.3.1)
       activesupport (= 8.1.3.1)
       globalid (>= 0.3.6)
@@ -1083,7 +1078,7 @@ DEPENDENCIES
   active_admin_theme!
   active_record_extended
   activeadmin
-  activeadmin-oidc!
+  activeadmin-oidc (~> 2.2)
   activemodel-serializers-xml
   activerecord-import
   annotaterb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,16 @@ Rails.application.routes.draw do
     resource(name.to_s.dasherize.to_sym, **options, &block)
   end
 
-  devise_for :admin_users, ActiveAdmin::Devise.config
+  # activeadmin-oidc 2.2 draws its own :sessions-shaped routes (login_path /
+  # logout_path, default /admin/login and /admin/logout) whenever AdminUser
+  # is in OIDC mode — see ActiveAdmin::Oidc::Engine#mount_oidc_sessions_routes.
+  # AdminUser keeps :database_authenticatable there so Devise mounts a
+  # sessions controller too, which would draw the very same route names
+  # ('new_admin_user_session' / 'destroy_admin_user_session') a second time
+  # and blow up route finalization. Skip Devise's own :sessions routes in
+  # that mode; in DB-auth mode (no config/oidc.yml) AdminUser has no
+  # :omniauthable, the gem draws nothing, and Devise must keep drawing them.
+  devise_for :admin_users, ActiveAdmin::Devise.config.merge(skip: (AdminUser.oidc? ? [:sessions] : []))
 
   # Doorkeeper OAuth provider + RFC 8414 metadata + RFC 7591 dynamic client
   # registration. Gated on YetiConfig.oauth.enabled so the surface is opt-in.
@@ -298,6 +307,19 @@ Rails.application.routes.draw do
     end
   end
 
+  # activeadmin-oidc 2.2 mounts its own /admin/login and /admin/logout (see
+  # config/initializers/activeadmin_oidc.rb and
+  # ActiveAdmin::Oidc::Engine#mount_oidc_sessions_routes) by *appending* to
+  # the route set from an after_initialize hook, so they land after every
+  # route this file draws -- including the catch-all right below. Without
+  # this exclusion the catch-all would win first and both routes would
+  # 404. Logout is GET-reachable too: ActiveAdmin 3.x's default
+  # logout_link_method is :get.
+  oidc_session_path = lambda do |req|
+    cfg = ActiveAdmin::Oidc.config
+    ![cfg.login_path, cfg.logout_path].include?(req.path)
+  end
+
   # 404
-  match '*a' => 'application#render_404', via: :get
+  match '*a' => 'application#render_404', via: :get, constraints: oidc_session_path
 end

--- a/spec/support/oidc_mode.rb
+++ b/spec/support/oidc_mode.rb
@@ -1,6 +1,29 @@
 # frozen_string_literal: true
 
-# Test helpers and oidc_mode tag filtering are provided by the gem.
-# Requiring this file auto-installs the RSpec support (tag filtering,
-# stub helpers, and after-hook cleanup).
+# activeadmin-oidc 2.x ships `ActiveAdmin::Oidc::TestHelpers` (stub_oidc_sign_in,
+# stub_oidc_failure, reset_oidc_stubs) but, unlike 0.1.0, no longer auto-installs
+# RSpec tag filtering for `oidc_mode: true` — the gem's README now says to wire
+# this up in the host's rails_helper ourselves. This file is that wiring, plus
+# the skip-when-not-in-OIDC-mode guard the old gem used to provide.
 require 'activeadmin/oidc/test_helpers'
+
+RSpec.configure do |config|
+  config.include ActiveAdmin::Oidc::TestHelpers, oidc_mode: true
+  config.after(:each, :oidc_mode) { reset_oidc_stubs }
+
+  # `oidc_mode: true` specs need config/oidc.yml in place (AdminUser gets
+  # :omniauthable only then — see AdminUser.oidc_config_exists?). Skip them
+  # rather than fail when it's absent, so the regular suite stays green
+  # without it.
+  config.before(:each, :oidc_mode) do
+    skip 'requires OIDC mode (run with config/oidc.yml in place and CI_RUN_OIDC=true)' unless AdminUser.oidc?
+  end
+
+  # CI runs OIDC specs in a dedicated job (config/oidc.yml + CI_RUN_OIDC=true)
+  # so the regular job — which has neither — doesn't also try to run them.
+  if ENV['CI_RUN_OIDC'].present?
+    config.filter_run_including oidc_mode: true
+  else
+    config.filter_run_excluding oidc_mode: true
+  end
+end

--- a/spec/support/oidc_mode.rb
+++ b/spec/support/oidc_mode.rb
@@ -12,11 +12,19 @@ RSpec.configure do |config|
   config.after(:each, :oidc_mode) { reset_oidc_stubs }
 
   # `oidc_mode: true` specs need config/oidc.yml in place (AdminUser gets
-  # :omniauthable only then — see AdminUser.oidc_config_exists?). Skip them
-  # rather than fail when it's absent, so the regular suite stays green
-  # without it.
+  # :omniauthable only then — see AdminUser.oidc_config_exists?).
+  #
+  # Locally, skip them rather than fail when it's absent, so the regular suite
+  # stays green without it. In the dedicated CI OIDC job (CI_RUN_OIDC=true)
+  # these are the *only* specs that run, so skipping them all would turn a
+  # broken setup into a green run that tested nothing — fail loudly instead.
   config.before(:each, :oidc_mode) do
-    skip 'requires OIDC mode (run with config/oidc.yml in place and CI_RUN_OIDC=true)' unless AdminUser.oidc?
+    next if AdminUser.oidc?
+
+    message = 'requires OIDC mode (run with config/oidc.yml in place and CI_RUN_OIDC=true)'
+    raise message if ENV['CI_RUN_OIDC'].present?
+
+    skip message
   end
 
   # CI runs OIDC specs in a dedicated job (config/oidc.yml + CI_RUN_OIDC=true)


### PR DESCRIPTION
## What

Moves `activeadmin-oidc` off the git-pinned `0.1.0` revision onto the released
rubygems gem (`~> 2.2`, currently 2.2.1), and adapts this app to the two
behaviour changes that come with it.

> **Note:** this PR previously also added an opt-in development stub login built
> on the `stub_dev_env_login!` that 2.2 introduces. It has been dropped. It was
> not needed — with no `config/oidc.yml`, `AdminUser.oidc?` is false,
> `:omniauthable` is not added and the ordinary password login renders, which is
> already the local-development path — and as implemented it did not work:
> `app/views/active_admin/devise/sessions/new.html.erb` hardcodes
> `omniauth_authorize_path(resource_name, :oidc)` instead of reading
> `ActiveAdmin::Oidc.config.login_submit_path`, so the button kept redirecting to
> the IdP and the `/admin/login/stub` route was unreachable from the UI.

## The upgrade is not a no-op — read `config/routes.rb`

2.2.1 keeps the `Configuration` API this app relies on (`issuer`, `client_id`,
`identity_attribute`, `identity_claim`, `on_login`, ...) unchanged, but two
things needed adapting:

- It now draws its own `/admin/login` and `/admin/logout` routes
  (`ActiveAdmin::Oidc::Engine#mount_oidc_sessions_routes`) whenever `AdminUser`
  is in OIDC mode, appended after `routes.rb` finishes drawing. `AdminUser` here
  keeps `:database_authenticatable`, so Devise drew the same route names
  (`new_admin_user_session` / `destroy_admin_user_session`) a second time and
  crashed route finalization. Devise's own `:sessions` routes are now skipped in
  OIDC mode — and only there: in DB-auth mode the gem draws nothing and Devise
  must keep drawing them. Appended routes also land after this file's
  `match '*a' => ...` 404 catch-all, so that catch-all now excludes the gem's
  login/logout paths (logout is GET-reachable too — ActiveAdmin 3.x defaults
  `logout_link_method` to `:get`).
- It no longer auto-installs RSpec's `oidc_mode: true` tag filtering
  (`test_helpers.rb` dropped its `RSpecSupport.install!`); the gem's README now
  says to wire that in the host. `spec/support/oidc_mode.rb` does that now:
  includes `ActiveAdmin::Oidc::TestHelpers`, resets the stubs after each tagged
  example, and keeps the filtering the old gem provided — `oidc_mode` specs run
  only in the dedicated CI job (`CI_RUN_OIDC=true` + `config/oidc.yml`) and are
  excluded elsewhere.

That last commit also makes the CI OIDC job fail loudly rather than skip: in the
job where `oidc_mode` specs are the *only* specs that run, a missing
`config/oidc.yml` would otherwise skip every one of them and report a green run
that tested nothing. Locally it still skips, so the regular suite stays green
without the file.

## Verified

- With `config/oidc.yml` in place and `CI_RUN_OIDC=true`:
  `spec/requests/oidc_routes_spec.rb`, `spec/features/oidc`,
  `spec/requests/api/rest/admin/auth_controller_spec.rb` — 19 examples,
  0 failures.
- Without `config/oidc.yml`: `spec/initializers/activeadmin_oidc_spec.rb` —
  16 examples, 0 failures, and the `oidc_mode`-tagged specs are filtered out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNXVXLGxQCHWXdYLztcaz2
